### PR TITLE
Migrate to Drizzle ORM, add AsyncButton spam-guard, add Labeler annotations drawer

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'sqlite',
+  schema: './src/main/schema.ts',
+  out: './drizzle'
+})

--- a/drizzle/0000_supreme_mattie_franklin.sql
+++ b/drizzle/0000_supreme_mattie_franklin.sql
@@ -1,0 +1,73 @@
+CREATE TABLE `annotations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`labelId` text NOT NULL,
+	`sampleId` text NOT NULL,
+	FOREIGN KEY (`labelId`) REFERENCES `labels`(`id`) ON UPDATE restrict ON DELETE restrict,
+	FOREIGN KEY (`sampleId`) REFERENCES `samples`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_annotations_sampleId` ON `annotations` (`sampleId`);--> statement-breakpoint
+CREATE INDEX `idx_annotations_labelId` ON `annotations` (`labelId`);--> statement-breakpoint
+CREATE TABLE `annotators` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`url` text NOT NULL,
+	`headers` text NOT NULL,
+	`projectId` text NOT NULL,
+	FOREIGN KEY (`projectId`) REFERENCES `projects`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_annotators_projectId` ON `annotators` (`projectId`);--> statement-breakpoint
+CREATE TABLE `images` (
+	`id` text PRIMARY KEY NOT NULL,
+	`hash` text NOT NULL,
+	`extension` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `labels` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`color` text NOT NULL,
+	`projectId` text NOT NULL,
+	FOREIGN KEY (`projectId`) REFERENCES `projects`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_labels_projectId` ON `labels` (`projectId`);--> statement-breakpoint
+CREATE TABLE `points` (
+	`id` text PRIMARY KEY NOT NULL,
+	`x` real NOT NULL,
+	`y` real NOT NULL,
+	`sequence` integer NOT NULL,
+	`annotationId` text NOT NULL,
+	FOREIGN KEY (`annotationId`) REFERENCES `annotations`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_points_annotationId` ON `points` (`annotationId`);--> statement-breakpoint
+CREATE TABLE `projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `samples` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`split` text NOT NULL,
+	`createdAt` text NOT NULL,
+	`completedAt` text,
+	`imageId` text NOT NULL,
+	`taskId` text NOT NULL,
+	FOREIGN KEY (`imageId`) REFERENCES `images`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`taskId`) REFERENCES `tasks`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_samples_taskId` ON `samples` (`taskId`);--> statement-breakpoint
+CREATE INDEX `idx_samples_imageId` ON `samples` (`imageId`);--> statement-breakpoint
+CREATE TABLE `tasks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`projectId` text NOT NULL,
+	FOREIGN KEY (`projectId`) REFERENCES `projects`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_projectId` ON `tasks` (`projectId`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,501 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c965a501-c9e2-43be-8e63-159b2cb720bd",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "samples",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotators": {
+      "name": "annotators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotators_projectId": {
+          "name": "idx_annotators_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotators_projectId_projects_id_fk": {
+          "name": "annotators_projectId_projects_id_fk",
+          "tableFrom": "annotators",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "tableTo": "annotations",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "images",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1783908383415,
+      "tag": "0000_supreme_mattie_franklin",
+      "breakpoints": true
+    }
+  ]
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,9 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
 asarUnpack:
   - resources/**
+extraResources:
+  - from: drizzle
+    to: drizzle
 fileAssociations:
   - ext: cvlabel
     name: cv-label File

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "electron-vite dev",
     "build": "pnpm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3",
+    "db:generate": "drizzle-kit generate",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:win": "pnpm run build && electron-builder --win",
     "test": "vitest",
@@ -38,6 +39,7 @@
     "adm-zip": "^0.5.17",
     "better-sqlite3": "^12.6.2",
     "clsx": "^2.1.1",
+    "drizzle-orm": "^0.45.2",
     "i18next": "^26.0.6",
     "jszip": "^3.10.1",
     "mantine-contextmenu": "^8.3.13",
@@ -70,6 +72,7 @@
     "@types/tinycolor2": "^1.4.6",
     "@vitejs/plugin-react": "^5.1.1",
     "@wyw-in-js/vite": "^1.0.6",
+    "drizzle-kit": "^0.31.10",
     "electron": "^39.2.6",
     "electron-builder": "^26.0.12",
     "electron-vite": "^5.0.0",
@@ -95,6 +98,12 @@
     "files": [
       "out/**",
       "resources/**"
+    ],
+    "extraResources": [
+      {
+        "from": "drizzle",
+        "to": "drizzle"
+      }
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
       i18next:
         specifier: ^26.0.6
         version: 26.0.6(typescript@5.9.3)
@@ -145,10 +148,13 @@ importers:
         version: 1.4.6
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.4(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
+        version: 5.1.4(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))
       '@wyw-in-js/vite':
         specifier: ^1.0.6
-        version: 1.0.6(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
+        version: 1.0.6(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       electron:
         specifier: ^39.2.6
         version: 39.8.7
@@ -157,7 +163,7 @@ importers:
         version: 26.7.0(electron-builder-squirrel-windows@26.7.0)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
+        version: 5.0.0(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -202,10 +208,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.6
-        version: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+        version: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.11)(happy-dom@20.8.9)(jsdom@29.1.1)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
+        version: 4.1.5(@types/node@22.19.11)(happy-dom@20.8.9)(jsdom@29.1.1)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -567,6 +573,9 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@electron-toolkit/eslint-config-prettier@3.0.0':
     resolution: {integrity: sha512-YapmIOVkbYdHLuTa+ad1SAVtcqYL9A/SJsc7cxQokmhcwAwonGevNom37jBf9slXegcZ/Slh01I/JARG1yhNFw==}
     peerDependencies:
@@ -646,6 +655,14 @@ packages:
   '@emotion/memoize@0.9.0':
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -658,6 +675,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -668,6 +691,12 @@ packages:
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -682,6 +711,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -694,6 +729,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -704,6 +745,12 @@ packages:
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -718,6 +765,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -728,6 +781,12 @@ packages:
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -742,6 +801,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -752,6 +817,12 @@ packages:
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -766,6 +837,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -776,6 +853,12 @@ packages:
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -790,6 +873,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -800,6 +889,12 @@ packages:
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -814,6 +909,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -826,6 +927,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -836,6 +943,12 @@ packages:
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -862,6 +975,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -884,6 +1003,12 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -910,6 +1035,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -921,6 +1052,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -934,6 +1071,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -944,6 +1087,12 @@ packages:
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -2157,6 +2306,102 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2274,6 +2519,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2541,6 +2791,9 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -3528,6 +3781,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -3892,6 +4148,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -4735,6 +4996,8 @@ snapshots:
       ajv: 6.14.0
       ajv-keywords: 3.5.2(ajv@6.14.0)
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@electron-toolkit/eslint-config-prettier@3.0.0(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -4878,10 +5141,23 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -4890,10 +5166,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -4902,10 +5184,16 @@ snapshots:
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -4914,10 +5202,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -4926,10 +5220,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -4938,10 +5238,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -4950,10 +5256,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -4962,16 +5274,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -4986,6 +5307,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -4996,6 +5320,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -5010,10 +5337,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -5022,10 +5355,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -5675,7 +6014,7 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -5683,7 +6022,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5696,13 +6035,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -5776,11 +6115,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@wyw-in-js/vite@1.0.6(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
+  '@wyw-in-js/vite@1.0.6(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@wyw-in-js/shared': 1.0.4
       '@wyw-in-js/transform': 1.0.6(typescript@5.9.3)
-      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6310,6 +6649,18 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.23.0
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.6.2
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6362,7 +6713,7 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  electron-vite@5.0.0(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)):
+  electron-vite@5.0.0(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
@@ -6370,7 +6721,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6526,6 +6877,31 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -6889,6 +7265,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
 
@@ -7929,6 +8309,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -8396,6 +8778,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.0:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -8535,7 +8923,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0):
+  vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8548,12 +8936,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       sugarss: 5.0.1(postcss@8.5.16)
+      tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.5(@types/node@22.19.11)(happy-dom@20.8.9)(jsdom@29.1.1)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)):
+  vitest@4.1.5(@types/node@22.19.11)(happy-dom@20.8.9)(jsdom@29.1.1)(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -8570,7 +8959,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -1,58 +1,38 @@
 // Will be loaded in a worker thread, cant use any electron API's
 import {
+  AnnotationType,
   IAnnotation,
   IAnnotator,
   IDataStore,
-  ILabel,
   INewAnnotation,
   INewAnnotator,
   INewSample,
   IPoint,
-  IPointReplacement,
   IProject,
-  IProjectUpdate,
   ISample,
-  ISampleUpdate,
   ITask,
-  ITaskUpdate,
-  OmitV2
+  TrainingSplit
 } from '../shared/types'
 import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import path from 'path'
 import fs from 'fs/promises'
 import sharp from 'sharp'
 import { makeUUID } from '../shared/utils'
 import assert from 'assert'
 import { sha512 } from './utils_no_electron'
+import * as schema from './schema'
 
 console.log('Database loaded into worker', APP_PATH)
 declare global {
   const APP_PATH: string
+  const MIGRATIONS_PATH: string
 }
 
 assert(APP_PATH !== undefined, 'APP_PATH global was not defined')
-
-interface IStoredAnnotation extends OmitV2<INewAnnotation, 'points'> {
-  sampleId: string
-}
-
-interface IStoredAnnotator extends OmitV2<INewAnnotator, 'headers'> {
-  headers: string
-  projectId: string
-}
-
-interface IStoredSample extends OmitV2<INewSample, 'base64Image' | 'annotations'> {
-  taskId: string
-  imageId: string
-  completedAt?: string
-}
-
-type DatabasePoint = {
-  id: string
-  x: number
-  y: number
-  sequence: number
-}
+assert(MIGRATIONS_PATH !== undefined, 'MIGRATIONS_PATH global was not defined')
 
 const storePath = path.join(APP_PATH, 'store')
 const databasePath = path.join(storePath, 'database', 'data.db')
@@ -61,451 +41,16 @@ const imagesPath = path.join(storePath, 'images')
 await fs.mkdir(imagesPath, { recursive: true })
 await fs.mkdir(path.dirname(databasePath), { recursive: true })
 
-const db = new Database(databasePath, { fileMustExist: false })
+const sqlite = new Database(databasePath, { fileMustExist: false })
 
-db.pragma('journal_mode = WAL')
-db.pragma('foreign_keys = ON')
+sqlite.pragma('journal_mode = WAL')
+sqlite.pragma('foreign_keys = ON')
 
-db.exec(`
-    CREATE TABLE IF NOT EXISTS projects(
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS annotators(
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        url TEXT NOT NULL,
-        headers TEXT NOT NULL,
-        projectId TEXT NOT NULL,
-        FOREIGN KEY(projectId) REFERENCES projects(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS tasks(
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        projectId TEXT NOT NULL,
-        FOREIGN KEY(projectId) REFERENCES projects(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS labels(
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        color TEXT NOT NULL,
-        projectId TEXT NOT NULL,
-        FOREIGN KEY(projectId) REFERENCES projects(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS images(
-        id TEXT PRIMARY KEY,
-        hash TEXT NOT NULL,
-        extension TEXT NOT NULL
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS samples(
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        split TEXT NOT NULL,
-        createdAt TEXT NOT NULL,
-        completedAt TEXT,
-        imageId TEXT NOT NULL,
-        taskId TEXT NOT NULL,
-        FOREIGN KEY(imageId) REFERENCES images(id),
-        FOREIGN KEY(taskId) REFERENCES tasks(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS annotations(
-        id TEXT PRIMARY KEY,
-        type TEXT NOT NULL,
-        labelId TEXT NOT NULL,
-        sampleId TEXT NOT NULL,
-        FOREIGN KEY(labelId) REFERENCES labels(id)
-            ON DELETE RESTRICT
-            ON UPDATE RESTRICT,
-        FOREIGN KEY(sampleId) REFERENCES samples(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE TABLE IF NOT EXISTS points(
-        id TEXT PRIMARY KEY,
-        x REAL NOT NULL,
-        y REAL NOT NULL,
-        sequence INTEGER NOT NULL,
-        annotationId TEXT NOT NULL,
-        FOREIGN KEY(annotationId) REFERENCES annotations(id)
-            ON DELETE CASCADE
-            ON UPDATE RESTRICT
-    ) WITHOUT ROWID;
-    CREATE INDEX IF NOT EXISTS idx_annotators_projectId ON annotators(projectId);
-    CREATE INDEX IF NOT EXISTS idx_tasks_projectId ON tasks(projectId);
-    CREATE INDEX IF NOT EXISTS idx_labels_projectId ON labels(projectId);
-    CREATE INDEX IF NOT EXISTS idx_samples_taskId ON samples(taskId);
-    CREATE INDEX IF NOT EXISTS idx_samples_imageId ON samples(imageId);
-    CREATE INDEX IF NOT EXISTS idx_annotations_sampleId ON annotations(sampleId);
-    CREATE INDEX IF NOT EXISTS idx_annotations_labelId ON annotations(labelId);
-    CREATE INDEX IF NOT EXISTS idx_points_annotationId ON points(annotationId);
-`)
+const db = drizzle(sqlite, { schema })
 
-const GetProjectsStatement = db.prepare<[], Pick<IProject, 'id' | 'name'>>(
-  `SELECT * FROM projects ORDER BY id ASC`
-)
+migrate(db, { migrationsFolder: MIGRATIONS_PATH })
 
-const CreateProjectStatement = db.prepare<Pick<IProject, 'id' | 'name'>>(
-  `INSERT INTO projects (id,name) VALUES (@id,@name)`
-)
-
-const CreateProjectTransaction = db.transaction(
-  (id: IProject['id'], name: IProject['name'], labels: ILabel[]): IProject => {
-    CreateProjectStatement.run({ id: id, name: name })
-    for (const label of labels) {
-      CreateLabelStatement.run({ ...label, projectId: id })
-    }
-
-    return { id, name, labels }
-  }
-)
-
-const DeleteProjectStatement = db.prepare<{
-  id: IProject['id']
-}>('DELETE FROM projects WHERE id = @id')
-
-const DeleteProjectsTransaction = db.transaction((ids: string[]) => {
-  for (const id of ids) {
-    DeleteProjectStatement.run({ id: id })
-  }
-})
-
-const GetProjectByIdStatement = db.prepare<{ id: IProject['id'] }, Pick<IProject, 'id' | 'name'>>(
-  `SELECT * FROM projects WHERE id = @id`
-)
-
-const UpdateProjectStatement = db.prepare<{ id: IProject['id']; name: IProject['name'] }>(
-  `UPDATE projects SET name = @name WHERE id = @id`
-)
-
-// Scoped to projectId as a defensive check - the renderer only ever sends a project's own
-// labels back, but this keeps a bad id from silently renaming a label in another project.
-const UpdateLabelNameStatement = db.prepare<{
-  id: ILabel['id']
-  name: ILabel['name']
-  projectId: IProject['id']
-}>(`UPDATE labels SET name = @name WHERE id = @id AND projectId = @projectId`)
-
-const UpdateProjectsTransaction = db.transaction((updates: IProjectUpdate[]): IProject[] => {
-  return updates.map((update) => {
-    if (update.name !== undefined) {
-      UpdateProjectStatement.run({ id: update.id, name: update.name })
-    }
-
-    for (const label of update.labels ?? []) {
-      UpdateLabelNameStatement.run({ id: label.id, name: label.name, projectId: update.id })
-    }
-
-    const project = GetProjectByIdStatement.get({ id: update.id })
-    if (project === undefined) {
-      throw new Error(`project not found: ${update.id}`)
-    }
-
-    return { ...project, labels: GetLabelsStatement.all({ projectId: update.id }) }
-  })
-})
-
-const CreateImageStatement = db.prepare<DatabaseImage>(
-  `INSERT INTO images (id,hash,extension) VALUES (@id,@hash,@extension)`
-)
-
-const GetLabelsStatement = db.prepare<{ projectId: IProject['id'] }, ILabel>(
-  `SELECT id,name,color FROM labels WHERE projectId = @projectId ORDER BY id ASC`
-)
-
-const GetTasksStatement = db.prepare<{ projectId: IProject['id'] }, ITask>(
-  `SELECT id,name FROM tasks WHERE projectId = @projectId ORDER BY id ASC`
-)
-
-type DatabaseImage = {
-  id: string
-  hash: string
-  extension: string
-}
-
-const GetImageByIdStatement = db.prepare<[id: string], DatabaseImage>(
-  `SELECT * FROM images WHERE id = ?`
-)
-
-const GetImageByHashStatement = db.prepare<[hash: string], DatabaseImage>(
-  `SELECT * FROM images WHERE hash = ?`
-)
-
-const CreateLabelStatement = db.prepare<ILabel & { projectId: string }>(
-  `INSERT INTO labels (id,name,color,projectId) VALUES (@id,@name,@color,@projectId)`
-)
-
-const CreateTaskStatement = db.prepare<ITask & { projectId: string }>(
-  `INSERT INTO tasks (id,name,projectId) VALUES (@id,@name,@projectId)`
-)
-
-const GetTaskByIdStatement = db.prepare<{ id: ITask['id'] }, ITask>(
-  `SELECT id, name FROM tasks WHERE id = @id`
-)
-
-const UpdateTaskStatement = db.prepare<{ id: ITask['id']; name: ITask['name'] }>(
-  `UPDATE tasks SET name = @name WHERE id = @id`
-)
-
-const UpdateTasksTransaction = db.transaction((updates: ITaskUpdate[]): ITask[] => {
-  return updates.map((update) => {
-    if (update.name !== undefined) {
-      UpdateTaskStatement.run({ id: update.id, name: update.name })
-    }
-
-    const task = GetTaskByIdStatement.get({ id: update.id })
-    if (task === undefined) {
-      throw new Error(`task not found: ${update.id}`)
-    }
-
-    return task
-  })
-})
-
-const GetAnnotationsStatement = db.prepare<[sampleId: string], IStoredAnnotation>(
-  `SELECT id, type, labelId, sampleId FROM annotations WHERE sampleId = ? ORDER BY id ASC`
-)
-
-const CreateAnnotationStatement = db.prepare<IStoredAnnotation>(
-  `INSERT INTO annotations (id,type,labelId,sampleId) VALUES (@id,@type,@labelId,@sampleId)`
-)
-
-const GetAnnotationByIdStatement = db.prepare<[id: string], IStoredAnnotation>(
-  `SELECT id, type, labelId, sampleId FROM annotations WHERE id = ?`
-)
-
-const UpdateAnnotationStatement = db.prepare<Pick<IStoredAnnotation, 'id' | 'type' | 'labelId'>>(
-  `UPDATE annotations SET type = @type, labelId = @labelId WHERE id = @id`
-)
-
-const CreatePointStatement = db.prepare<{
-  id: string
-  x: number
-  y: number
-  sequence: number
-  annotationId: string
-}>(`INSERT INTO points (id,x,y,sequence,annotationId) VALUES (@id,@x,@y,@sequence,@annotationId)`)
-
-const GetPointsStatement = db.prepare<[annotationId: string], DatabasePoint>(
-  `SELECT id, x, y, sequence FROM points WHERE annotationId = ? ORDER BY sequence ASC`
-)
-
-const GetPointsWithoutSequenceStatement = db.prepare<[annotationId: string], IPoint>(
-  `SELECT id, x, y FROM points WHERE annotationId = ? ORDER BY sequence ASC`
-)
-
-const UpdatePointStatement = db.prepare<{
-  id: string
-  x: number
-  y: number
-  sequence: number
-}>(`UPDATE points SET x = @x, y = @y, sequence = @sequence WHERE id = @id`)
-
-const DeletePointStatement = db.prepare<[id: string]>('DELETE FROM points WHERE id = ?')
-
-const GetSampleStatement = db.prepare<[taskId: string], IStoredSample>(
-  `SELECT * FROM samples WHERE taskId = ? ORDER BY id ASC`
-)
-
-const GetSampleByIdStatement = db.prepare<[sampleId: string], IStoredSample>(
-  `SELECT * FROM samples WHERE id = ?`
-)
-
-const CreateSampleStatement = db.prepare<IStoredSample>(
-  `INSERT INTO samples (id,name,split,createdAt,imageId,taskId) VALUES (@id,@name,@split,@createdAt,@imageId,@taskId)`
-)
-
-const UpdateSampleStatement = db.prepare<ISampleUpdate>(
-  `UPDATE samples SET name = @name, split = @split, createdAt = @createdAt, completedAt = @completedAt WHERE id = @id`
-)
-
-const CreateAnnotatorStatement = db.prepare<IStoredAnnotator>(
-  `INSERT INTO annotators (id,name,url,headers,projectId) VALUES (@id,@name,@url,@headers,@projectId)`
-)
-
-const GetAnnotatorsStatement = db.prepare<[projectId: string], IStoredAnnotator>(
-  `SELECT id,name,url,headers FROM annotators WHERE projectId = ? ORDER BY id ASC`
-)
-
-const DeleteAnnotatorStatement = db.prepare<[annotatorId: string]>(
-  `DELETE FROM annotators WHERE id = ?`
-)
-
-const DeleteAnnotatorsTransaction = db.transaction((annotatorIds: string[]) => {
-  for (const annotatorId of annotatorIds) {
-    DeleteAnnotatorStatement.run(annotatorId)
-  }
-})
-
-// const DeleteLabelStatement = db.prepare<INewLabel & { projectId: string }>(
-//   `INSERT INTO labels (id,name) VALUES (@id,@name,@color,@createdAt,@projectId)`
-// )
-
-const DeleteTaskStatement = db.prepare<{
-  id: ITask['id']
-}>('DELETE FROM tasks WHERE id = @id')
-
-const DeleteSampleStatement = db.prepare<{
-  id: ISample['id']
-}>('DELETE FROM samples WHERE id = @id')
-
-const DeleteAnnotationStatement = db.prepare<{
-  id: IAnnotation['id']
-}>('DELETE FROM annotations WHERE id = @id')
-
-const CreateAnnotationsTransaction = db.transaction(
-  (sampleId: string, annotations: INewAnnotation[]): IAnnotation[] => {
-    const result: IAnnotation[] = []
-
-    annotations.forEach((annotation) => {
-      CreateAnnotationStatement.run({
-        id: annotation.id,
-        type: annotation.type,
-        labelId: annotation.labelId,
-        sampleId: sampleId
-      })
-
-      // Insert points into the points table
-      annotation.points.forEach((point, sequence) => {
-        CreatePointStatement.run({
-          id: point.id,
-          x: point.x,
-          y: point.y,
-          sequence: sequence,
-          annotationId: annotation.id
-        })
-      })
-
-      result.push(annotation)
-    })
-
-    return result
-  }
-)
-
-const CreateImagesTransaction = db.transaction((hashes: string[], extensions: string[]) => {
-  const ids: string[] = []
-  const inserted: Set<number> = new Set()
-
-  for (let i = 0; i < hashes.length; i++) {
-    const hash = hashes[i]
-    const extension = extensions[i]
-    const existing = GetImageByHashStatement.get(hash)
-    if (existing !== undefined) {
-      ids.push(existing.id)
-    } else {
-      inserted.add(i)
-      const id = makeUUID()
-      ids.push(id)
-      CreateImageStatement.run({ id, hash, extension })
-    }
-  }
-
-  return { ids, inserted }
-})
-
-const DeleteTasksTransaction = db.transaction((ids: string[]) => {
-  for (const id of ids) {
-    DeleteTaskStatement.run({ id: id })
-  }
-})
-
-const DeleteSamplesTransaction = db.transaction((ids: string[]) => {
-  for (const id of ids) {
-    DeleteSampleStatement.run({ id: id })
-  }
-})
-
-const DeleteAnnotationsTransaction = db.transaction((ids: string[]) => {
-  for (const id of ids) {
-    DeleteAnnotationStatement.run({ id: id })
-  }
-})
-
-const ReplacePointsTransaction = db.transaction(
-  (annotationId: string, points: IPointReplacement[]): IPoint[] => {
-    // Get current points for the annotation
-    const currentPoints = GetPointsStatement.all(annotationId)
-
-    // Create a map of current points by id
-    const currentPointsMap = new Map(currentPoints.map((p) => [p.id, p]))
-
-    // Categorize operations
-    const toInsert: DatabasePoint[] = []
-    const toUpdate: DatabasePoint[] = []
-    const toDelete: string[] = []
-
-    // Process each input point
-    for (let sequence = 0; sequence < points.length; sequence++) {
-      const pointInput = points[sequence]
-      const id = pointInput.id
-
-      if (currentPointsMap.has(id)) {
-        // Update existing point
-        const existing = currentPointsMap.get(id)!
-        toUpdate.push({
-          id: id,
-          x: pointInput.x ?? existing.x,
-          y: pointInput.y ?? existing.y,
-          sequence: sequence
-        })
-      } else {
-        // Insert new point - must have x and y
-        if (pointInput.x === undefined || pointInput.y === undefined) {
-          throw new Error(`New point with id ${id} missing x or y coordinate`)
-        }
-        toInsert.push({
-          id: id,
-          x: pointInput.x,
-          y: pointInput.y,
-          sequence: sequence
-        })
-      }
-    }
-
-    // Points to delete: current points not in input
-    for (const current of currentPoints) {
-      const isInInput = points.some((p) => p.id === current.id)
-      if (!isInInput) {
-        toDelete.push(current.id)
-      }
-    }
-
-    // Perform operations in order: delete, insert, update
-    for (const id of toDelete) {
-      DeletePointStatement.run(id)
-    }
-
-    for (const point of toInsert) {
-      CreatePointStatement.run({
-        id: point.id,
-        x: point.x,
-        y: point.y,
-        sequence: point.sequence,
-        annotationId: annotationId
-      })
-    }
-
-    for (const point of toUpdate) {
-      UpdatePointStatement.run({
-        id: point.id,
-        x: point.x,
-        y: point.y,
-        sequence: point.sequence
-      })
-    }
-
-    // Return the full list of points ordered by sequence
-    return GetPointsWithoutSequenceStatement.all(annotationId) as IPoint[]
-  }
-)
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0]
 
 export const IMAGES_PROTOCOL_URL = 'images'
 
@@ -517,7 +62,7 @@ export const getImagePathFromUrl = async (url: string) => {
   const imageKey = url.slice(IMAGES_PROTOCOL_URL.length + 3)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [id, _] = imageKey.split('.') as [string, string]
-  const imageInfo = GetImageByIdStatement.get(id)
+  const imageInfo = db.select().from(schema.images).where(eq(schema.images.id, id)).get()
 
   if (imageInfo === undefined) {
     return undefined
@@ -526,145 +71,134 @@ export const getImagePathFromUrl = async (url: string) => {
   return path.join(imagesPath, `${imageInfo.hash}.${imageInfo.extension}`)
 }
 
-const materializeSample = (s: IStoredSample): ISample => {
-  const imageInfo = GetImageByIdStatement.get(s.imageId)
-  if (imageInfo === undefined) throw new Error('Sample image does not exist')
-
-  const annotations = GetAnnotationsStatement.all(s.id)
-
-  return {
-    id: s.id,
-    name: s.name,
-    annotations: annotations.map<IAnnotation>((a) => {
-      const pointRows = GetPointsWithoutSequenceStatement.all(a.id)
-      return {
-        id: a.id,
-        type: a.type,
-        labelId: a.labelId,
-        points: pointRows
+function fetchSampleWithRelations(id: string) {
+  return db.query.samples.findFirst({
+    where: eq(schema.samples.id, id),
+    with: {
+      image: true,
+      annotations: {
+        orderBy: (annotations, { asc }) => [asc(annotations.id)],
+        with: {
+          points: {
+            orderBy: (points, { asc }) => [asc(points.sequence)]
+          }
+        }
       }
-    }),
-    createdAt: s.createdAt,
-    split: s.split,
-    imageUri: makeImageUri(imageInfo.id, imageInfo.extension),
-    completedAt: s.completedAt ?? null
-  }
-}
-
-const GetSamplesForTaskTransaction = db.transaction((taskId: string): ISample[] => {
-  const samples = GetSampleStatement.all(taskId)
-  return samples.map(materializeSample)
-})
-
-const GetSamplesByIdsTransaction = db.transaction((sampleIds: string[]): ISample[] => {
-  const samples: ISample[] = []
-  for (const sampleId of sampleIds) {
-    const sample = GetSampleByIdStatement.get(sampleId)
-    if (sample !== undefined) {
-      samples.push(materializeSample(sample))
-    }
-  }
-  return samples
-})
-
-const GetAnnotationsForSampleTransaction = db.transaction((sampleId: string): IAnnotation[] => {
-  const annotations = GetAnnotationsStatement.all(sampleId)
-
-  return annotations.map<IAnnotation>((annotation) => {
-    const pointRows = GetPointsWithoutSequenceStatement.all(annotation.id)
-    return {
-      id: annotation.id,
-      type: annotation.type,
-      labelId: annotation.labelId,
-      points: pointRows
     }
   })
+}
+
+// Row shape returned by the sample relational query above (id/image/annotations/points).
+type SampleWithRelationsRow = NonNullable<Awaited<ReturnType<typeof fetchSampleWithRelations>>>
+
+const mapSampleRow = (row: SampleWithRelationsRow): ISample => ({
+  id: row.id,
+  name: row.name,
+  split: row.split as TrainingSplit,
+  createdAt: row.createdAt,
+  completedAt: row.completedAt,
+  imageUri: makeImageUri(row.image.id, row.image.extension),
+  annotations: row.annotations.map<IAnnotation>((a) => ({
+    id: a.id,
+    type: a.type as AnnotationType,
+    labelId: a.labelId,
+    points: a.points
+  }))
 })
 
-const CreateSamplesTransaction = db.transaction(
-  (taskId: string, samples: INewSample[], hashes: string[], extensions: string[]) => {
-    const { ids: imageIds, inserted: insertedImagesIndex } = CreateImagesTransaction.immediate(
-      hashes,
-      extensions
-    )
+const dedupeImages = (
+  tx: Tx,
+  hashes: string[],
+  extensions: string[]
+): { ids: string[]; inserted: Set<number> } => {
+  const ids: string[] = []
+  const inserted: Set<number> = new Set()
 
-    const newSamples: ISample[] = []
+  for (let i = 0; i < hashes.length; i++) {
+    const hash = hashes[i]
+    const extension = extensions[i]
+    const existing = tx.select().from(schema.images).where(eq(schema.images.hash, hash)).get()
+    if (existing !== undefined) {
+      ids.push(existing.id)
+    } else {
+      inserted.add(i)
+      const id = makeUUID()
+      ids.push(id)
+      tx.insert(schema.images).values({ id, hash, extension }).run()
+    }
+  }
 
-    for (let i = 0; i < samples.length; i++) {
-      const sample = samples[i]
-      const imageId = imageIds[i]
-      const imageExtension = extensions[i]
-      CreateSampleStatement.run({ ...sample, taskId, imageId })
+  return { ids, inserted }
+}
 
-      newSamples.push({
+const insertAnnotations = (
+  tx: Tx,
+  sampleId: string,
+  annotations: INewAnnotation[]
+): IAnnotation[] => {
+  for (const annotation of annotations) {
+    tx.insert(schema.annotations)
+      .values({ id: annotation.id, type: annotation.type, labelId: annotation.labelId, sampleId })
+      .run()
+
+    if (annotation.points.length > 0) {
+      tx.insert(schema.points)
+        .values(
+          annotation.points.map((point, sequence) => ({
+            id: point.id,
+            x: point.x,
+            y: point.y,
+            sequence,
+            annotationId: annotation.id
+          }))
+        )
+        .run()
+    }
+  }
+
+  return annotations
+}
+
+const insertSamplesWithImages = (
+  tx: Tx,
+  taskId: string,
+  samples: INewSample[],
+  hashes: string[],
+  extensions: string[]
+): { insertedImagesIndex: Set<number>; newSamples: ISample[] } => {
+  const { ids: imageIds, inserted: insertedImagesIndex } = dedupeImages(tx, hashes, extensions)
+
+  const newSamples: ISample[] = []
+
+  for (let i = 0; i < samples.length; i++) {
+    const sample = samples[i]
+    const imageId = imageIds[i]
+    const imageExtension = extensions[i]
+
+    tx.insert(schema.samples)
+      .values({
         id: sample.id,
         name: sample.name,
-        imageUri: makeImageUri(imageId, imageExtension),
-        createdAt: sample.createdAt,
-        annotations: CreateAnnotationsTransaction.immediate(sample.id, sample.annotations),
         split: sample.split,
-        completedAt: null
+        createdAt: sample.createdAt,
+        imageId,
+        taskId
       })
-    }
+      .run()
 
-    return { insertedImagesIndex, newSamples }
-  }
-)
-
-const UpdateSamplesTransaction = db.transaction((updates: ISampleUpdate[]): ISample[] => {
-  const updatedSamples: ISample[] = []
-
-  for (const update of updates) {
-    const existing = GetSampleByIdStatement.get(update.id)
-    if (existing === undefined) {
-      throw new Error(`sample not found: ${update.id}`)
-    }
-
-    // Materialize once
-    const existingSample = materializeSample(existing)
-
-    UpdateSampleStatement.run({
-      id: update.id,
-      name: update.name ?? existing.name,
-      split: update.split ?? existing.split,
-      createdAt: update.createdAt ?? existing.createdAt,
-      completedAt: update.completedAt ?? existing.completedAt
+    newSamples.push({
+      id: sample.id,
+      name: sample.name,
+      imageUri: makeImageUri(imageId, imageExtension),
+      createdAt: sample.createdAt,
+      annotations: insertAnnotations(tx, sample.id, sample.annotations),
+      split: sample.split,
+      completedAt: null
     })
-
-    // Construct updated sample from existing materialized sample
-    const updatedSample: ISample = {
-      ...existingSample,
-      name: update.name ?? existingSample.name,
-      split: update.split ?? existingSample.split,
-      createdAt: update.createdAt ?? existingSample.createdAt,
-      completedAt: update.completedAt ?? existingSample.completedAt
-    }
-
-    updatedSamples.push(updatedSample)
   }
 
-  return updatedSamples
-})
-
-const CreateTaskTransaction = db.transaction(
-  (
-    projectId: string,
-    id: string,
-    name: string,
-    newSamples: INewSample[],
-    hashes: string[],
-    extensions: string[]
-  ): ITask => {
-    const task = { id, name }
-    CreateTaskStatement.run({ ...task, projectId })
-
-    if (newSamples.length > 0) {
-      CreateSamplesTransaction.immediate(task.id, newSamples, hashes, extensions)
-    }
-
-    return task
-  }
-)
+  return { insertedImagesIndex, newSamples }
+}
 
 const localStore: IDataStore = {
   connect: async () => {},
@@ -672,37 +206,123 @@ const localStore: IDataStore = {
   disconnect: async () => {},
 
   getProjects: async () => {
-    const projects = GetProjectsStatement.all().map<IProject>((c) => ({
-      ...c,
-      labels: GetLabelsStatement.all({ projectId: c.id })
+    const projects = await db.query.projects.findMany({
+      orderBy: (projects, { asc }) => [asc(projects.id)],
+      with: {
+        labels: {
+          orderBy: (labels, { asc }) => [asc(labels.id)]
+        }
+      }
+    })
+
+    return projects.map<IProject>((p) => ({
+      id: p.id,
+      name: p.name,
+      labels: p.labels
     }))
-    return projects
   },
 
   createProject: async (id, name, labels) => {
-    return CreateProjectTransaction.immediate(id, name, labels)
+    return db.transaction((tx) => {
+      tx.insert(schema.projects).values({ id, name }).run()
+
+      if (labels.length > 0) {
+        tx.insert(schema.labels)
+          .values(labels.map((label) => ({ ...label, projectId: id })))
+          .run()
+      }
+
+      return { id, name, labels }
+    })
   },
 
   updateProjects: async (updates) => {
-    return UpdateProjectsTransaction.immediate(updates)
+    return db.transaction((tx) => {
+      return updates.map((update) => {
+        if (update.name !== undefined) {
+          tx.update(schema.projects)
+            .set({ name: update.name })
+            .where(eq(schema.projects.id, update.id))
+            .run()
+        }
+
+        for (const label of update.labels ?? []) {
+          // Scoped to projectId as a defensive check - the renderer only ever sends a project's
+          // own labels back, but this keeps a bad id from silently renaming a label in another project.
+          tx.update(schema.labels)
+            .set({ name: label.name })
+            .where(and(eq(schema.labels.id, label.id), eq(schema.labels.projectId, update.id)))
+            .run()
+        }
+
+        const project = tx.query.projects
+          .findFirst({
+            where: eq(schema.projects.id, update.id),
+            with: { labels: { orderBy: (labels, { asc }) => [asc(labels.id)] } }
+          })
+          .sync()
+
+        if (project === undefined) {
+          throw new Error(`project not found: ${update.id}`)
+        }
+
+        return project
+      })
+    })
   },
 
   deleteProjects: async (projectIds) => {
-    DeleteProjectsTransaction.immediate(projectIds)
+    db.transaction((tx) => {
+      for (const id of projectIds) {
+        tx.delete(schema.projects).where(eq(schema.projects.id, id)).run()
+      }
+    })
     return projectIds.map(() => true)
   },
 
   getTasksForProject: async (projectId) => {
-    return GetTasksStatement.all({ projectId })
+    return db
+      .select({ id: schema.tasks.id, name: schema.tasks.name })
+      .from(schema.tasks)
+      .where(eq(schema.tasks.projectId, projectId))
+      .orderBy(asc(schema.tasks.id))
   },
 
   updateTasks: async (updates) => {
-    return UpdateTasksTransaction.immediate(updates)
+    return db.transaction((tx) => {
+      return updates.map((update) => {
+        if (update.name !== undefined) {
+          tx.update(schema.tasks)
+            .set({ name: update.name })
+            .where(eq(schema.tasks.id, update.id))
+            .run()
+        }
+
+        const task = tx
+          .select({ id: schema.tasks.id, name: schema.tasks.name })
+          .from(schema.tasks)
+          .where(eq(schema.tasks.id, update.id))
+          .get()
+
+        if (task === undefined) {
+          throw new Error(`task not found: ${update.id}`)
+        }
+
+        return task
+      })
+    })
   },
 
   createTask: async (projectId, id, name, newSamples = []) => {
+    const task: ITask = { id, name }
+
     if (newSamples.length === 0) {
-      return CreateTaskTransaction.immediate(projectId, id, name, [], [], [])
+      db.transaction((tx) => {
+        tx.insert(schema.tasks)
+          .values({ ...task, projectId })
+          .run()
+      })
+      return task
     }
 
     const b64Images = newSamples.map((c) => c.base64Image)
@@ -723,19 +343,56 @@ const localStore: IDataStore = {
       )
     )
 
-    return CreateTaskTransaction.immediate(projectId, id, name, newSamples, hashes, extensions)
+    db.transaction((tx) => {
+      tx.insert(schema.tasks)
+        .values({ ...task, projectId })
+        .run()
+      insertSamplesWithImages(tx, task.id, newSamples, hashes, extensions as string[])
+    })
+
+    return task
   },
 
   deleteTasks: async (taskIds) => {
-    DeleteTasksTransaction.immediate(taskIds)
+    db.transaction((tx) => {
+      for (const id of taskIds) {
+        tx.delete(schema.tasks).where(eq(schema.tasks.id, id)).run()
+      }
+    })
     return taskIds.map(() => true)
   },
+
   getSamplesForTask: async (taskId) => {
-    return GetSamplesForTaskTransaction.deferred(taskId)
+    const samples = await db.query.samples.findMany({
+      where: eq(schema.samples.taskId, taskId),
+      orderBy: (samples, { asc }) => [asc(samples.id)],
+      with: {
+        image: true,
+        annotations: {
+          orderBy: (annotations, { asc }) => [asc(annotations.id)],
+          with: {
+            points: {
+              orderBy: (points, { asc }) => [asc(points.sequence)]
+            }
+          }
+        }
+      }
+    })
+
+    return samples.map(mapSampleRow)
   },
+
   getSamples: async (sampleIds) => {
-    return GetSamplesByIdsTransaction.deferred(sampleIds)
+    const samples: ISample[] = []
+    for (const sampleId of sampleIds) {
+      const sample = await fetchSampleWithRelations(sampleId)
+      if (sample !== undefined) {
+        samples.push(mapSampleRow(sample))
+      }
+    }
+    return samples
   },
+
   createSamples: async (taskId, samples) => {
     const b64Images = samples.map((c) => c.base64Image)
     const hashes = sha512(b64Images)
@@ -748,11 +405,8 @@ const localStore: IDataStore = {
       )
     )
 
-    const { insertedImagesIndex, newSamples } = CreateSamplesTransaction.immediate(
-      taskId,
-      samples,
-      hashes,
-      extensions
+    const { insertedImagesIndex, newSamples } = db.transaction((tx) =>
+      insertSamplesWithImages(tx, taskId, samples, hashes, extensions as string[])
     )
 
     // Write images to disk
@@ -766,46 +420,117 @@ const localStore: IDataStore = {
   },
 
   updateSamples: async (updates) => {
-    return UpdateSamplesTransaction.immediate(updates)
+    return db.transaction((tx) => {
+      const updatedSamples: ISample[] = []
+
+      for (const update of updates) {
+        const existingRow = tx.query.samples
+          .findFirst({
+            where: eq(schema.samples.id, update.id),
+            with: {
+              image: true,
+              annotations: {
+                orderBy: (annotations, { asc }) => [asc(annotations.id)],
+                with: {
+                  points: {
+                    orderBy: (points, { asc }) => [asc(points.sequence)]
+                  }
+                }
+              }
+            }
+          })
+          .sync()
+
+        if (existingRow === undefined) {
+          throw new Error(`sample not found: ${update.id}`)
+        }
+
+        const existingSample = mapSampleRow(existingRow)
+
+        tx.update(schema.samples)
+          .set({
+            name: update.name ?? existingRow.name,
+            split: update.split ?? existingRow.split,
+            createdAt: update.createdAt ?? existingRow.createdAt,
+            completedAt: update.completedAt ?? existingRow.completedAt
+          })
+          .where(eq(schema.samples.id, update.id))
+          .run()
+
+        updatedSamples.push({
+          ...existingSample,
+          name: update.name ?? existingSample.name,
+          split: update.split ?? existingSample.split,
+          createdAt: update.createdAt ?? existingSample.createdAt,
+          completedAt: update.completedAt ?? existingSample.completedAt
+        })
+      }
+
+      return updatedSamples
+    })
   },
 
   deleteSamples: async (sampleIds) => {
-    DeleteSamplesTransaction.immediate(sampleIds)
+    db.transaction((tx) => {
+      for (const id of sampleIds) {
+        tx.delete(schema.samples).where(eq(schema.samples.id, id)).run()
+      }
+    })
     return sampleIds.map(() => true)
   },
 
   getAnnotationsForSample: async (sampleId) => {
-    return GetAnnotationsForSampleTransaction.deferred(sampleId)
+    const annotations = await db.query.annotations.findMany({
+      where: eq(schema.annotations.sampleId, sampleId),
+      orderBy: (annotations, { asc }) => [asc(annotations.id)],
+      with: {
+        points: {
+          orderBy: (points, { asc }) => [asc(points.sequence)]
+        }
+      }
+    })
+
+    return annotations.map<IAnnotation>((annotation) => ({
+      id: annotation.id,
+      type: annotation.type as AnnotationType,
+      labelId: annotation.labelId,
+      points: annotation.points
+    }))
   },
 
   createAnnotations: async (sampleId, annotations) => {
-    return CreateAnnotationsTransaction.immediate(sampleId, annotations)
+    return db.transaction((tx) => insertAnnotations(tx, sampleId, annotations))
   },
 
   updateAnnotations: async (updates) => {
-    const updatedAnnotations = db.transaction((annotationUpdates): IAnnotation[] => {
+    return db.transaction((tx) => {
       const results: IAnnotation[] = []
 
-      for (const update of annotationUpdates) {
-        const existing = GetAnnotationByIdStatement.get(update.id)
+      for (const update of updates) {
+        const existing = tx
+          .select()
+          .from(schema.annotations)
+          .where(eq(schema.annotations.id, update.id))
+          .get()
+
         if (existing === undefined) {
           throw new Error(`annotation not found: ${update.id}`)
         }
 
-        const nextType = update.type ?? existing.type
+        const nextType = update.type ?? (existing.type as AnnotationType)
         const nextLabelId = update.labelId ?? existing.labelId
 
-        UpdateAnnotationStatement.run({
-          id: existing.id,
-          type: nextType,
-          labelId: nextLabelId
-        })
+        tx.update(schema.annotations)
+          .set({ type: nextType, labelId: nextLabelId })
+          .where(eq(schema.annotations.id, existing.id))
+          .run()
 
-        const points = GetPointsStatement.all(existing.id).map((point) => ({
-          id: point.id,
-          x: point.x,
-          y: point.y
-        }))
+        const points = tx
+          .select({ id: schema.points.id, x: schema.points.x, y: schema.points.y })
+          .from(schema.points)
+          .where(eq(schema.points.annotationId, existing.id))
+          .orderBy(asc(schema.points.sequence))
+          .all()
 
         results.push({
           id: existing.id,
@@ -817,41 +542,137 @@ const localStore: IDataStore = {
 
       return results
     })
-
-    return updatedAnnotations.immediate(updates)
   },
 
   deleteAnnotations: async (annotationsIds) => {
-    DeleteAnnotationsTransaction.immediate(annotationsIds)
+    db.transaction((tx) => {
+      for (const id of annotationsIds) {
+        tx.delete(schema.annotations).where(eq(schema.annotations.id, id)).run()
+      }
+    })
     return annotationsIds.map(() => true)
   },
 
   getAnnotators: async (projectId) => {
-    return GetAnnotatorsStatement.all(projectId).map<IAnnotator>((c) => ({
-      ...c,
-      headers: JSON.parse(c.headers)
+    const annotators = await db
+      .select({
+        id: schema.annotators.id,
+        name: schema.annotators.name,
+        url: schema.annotators.url,
+        headers: schema.annotators.headers
+      })
+      .from(schema.annotators)
+      .where(eq(schema.annotators.projectId, projectId))
+      .orderBy(asc(schema.annotators.id))
+
+    return annotators.map<IAnnotator>((a) => ({
+      ...a,
+      headers: JSON.parse(a.headers)
     }))
   },
 
   createAnnotator: async (projectId, id, name, url, headers) => {
-    const newAnnotator = { id, name, url, headers }
-    CreateAnnotatorStatement.run({
-      ...newAnnotator,
-      headers: JSON.stringify(newAnnotator.headers),
-      projectId
-    })
-    return {
-      ...newAnnotator
-    }
+    const newAnnotator: INewAnnotator = { id, name, url, headers }
+    db.insert(schema.annotators)
+      .values({ ...newAnnotator, headers: JSON.stringify(newAnnotator.headers), projectId })
+      .run()
+    return { ...newAnnotator }
   },
 
   deleteAnnotators: async (annotatorIds) => {
-    DeleteAnnotatorsTransaction.immediate(annotatorIds)
+    db.transaction((tx) => {
+      for (const id of annotatorIds) {
+        tx.delete(schema.annotators).where(eq(schema.annotators.id, id)).run()
+      }
+    })
     return annotatorIds.map(() => true)
   },
 
   replacePoints: async (annotationId, points) => {
-    return ReplacePointsTransaction.immediate(annotationId, points)
+    return db.transaction((tx) => {
+      // Get current points for the annotation
+      const currentPoints = tx
+        .select({
+          id: schema.points.id,
+          x: schema.points.x,
+          y: schema.points.y,
+          sequence: schema.points.sequence
+        })
+        .from(schema.points)
+        .where(eq(schema.points.annotationId, annotationId))
+        .orderBy(asc(schema.points.sequence))
+        .all()
+
+      // Create a map of current points by id
+      const currentPointsMap = new Map(currentPoints.map((p) => [p.id, p]))
+
+      // Categorize operations
+      const toInsert: { id: string; x: number; y: number; sequence: number }[] = []
+      const toUpdate: { id: string; x: number; y: number; sequence: number }[] = []
+      const toDelete: string[] = []
+
+      // Process each input point
+      for (let sequence = 0; sequence < points.length; sequence++) {
+        const pointInput = points[sequence]
+        const id = pointInput.id
+
+        if (currentPointsMap.has(id)) {
+          // Update existing point
+          const existing = currentPointsMap.get(id)!
+          toUpdate.push({
+            id: id,
+            x: pointInput.x ?? existing.x,
+            y: pointInput.y ?? existing.y,
+            sequence: sequence
+          })
+        } else {
+          // Insert new point - must have x and y
+          if (pointInput.x === undefined || pointInput.y === undefined) {
+            throw new Error(`New point with id ${id} missing x or y coordinate`)
+          }
+          toInsert.push({
+            id: id,
+            x: pointInput.x,
+            y: pointInput.y,
+            sequence: sequence
+          })
+        }
+      }
+
+      // Points to delete: current points not in input
+      for (const current of currentPoints) {
+        const isInInput = points.some((p) => p.id === current.id)
+        if (!isInInput) {
+          toDelete.push(current.id)
+        }
+      }
+
+      // Perform operations in order: delete, insert, update
+      if (toDelete.length > 0) {
+        tx.delete(schema.points).where(inArray(schema.points.id, toDelete)).run()
+      }
+
+      if (toInsert.length > 0) {
+        tx.insert(schema.points)
+          .values(toInsert.map((point) => ({ ...point, annotationId })))
+          .run()
+      }
+
+      for (const point of toUpdate) {
+        tx.update(schema.points)
+          .set({ x: point.x, y: point.y, sequence: point.sequence })
+          .where(eq(schema.points.id, point.id))
+          .run()
+      }
+
+      // Return the full list of points ordered by sequence
+      return tx
+        .select({ id: schema.points.id, x: schema.points.x, y: schema.points.y })
+        .from(schema.points)
+        .where(eq(schema.points.annotationId, annotationId))
+        .orderBy(asc(schema.points.sequence))
+        .all() as IPoint[]
+    })
   }
 }
 

--- a/src/main/schema.ts
+++ b/src/main/schema.ts
@@ -1,0 +1,144 @@
+import { relations } from 'drizzle-orm'
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const projects = sqliteTable('projects', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull()
+})
+
+export const annotators = sqliteTable(
+  'annotators',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    url: text('url').notNull(),
+    headers: text('headers').notNull(),
+    projectId: text('projectId')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [index('idx_annotators_projectId').on(table.projectId)]
+)
+
+export const tasks = sqliteTable(
+  'tasks',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    projectId: text('projectId')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [index('idx_tasks_projectId').on(table.projectId)]
+)
+
+export const labels = sqliteTable(
+  'labels',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    color: text('color').notNull(),
+    projectId: text('projectId')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [index('idx_labels_projectId').on(table.projectId)]
+)
+
+export const images = sqliteTable('images', {
+  id: text('id').primaryKey(),
+  hash: text('hash').notNull(),
+  extension: text('extension').notNull()
+})
+
+export const samples = sqliteTable(
+  'samples',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    split: text('split').notNull(),
+    createdAt: text('createdAt').notNull(),
+    completedAt: text('completedAt'),
+    imageId: text('imageId')
+      .notNull()
+      .references(() => images.id),
+    taskId: text('taskId')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [
+    index('idx_samples_taskId').on(table.taskId),
+    index('idx_samples_imageId').on(table.imageId)
+  ]
+)
+
+export const annotations = sqliteTable(
+  'annotations',
+  {
+    id: text('id').primaryKey(),
+    type: text('type').notNull(),
+    labelId: text('labelId')
+      .notNull()
+      .references(() => labels.id, { onDelete: 'restrict', onUpdate: 'restrict' }),
+    sampleId: text('sampleId')
+      .notNull()
+      .references(() => samples.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [
+    index('idx_annotations_sampleId').on(table.sampleId),
+    index('idx_annotations_labelId').on(table.labelId)
+  ]
+)
+
+export const points = sqliteTable(
+  'points',
+  {
+    id: text('id').primaryKey(),
+    x: real('x').notNull(),
+    y: real('y').notNull(),
+    sequence: integer('sequence').notNull(),
+    annotationId: text('annotationId')
+      .notNull()
+      .references(() => annotations.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [index('idx_points_annotationId').on(table.annotationId)]
+)
+
+export const projectsRelations = relations(projects, ({ many }) => ({
+  labels: many(labels),
+  tasks: many(tasks),
+  annotators: many(annotators)
+}))
+
+export const annotatorsRelations = relations(annotators, ({ one }) => ({
+  project: one(projects, { fields: [annotators.projectId], references: [projects.id] })
+}))
+
+export const tasksRelations = relations(tasks, ({ one, many }) => ({
+  project: one(projects, { fields: [tasks.projectId], references: [projects.id] }),
+  samples: many(samples)
+}))
+
+export const labelsRelations = relations(labels, ({ one }) => ({
+  project: one(projects, { fields: [labels.projectId], references: [projects.id] })
+}))
+
+export const imagesRelations = relations(images, ({ many }) => ({
+  samples: many(samples)
+}))
+
+export const samplesRelations = relations(samples, ({ one, many }) => ({
+  task: one(tasks, { fields: [samples.taskId], references: [tasks.id] }),
+  image: one(images, { fields: [samples.imageId], references: [images.id] }),
+  annotations: many(annotations)
+}))
+
+export const annotationsRelations = relations(annotations, ({ one, many }) => ({
+  sample: one(samples, { fields: [annotations.sampleId], references: [samples.id] }),
+  label: one(labels, { fields: [annotations.labelId], references: [labels.id] }),
+  points: many(points)
+}))
+
+export const pointsRelations = relations(points, ({ one }) => ({
+  annotation: one(annotations, { fields: [points.annotationId], references: [annotations.id] })
+}))

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -3,13 +3,14 @@ import { IPCKeys } from '../shared/types'
 import url from 'node:url'
 // import path from 'path'
 import { importWorkerModule } from './worker'
-import { getAppPath } from './utils'
+import { getAppPath, getMigrationsPath } from './utils'
 import databaseWorkerPath from './database?modulePath'
 import { handleIpc } from './ipc'
 const database = await importWorkerModule<typeof import('./database')>(
   url.pathToFileURL(databaseWorkerPath),
   {
-    APP_PATH: getAppPath()
+    APP_PATH: getAppPath(),
+    MIGRATIONS_PATH: getMigrationsPath()
   }
 )
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,6 +1,20 @@
 import { app } from 'electron'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export const getAppPath = () =>
   process.env.CV_LABEL_APP_PATH ??
   (app.isPackaged ? path.dirname(app.getPath('exe')) : app.getAppPath())
+
+// electron-vite bundles every src/main/** module flat into out/main/, regardless of which
+// chunk this code ends up in - so this file's own bundled location is always out/main,
+// two levels below the repo root. Deliberately not app.getAppPath(): in dev mode (launched
+// via out/main/index.js, as both `electron-vite dev` and the e2e/manual-test harness do) it
+// resolves to out/main itself, not the repo root, which pointed this at a non-existent
+// out/main/drizzle folder.
+const mainDir = path.dirname(fileURLToPath(import.meta.url))
+
+export const getMigrationsPath = () =>
+  app.isPackaged
+    ? path.join(process.resourcesPath, 'drizzle')
+    : path.join(mainDir, '..', '..', 'drizzle')

--- a/src/renderer/src/components/AsyncButton.tsx
+++ b/src/renderer/src/components/AsyncButton.tsx
@@ -1,0 +1,55 @@
+import { Button, type ButtonProps } from '@mantine/core'
+import { useCallback, useRef, useState, type FC } from 'react'
+
+export type AsyncButtonProps = Omit<ButtonProps, 'loading'> & {
+  onClick: () => Promise<unknown>
+  /** Mirrors the internal pending state up, for callers that also need to disable sibling
+   *  controls (e.g. a Cancel button or other inputs) while the async work is in flight. */
+  onPendingChange?: (isPending: boolean) => void
+}
+
+/** Wraps Mantine's Button to guard against double-submit: ignores clicks while a previous
+ *  onClick's promise is still pending, and shows Mantine's built-in loading state meanwhile. */
+export const AsyncButton: FC<AsyncButtonProps> = ({
+  onClick,
+  onPendingChange,
+  disabled,
+  ...buttonProps
+}) => {
+  const [isPending, setIsPending] = useState(false)
+  // The re-entrancy gate itself must be a ref, not the isPending state: several clicks
+  // dispatched within the same synchronous tick (e.g. a fast native double-click) get
+  // batched by React into a single re-render, so a second click's handler can still read
+  // the pre-update `isPending` value from state. A ref is read/written synchronously and
+  // isn't subject to that batching, so it reliably blocks same-tick re-entrant clicks.
+  const isPendingRef = useRef(false)
+
+  const handleClick = useCallback(() => {
+    if (isPendingRef.current) return
+    isPendingRef.current = true
+    setIsPending(true)
+    onPendingChange?.(true)
+    // Swallow rejections on this specific derived chain only - other consumers of the same
+    // promise (e.g. a caller's own try/catch, or react-hot-toast's toast.promise) still see
+    // the rejection on their own branch; this just keeps our own bookkeeping from producing
+    // a spurious unhandled-rejection warning when nothing else happens to be watching it.
+    // Wrapped in Promise.resolve() since onClick isn't guaranteed to return a real Promise
+    // (e.g. a test double that forgets to mock a resolved value).
+    Promise.resolve(onClick())
+      .catch(() => {})
+      .finally(() => {
+        isPendingRef.current = false
+        setIsPending(false)
+        onPendingChange?.(false)
+      })
+  }, [onClick, onPendingChange])
+
+  return (
+    <Button
+      {...buttonProps}
+      disabled={disabled || isPending}
+      loading={isPending}
+      onClick={handleClick}
+    />
+  )
+}

--- a/src/renderer/src/components/ConfirmDeleteModal.tsx
+++ b/src/renderer/src/components/ConfirmDeleteModal.tsx
@@ -1,13 +1,14 @@
 import { Button, Group, Modal, Text } from '@mantine/core'
 import type { FC } from 'react'
 import { ZIndex } from '@renderer/zIndex'
+import { AsyncButton } from './AsyncButton'
 
 export type ConfirmDeleteModalProps = {
   opened: boolean
   entityName: string
   itemName?: string
   onCancel: () => void
-  onConfirm: () => void
+  onConfirm: () => Promise<unknown>
 }
 
 export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
@@ -38,15 +39,16 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
         <Button variant="outline" onClick={onCancel}>
           Cancel
         </Button>
-        <Button
+        <AsyncButton
           color="red"
           onClick={() => {
-            onConfirm()
+            const result = onConfirm()
             onCancel()
+            return result
           }}
         >
           Delete
-        </Button>
+        </AsyncButton>
       </Group>
     </Modal>
   )

--- a/src/renderer/src/components/RenameModal.tsx
+++ b/src/renderer/src/components/RenameModal.tsx
@@ -1,13 +1,14 @@
 import { Button, Group, Modal, TextInput } from '@mantine/core'
 import { useState, type FC } from 'react'
 import { ZIndex } from '@renderer/zIndex'
+import { AsyncButton } from './AsyncButton'
 
 export type RenameModalProps = {
   opened: boolean
   entityName: string
   initialName: string
   onCancel: () => void
-  onConfirm: (name: string) => void
+  onConfirm: (name: string) => Promise<unknown>
 }
 
 /** Controlled by mounting with a `key` tied to the item being renamed (e.g. `key={item?.id}`)
@@ -45,9 +46,9 @@ export const RenameModal: FC<RenameModalProps> = ({
         <Button variant="outline" onClick={onCancel}>
           Cancel
         </Button>
-        <Button disabled={name.trim().length === 0} onClick={() => onConfirm(name.trim())}>
+        <AsyncButton disabled={name.trim().length === 0} onClick={() => onConfirm(name.trim())}>
           Save
-        </Button>
+        </AsyncButton>
       </Group>
     </Modal>
   )

--- a/src/renderer/src/components/__tests__/AsyncButton.test.tsx
+++ b/src/renderer/src/components/__tests__/AsyncButton.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { AsyncButton } from '../AsyncButton'
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('AsyncButton', () => {
+  it('renders its label and calls onClick when clicked', () => {
+    const onClick = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(<AsyncButton onClick={onClick}>Save</AsyncButton>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a loading, disabled state while the promise is pending, then re-enables on success', async () => {
+    const { promise, resolve } = deferred<void>()
+    const onClick = vi.fn(() => promise)
+    renderWithProviders(<AsyncButton onClick={onClick}>Save</AsyncButton>)
+
+    const button = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(button)
+
+    expect(button).toBeDisabled()
+
+    resolve()
+    await waitFor(() => expect(button).toBeEnabled())
+  })
+
+  it('re-enables after the promise rejects, without swallowing the error for other consumers', async () => {
+    const { promise, reject } = deferred<void>()
+    const onClick = vi.fn(() => promise)
+    renderWithProviders(<AsyncButton onClick={onClick}>Save</AsyncButton>)
+
+    const button = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(button)
+    expect(button).toBeDisabled()
+
+    const assertionOnRejection = expect(promise).rejects.toThrow('boom')
+    reject(new Error('boom'))
+
+    await assertionOnRejection
+    await waitFor(() => expect(button).toBeEnabled())
+  })
+
+  it('ignores clicks while a previous call is still pending', () => {
+    const { promise, resolve } = deferred<void>()
+    const onClick = vi.fn(() => promise)
+    renderWithProviders(<AsyncButton onClick={onClick}>Save</AsyncButton>)
+
+    const button = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(button)
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    resolve()
+  })
+
+  it('ignores a second click dispatched in the same batch as the first (native rapid double-click)', () => {
+    // Regression test: fireEvent.click() individually flushes React state between calls,
+    // which masked a real bug where two clicks landing in the SAME React batch (as a fast
+    // native double-click does) both read the pre-update pending state and both fired
+    // onClick. Dispatching both native events inside one act() call reproduces that.
+    const { promise, resolve } = deferred<void>()
+    const onClick = vi.fn(() => promise)
+    renderWithProviders(<AsyncButton onClick={onClick}>Save</AsyncButton>)
+
+    const button = screen.getByRole('button', { name: 'Save' })
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    resolve()
+  })
+
+  it('calls onPendingChange with true then false around the click', async () => {
+    const { promise, resolve } = deferred<void>()
+    const onClick = vi.fn(() => promise)
+    const onPendingChange = vi.fn()
+    renderWithProviders(
+      <AsyncButton onClick={onClick} onPendingChange={onPendingChange}>
+        Save
+      </AsyncButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onPendingChange).toHaveBeenNthCalledWith(1, true)
+
+    resolve()
+    await waitFor(() => expect(onPendingChange).toHaveBeenNthCalledWith(2, false))
+  })
+
+  it('respects an explicit disabled prop even when not pending', () => {
+    const onClick = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(
+      <AsyncButton onClick={onClick} disabled>
+        Save
+      </AsyncButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/__tests__/ConfirmDeleteModal.test.tsx
+++ b/src/renderer/src/components/__tests__/ConfirmDeleteModal.test.tsx
@@ -65,7 +65,10 @@ describe('ConfirmDeleteModal', () => {
   it('calls onConfirm then onCancel when Delete is clicked', () => {
     const calls: string[] = []
     const onCancel = vi.fn(() => calls.push('cancel'))
-    const onConfirm = vi.fn(() => calls.push('confirm'))
+    const onConfirm = vi.fn(() => {
+      calls.push('confirm')
+      return Promise.resolve()
+    })
     renderWithProviders(
       <ConfirmDeleteModal
         opened
@@ -79,5 +82,31 @@ describe('ConfirmDeleteModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
     expect(calls).toEqual(['confirm', 'cancel'])
+  })
+
+  it('ignores a second click while the first onConfirm is still pending', () => {
+    let resolveConfirm: (() => void) | undefined
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    renderWithProviders(
+      <ConfirmDeleteModal
+        opened
+        entityName="project"
+        itemName="Street Signs"
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' })
+    fireEvent.click(deleteButton)
+    fireEvent.click(deleteButton)
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    resolveConfirm?.()
   })
 })

--- a/src/renderer/src/components/__tests__/RenameModal.test.tsx
+++ b/src/renderer/src/components/__tests__/RenameModal.test.tsx
@@ -19,7 +19,7 @@ describe('RenameModal', () => {
   })
 
   it('calls onConfirm with the trimmed new name when Save is clicked', () => {
-    const onConfirm = vi.fn()
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
     renderWithProviders(
       <RenameModal
         opened
@@ -37,7 +37,7 @@ describe('RenameModal', () => {
   })
 
   it('submits on Enter', () => {
-    const onConfirm = vi.fn()
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
     renderWithProviders(
       <RenameModal
         opened
@@ -85,5 +85,31 @@ describe('RenameModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a second click while the first onConfirm is still pending', () => {
+    let resolveConfirm: (() => void) | undefined
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    renderWithProviders(
+      <RenameModal
+        opened
+        entityName="task"
+        initialName="Batch 1"
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(saveButton)
+    fireEvent.click(saveButton)
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    resolveConfirm?.()
   })
 })

--- a/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
@@ -3,6 +3,7 @@ import { Button, Group, Progress, SegmentedControlItem, Stack, Text } from '@man
 import { FaFileExport } from 'react-icons/fa'
 import toast from 'react-hot-toast'
 import JSZip from 'jszip'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { ISample } from '@shared/types'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
@@ -35,7 +36,6 @@ export const CocoExporterComponent = ({
   const [shape, setShape] = useState<CocoShapeMode>(CocoShapeMode.Native)
 
   const runExport = async () => {
-    setIsExporting(true)
     try {
       const zip = new JSZip()
       const labelIdToCategoryId = new Map(project.labels.map((label, i) => [label.id, i + 1]))
@@ -101,8 +101,6 @@ export const CocoExporterComponent = ({
     } catch (error) {
       console.error(error)
       toast.error('Failed to export samples')
-    } finally {
-      setIsExporting(false)
     }
   }
 
@@ -126,9 +124,13 @@ export const CocoExporterComponent = ({
         <Button variant="subtle" onClick={onCancel} disabled={isExporting}>
           Cancel
         </Button>
-        <Button leftSection={<FaFileExport />} loading={isExporting} onClick={runExport}>
+        <AsyncButton
+          leftSection={<FaFileExport />}
+          onClick={runExport}
+          onPendingChange={setIsExporting}
+        >
           Export
-        </Button>
+        </AsyncButton>
       </Group>
     </Stack>
   )

--- a/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
@@ -3,6 +3,7 @@ import { Button, Group, Progress, Stack, Text } from '@mantine/core'
 import { FaFileExport } from 'react-icons/fa'
 import toast from 'react-hot-toast'
 import JSZip from 'jszip'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
 import { buildCvLabelManifest, cvLabelImagePath, type CvLabelManifestSample } from './buildCvLabel'
@@ -18,7 +19,6 @@ export const CvLabelJsonExporterComponent = ({
   const [progress, setProgress] = useState(0)
 
   const runExport = async () => {
-    setIsExporting(true)
     try {
       const zip = new JSZip()
       const samplesByTask = await Promise.all(tasks.map((task) => getSamplesForTask(task.id)))
@@ -58,8 +58,6 @@ export const CvLabelJsonExporterComponent = ({
     } catch (error) {
       console.error(error)
       toast.error('Failed to export samples')
-    } finally {
-      setIsExporting(false)
     }
   }
 
@@ -75,9 +73,13 @@ export const CvLabelJsonExporterComponent = ({
         <Button variant="subtle" onClick={onCancel} disabled={isExporting}>
           Cancel
         </Button>
-        <Button leftSection={<FaFileExport />} loading={isExporting} onClick={runExport}>
+        <AsyncButton
+          leftSection={<FaFileExport />}
+          onClick={runExport}
+          onPendingChange={setIsExporting}
+        >
           Export
-        </Button>
+        </AsyncButton>
       </Group>
     </Stack>
   )

--- a/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
@@ -3,6 +3,7 @@ import { Button, Group, Progress, SegmentedControlItem, Stack, Text } from '@man
 import { FaFileExport } from 'react-icons/fa'
 import toast from 'react-hot-toast'
 import JSZip from 'jszip'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
 import { ExportShape } from '../annotationShape'
@@ -26,7 +27,6 @@ export const YoloExporterComponent = ({
   const [shape, setShape] = useState<ExportShape>(ExportShape.Box)
 
   const runExport = async () => {
-    setIsExporting(true)
     try {
       const zip = new JSZip()
       const labelIdToClassId = new Map(project.labels.map((label, id) => [label.id, id]))
@@ -71,8 +71,6 @@ export const YoloExporterComponent = ({
     } catch (error) {
       console.error(error)
       toast.error('Failed to export samples')
-    } finally {
-      setIsExporting(false)
     }
   }
 
@@ -95,9 +93,13 @@ export const YoloExporterComponent = ({
         <Button variant="subtle" onClick={onCancel} disabled={isExporting}>
           Cancel
         </Button>
-        <Button leftSection={<FaFileExport />} loading={isExporting} onClick={runExport}>
+        <AsyncButton
+          leftSection={<FaFileExport />}
+          onClick={runExport}
+          onPendingChange={setIsExporting}
+        >
           Export
-        </Button>
+        </AsyncButton>
       </Group>
     </Stack>
   )

--- a/src/renderer/src/routes/label/AnnotationsDrawer.tsx
+++ b/src/renderer/src/routes/label/AnnotationsDrawer.tsx
@@ -1,0 +1,106 @@
+import { ActionIcon, Badge, Drawer, Group, Stack, Text } from '@mantine/core'
+import { LabelerStore } from '@renderer/hooks/useLabeler'
+import { LabelerMode } from '@renderer/types'
+import { AnnotationType } from '@shared/types'
+import type { FC } from 'react'
+import { MdDeleteOutline } from 'react-icons/md'
+import { BsBoundingBoxCircles } from 'react-icons/bs'
+import { PiPolygonLight } from 'react-icons/pi'
+import tinycolor from 'tinycolor2'
+import { StoreApi, UseBoundStore } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+export type AnnotationsDrawerProps = {
+  store: UseBoundStore<StoreApi<LabelerStore>>
+  opened: boolean
+  onClose: () => void
+}
+
+const AnnotationTypeIcon = ({ type }: { type: AnnotationType }) =>
+  type === AnnotationType.Box ? <BsBoundingBoxCircles size={14} /> : <PiPolygonLight size={14} />
+
+export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, onClose }) => {
+  const annotations = store(
+    useShallow((s) =>
+      Object.values(s.sample?.resolve().annotations.resolve() ?? {}).map((a) => a.resolve())
+    )
+  )
+  const selectedAnnotationId = store((s) => s.selectedAnnotation?.resolve().id ?? null)
+  const labelsMap = store((s) => s.labelsMap)
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      withOverlay={false}
+      trapFocus={false}
+      closeOnClickOutside={false}
+      title="Annotations"
+    >
+      <Stack gap="xs">
+        {annotations.length === 0 && (
+          <Text c="dimmed" size="sm">
+            No annotations yet
+          </Text>
+        )}
+        {annotations.map((annotation) => {
+          const label = labelsMap[annotation.labelId]
+          const selected = annotation.id === selectedAnnotationId
+
+          return (
+            <Group
+              key={annotation.id}
+              justify="space-between"
+              wrap="nowrap"
+              p="xs"
+              style={{
+                cursor: 'pointer',
+                borderRadius: 'var(--mantine-radius-sm)',
+                backgroundColor: selected
+                  ? 'light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5))'
+                  : undefined
+              }}
+              onClick={() => {
+                const state = store.getState()
+                if (state.mode !== LabelerMode.Select) {
+                  state.setMode(LabelerMode.Select)
+                }
+                state.selectAnnotation(annotation.id)
+              }}
+            >
+              <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                {label && (
+                  <Badge
+                    size="xs"
+                    circle
+                    style={{
+                      backgroundColor: label.color,
+                      color: tinycolor(label.color).isLight() ? '#000' : '#fff',
+                      flexShrink: 0
+                    }}
+                  />
+                )}
+                <AnnotationTypeIcon type={annotation.type} />
+                <Text size="sm" truncate>
+                  {label?.name ?? 'Unknown label'}
+                </Text>
+              </Group>
+              <ActionIcon
+                aria-label="Delete annotation"
+                variant="subtle"
+                color="red"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  store.getState().deleteAnnotation(annotation.id)
+                }}
+              >
+                <MdDeleteOutline size={16} />
+              </ActionIcon>
+            </Group>
+          )
+        })}
+      </Stack>
+    </Drawer>
+  )
+}

--- a/src/renderer/src/routes/label/LabelPage.tsx
+++ b/src/renderer/src/routes/label/LabelPage.tsx
@@ -16,10 +16,12 @@ import { useCallback, useLayoutEffect, useState } from 'react'
 import { IoMdArrowBack } from 'react-icons/io'
 import { PiHandPalmBold, PiPolygonLight } from 'react-icons/pi'
 import { BsBoundingBoxCircles } from 'react-icons/bs'
+import { MdFormatListBulleted } from 'react-icons/md'
 import { ILabel, IProject, ITask, OmitV2 } from '@shared/types'
 import { mod } from '@shared/utils'
 import { useAppStore } from '@renderer/hooks/useAppStore'
 import { back } from '@renderer/router/appRouter'
+import { AnnotationsDrawer } from './AnnotationsDrawer'
 
 const Container = styled.div`
   position: relative;
@@ -222,6 +224,7 @@ export type LabelPageProps = {
 
 export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
   const [index, setIndex] = useState(initial)
+  const [isAnnotationsDrawerOpen, setIsAnnotationsDrawerOpen] = useState(false)
   const { store } = useLabeler(project.labels)
   const mode = store((s) => s.mode)
   const selecteLabelId = store((s) => s.selectedLabelId)
@@ -274,6 +277,19 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
       >
         Back
       </Button>
+      <Button
+        leftSection={<MdFormatListBulleted />}
+        variant="outline"
+        style={{ position: 'absolute', top: 20, right: 20 }}
+        onClick={() => setIsAnnotationsDrawerOpen(true)}
+      >
+        Annotations
+      </Button>
+      <AnnotationsDrawer
+        store={store}
+        opened={isAnnotationsDrawerOpen}
+        onClose={() => setIsAnnotationsDrawerOpen(false)}
+      />
       <Flex
         style={{ position: 'absolute', bottom: 30, left: '50%', transform: 'translate(-50%,0)' }}
         gap={'md'}

--- a/src/renderer/src/routes/label/__tests__/AnnotationsDrawer.test.tsx
+++ b/src/renderer/src/routes/label/__tests__/AnnotationsDrawer.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { LabelerStore } from '@renderer/hooks/useLabeler'
+import { LabelerMode } from '@renderer/types'
+import { AnnotationType, IAnnotation, ILabel } from '@shared/types'
+import { create } from 'zustand'
+import type { StoreApi, UseBoundStore } from 'zustand'
+import { AnnotationsDrawer } from '../AnnotationsDrawer'
+
+const labels: ILabel[] = [
+  { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+  { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+]
+
+const boxAnnotation: IAnnotation = {
+  id: 'a1',
+  type: AnnotationType.Box,
+  labelId: 'l1',
+  points: [
+    { id: 'p0', x: 0, y: 0 },
+    { id: 'p1', x: 10, y: 10 }
+  ]
+}
+
+const maskAnnotation: IAnnotation = {
+  id: 'a2',
+  type: AnnotationType.Mask,
+  labelId: 'l2',
+  points: [
+    { id: 'p2', x: 0, y: 0 },
+    { id: 'p3', x: 10, y: 0 },
+    { id: 'p4', x: 5, y: 10 }
+  ]
+}
+
+const setMode = vi.fn()
+const selectAnnotation = vi.fn()
+const deleteAnnotation = vi.fn()
+
+const makeStore = (
+  annotations: IAnnotation[],
+  mode: LabelerMode = LabelerMode.Select,
+  selectedAnnotationId: string | null = null
+) =>
+  create(() => ({
+    mode,
+    sample: {
+      resolve: () => ({
+        annotations: {
+          resolve: () => Object.fromEntries(annotations.map((a) => [a.id, { resolve: () => a }]))
+        }
+      })
+    },
+    selectedAnnotation:
+      selectedAnnotationId === null
+        ? null
+        : { resolve: () => annotations.find((a) => a.id === selectedAnnotationId) },
+    labelsMap: Object.fromEntries(labels.map((l) => [l.id, l])),
+    setMode,
+    selectAnnotation,
+    deleteAnnotation
+  })) as unknown as UseBoundStore<StoreApi<LabelerStore>>
+
+beforeEach(() => {
+  setMode.mockClear()
+  selectAnnotation.mockClear()
+  deleteAnnotation.mockClear()
+})
+
+describe('AnnotationsDrawer', () => {
+  it('shows an empty state when the sample has no annotations', () => {
+    renderWithProviders(<AnnotationsDrawer store={makeStore([])} opened onClose={vi.fn()} />)
+
+    expect(screen.getByText('No annotations yet')).toBeInTheDocument()
+  })
+
+  it('lists each annotation with its label name', () => {
+    renderWithProviders(
+      <AnnotationsDrawer
+        store={makeStore([boxAnnotation, maskAnnotation])}
+        opened
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Stop Sign')).toBeInTheDocument()
+    expect(screen.getByText('Yield Sign')).toBeInTheDocument()
+  })
+
+  it('selects an annotation when its row is clicked, without changing mode if already in Select', () => {
+    renderWithProviders(
+      <AnnotationsDrawer
+        store={makeStore([boxAnnotation], LabelerMode.Select)}
+        opened
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Stop Sign'))
+
+    expect(selectAnnotation).toHaveBeenCalledWith('a1')
+    expect(setMode).not.toHaveBeenCalled()
+  })
+
+  it('switches to Select mode before selecting when in a Create mode', () => {
+    renderWithProviders(
+      <AnnotationsDrawer
+        store={makeStore([boxAnnotation], LabelerMode.CreateBox)}
+        opened
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Stop Sign'))
+
+    expect(setMode).toHaveBeenCalledWith(LabelerMode.Select)
+    expect(selectAnnotation).toHaveBeenCalledWith('a1')
+  })
+
+  it('deletes an annotation via its delete icon, without selecting it', () => {
+    renderWithProviders(
+      <AnnotationsDrawer store={makeStore([boxAnnotation])} opened onClose={vi.fn()} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete annotation' }))
+
+    expect(deleteAnnotation).toHaveBeenCalledWith('a1')
+    expect(selectAnnotation).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
+++ b/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
 import { IProject, ITask } from '@shared/types'
 import { LabelerMode, OptimisticSample } from '@renderer/types'
@@ -8,6 +8,8 @@ import { create } from 'zustand'
 const setSample = vi.fn()
 const setMode = vi.fn()
 const setLabelId = vi.fn()
+const selectAnnotation = vi.fn()
+const deleteAnnotation = vi.fn()
 
 vi.mock('@renderer/components/Labeler', () => ({
   Labeler: () => <div data-testid="labeler-stub" />
@@ -19,11 +21,19 @@ vi.mock('@renderer/hooks/useLabeler', () => ({
       mode: LabelerMode.Select,
       selectedLabelId: labels[0]?.id ?? '',
       sample: {
-        resolve: () => ({ id: 'sample-1', completedAt: null })
+        resolve: () => ({
+          id: 'sample-1',
+          completedAt: null,
+          annotations: { resolve: () => ({}) }
+        })
       },
+      selectedAnnotation: null,
+      labelsMap: {},
       setSample,
       setMode,
-      setLabelId
+      setLabelId,
+      selectAnnotation,
+      deleteAnnotation
     }))
   })
 }))
@@ -99,5 +109,15 @@ describe('LabelPage', () => {
 
     expect(screen.getByText('In Progress')).toBeInTheDocument()
     expect(screen.getByText('Completed')).toBeInTheDocument()
+  })
+
+  it('opens the annotations drawer when the toggle button is clicked', async () => {
+    renderLabelPage()
+
+    expect(screen.queryByText('No annotations yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Annotations' }))
+
+    expect(await screen.findByText('No annotations yet')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/routes/projects/CreateProjectButton.tsx
+++ b/src/renderer/src/routes/projects/CreateProjectButton.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@linaria/react'
 import { Modal, Stack, TextInput, Flex, Button, ScrollArea } from '@mantine/core'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import { ColorPicker } from '@renderer/components/ColorPicker'
 import { useArray } from '@renderer/hooks/useArray'
 import { randomHexColor } from '@shared/color'
@@ -132,18 +133,19 @@ export const CreateProjectButton: FC<CreateProjectButtonProps> = ({ create }) =>
             </ScrollArea>
           </Flex>
 
-          <Button
+          <AsyncButton
             fullWidth
             onClick={() => {
-              create(projectName, labels.resolve())
+              const result = create(projectName, labels.resolve())
               setIsModalOpen(false)
+              return result
             }}
             disabled={
               projectName.trim().length === 0 || labels.some((c) => c.name.trim().length === 0)
             }
           >
             Create
-          </Button>
+          </AsyncButton>
         </Stack>
       </Modal>
       <Button

--- a/src/renderer/src/routes/projects/EditProjectModal.tsx
+++ b/src/renderer/src/routes/projects/EditProjectModal.tsx
@@ -3,12 +3,13 @@ import type { IProject } from '@shared/types'
 import { useState, type FC } from 'react'
 import tinycolor from 'tinycolor2'
 import { ZIndex } from '@renderer/zIndex'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 
 export type EditProjectModalProps = {
   opened: boolean
   project: IProject | null
   onCancel: () => void
-  onConfirm: (name: string, labels: { id: string; name: string }[]) => void
+  onConfirm: (name: string, labels: { id: string; name: string }[]) => Promise<unknown>
 }
 
 /** Only renames the project and its existing labels - adding/removing labels isn't
@@ -30,8 +31,8 @@ export const EditProjectModal: FC<EditProjectModalProps> = ({
     name.trim().length > 0 && labels.every((l) => (labelNames[l.id] ?? '').trim().length > 0)
 
   const confirm = () => {
-    if (!canSave) return
-    onConfirm(
+    if (!canSave) return Promise.resolve()
+    return onConfirm(
       name.trim(),
       labels.map((l) => ({ id: l.id, name: (labelNames[l.id] ?? l.name).trim() }))
     )
@@ -79,9 +80,9 @@ export const EditProjectModal: FC<EditProjectModalProps> = ({
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button disabled={!canSave} onClick={confirm}>
+          <AsyncButton disabled={!canSave} onClick={confirm}>
             Save
-          </Button>
+          </AsyncButton>
         </Group>
       </Stack>
     </Modal>

--- a/src/renderer/src/routes/projects/ProjectsPage.tsx
+++ b/src/renderer/src/routes/projects/ProjectsPage.tsx
@@ -107,11 +107,7 @@ export const ProjectsPage = () => {
         entityName="project"
         itemName={pendingDelete?.name}
         onCancel={() => setPendingDelete(null)}
-        onConfirm={() => {
-          if (pendingDelete !== null) {
-            remove(pendingDelete.id)
-          }
-        }}
+        onConfirm={() => (pendingDelete !== null ? remove(pendingDelete.id) : Promise.resolve())}
       />
       <ConfirmDeleteModal
         opened={isBatchDeletePending}
@@ -123,8 +119,9 @@ export const ProjectsPage = () => {
         }
         onCancel={() => setIsBatchDeletePending(false)}
         onConfirm={() => {
-          removeMany(selectedProjects.map((p) => p.id))
+          const result = removeMany(selectedProjects.map((p) => p.id))
           exitSelectMode()
+          return result
         }}
       />
       <EditProjectModal
@@ -133,10 +130,10 @@ export const ProjectsPage = () => {
         project={pendingEdit}
         onCancel={() => setPendingEdit(null)}
         onConfirm={(name, labels) => {
-          if (pendingEdit !== null) {
-            update(pendingEdit.id, name, labels)
-          }
+          const result =
+            pendingEdit !== null ? update(pendingEdit.id, name, labels) : Promise.resolve()
           setPendingEdit(null)
+          return result
         }}
       />
       <BasicListPage

--- a/src/renderer/src/routes/projects/__tests__/CreateProjectButton.test.tsx
+++ b/src/renderer/src/routes/projects/__tests__/CreateProjectButton.test.tsx
@@ -33,7 +33,7 @@ describe('CreateProjectButton', () => {
   })
 
   it('calls create with the project name and labels, then closes the modal', async () => {
-    const create = vi.fn()
+    const create = vi.fn().mockResolvedValue(undefined)
     renderWithProviders(<CreateProjectButton create={create} />)
     fireEvent.click(screen.getByRole('button', { name: 'Create Project' }))
     await screen.findByLabelText('Name')

--- a/src/renderer/src/routes/projects/__tests__/EditProjectModal.test.tsx
+++ b/src/renderer/src/routes/projects/__tests__/EditProjectModal.test.tsx
@@ -33,7 +33,7 @@ describe('EditProjectModal', () => {
   })
 
   it('calls onConfirm with the updated project name and label names', () => {
-    const onConfirm = vi.fn()
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
     renderWithProviders(
       <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={onConfirm} />
     )
@@ -88,5 +88,25 @@ describe('EditProjectModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a second click while the first onConfirm is still pending', () => {
+    let resolveConfirm: (() => void) | undefined
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    renderWithProviders(
+      <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={onConfirm} />
+    )
+
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(saveButton)
+    fireEvent.click(saveButton)
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    resolveConfirm?.()
   })
 })

--- a/src/renderer/src/routes/samples/SamplesPage.tsx
+++ b/src/renderer/src/routes/samples/SamplesPage.tsx
@@ -226,11 +226,9 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
         entityName="sample"
         itemName={pendingDelete?.resolve().name}
         onCancel={() => setPendingDelete(null)}
-        onConfirm={() => {
-          if (pendingDelete !== null) {
-            remove(pendingDelete.resolve().id)
-          }
-        }}
+        onConfirm={() =>
+          pendingDelete !== null ? remove(pendingDelete.resolve().id) : Promise.resolve()
+        }
       />
       <RenameModal
         key={pendingRename?.resolve().id}
@@ -239,14 +237,16 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
         initialName={pendingRename?.resolve().name ?? ''}
         onCancel={() => setPendingRename(null)}
         onConfirm={(name) => {
+          let result: Promise<unknown> = Promise.resolve()
           if (pendingRename !== null) {
             const { commit, rollback } = pendingRename.update({ name })
-            store
+            result = store
               .updateSamples([{ id: pendingRename.resolve().id, name }])
               .then(() => commit())
               .catch(() => rollback())
           }
           setPendingRename(null)
+          return result
         }}
       />
       <ImportSamplesModal

--- a/src/renderer/src/routes/tasks/CreateTaskButton.tsx
+++ b/src/renderer/src/routes/tasks/CreateTaskButton.tsx
@@ -17,6 +17,7 @@ import toast from 'react-hot-toast'
 import { IoMdAdd } from 'react-icons/io'
 import { MdDeleteOutline } from 'react-icons/md'
 import { INewSample, IProject } from '@shared/types'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import { ImportSamplesModal } from '@renderer/components/sampleIO/ImportSamplesModal'
 import { filesToSamples } from '@renderer/components/sampleIO/importers/filesToSamples'
 import { folderNameFromDroppedFiles, groupFilesByTopFolder } from '@renderer/utils'
@@ -179,7 +180,7 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
       toast
         .promise(filesToSamples(files), {
           loading: `Processing ${files.length} file${files.length === 1 ? '' : 's'}`,
-          success: 'Files added',
+          success: 'Files loaded',
           error: (e) => {
             console.error(e)
             return 'Failed to read image files'
@@ -215,6 +216,13 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
       setIsModalOpen(false)
       setImportQueue([])
       setImportQueueIndex(0)
+      // Mantine's Modal keeps its content mounted and interactive during its close
+      // transition, so the Create button (still bound to the just-submitted item) stays
+      // clickable for a moment after this. Clearing samples/taskName here disables it
+      // immediately (empty name), rather than leaving a window to resubmit the same
+      // already-created samples and hit a UNIQUE constraint on their ids.
+      setSamples([])
+      setTaskName('')
     }
   }
 
@@ -362,13 +370,14 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
           />
           <Group grow>
             {importQueue.length > 1 && (
-              <Button variant="outline" onClick={advanceQueue}>
+              <Button variant="outline" onClick={advanceQueue} disabled={isDropProcessing}>
                 Skip
               </Button>
             )}
-            <Button
-              onClick={() => {
-                toast.promise(create(taskName, samples), {
+            <AsyncButton
+              onClick={async () => {
+                const result = create(taskName, samples)
+                await toast.promise(result, {
                   loading: 'Creating task',
                   success: 'Task created',
                   error: (e) => {
@@ -377,11 +386,12 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
                   }
                 })
                 advanceQueue()
+                return result
               }}
-              disabled={taskName.trim().length === 0}
+              disabled={taskName.trim().length === 0 || isDropProcessing}
             >
               Create
-            </Button>
+            </AsyncButton>
           </Group>
         </Stack>
       </Modal>

--- a/src/renderer/src/routes/tasks/TasksPage.tsx
+++ b/src/renderer/src/routes/tasks/TasksPage.tsx
@@ -93,11 +93,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
         entityName="task"
         itemName={pendingDelete?.name}
         onCancel={() => setPendingDelete(null)}
-        onConfirm={() => {
-          if (pendingDelete !== null) {
-            remove(pendingDelete.id)
-          }
-        }}
+        onConfirm={() => (pendingDelete !== null ? remove(pendingDelete.id) : Promise.resolve())}
       />
       <RenameModal
         key={pendingRename?.id}
@@ -106,10 +102,9 @@ export const TasksPage = ({ project }: TasksPageProps) => {
         initialName={pendingRename?.name ?? ''}
         onCancel={() => setPendingRename(null)}
         onConfirm={(name) => {
-          if (pendingRename !== null) {
-            update(pendingRename.id, name)
-          }
+          const result = pendingRename !== null ? update(pendingRename.id, name) : Promise.resolve()
           setPendingRename(null)
+          return result
         }}
       />
       <ConfirmDeleteModal
@@ -120,8 +115,9 @@ export const TasksPage = ({ project }: TasksPageProps) => {
         }
         onCancel={() => setIsBatchDeletePending(false)}
         onConfirm={() => {
-          removeMany(selectedTasks.map((t) => t.id))
+          const result = removeMany(selectedTasks.map((t) => t.id))
           exitSelectMode()
+          return result
         }}
       />
       <ExportSamplesModal

--- a/src/renderer/src/routes/tasks/__tests__/CreateTaskButton.test.tsx
+++ b/src/renderer/src/routes/tasks/__tests__/CreateTaskButton.test.tsx
@@ -112,6 +112,29 @@ describe('CreateTaskButton', () => {
     expect(samples[0].name).toBe('photo-one')
   })
 
+  it('ignores a second rapid click on Create while the first create call is still pending', async () => {
+    let resolveCreate: (() => void) | undefined
+    const create = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve
+        })
+    )
+    renderWithProviders(<CreateTaskButton project={project} create={create} />)
+
+    dropFiles([makeFolderFile('FolderA/img1.jpg', 1024), makeFolderFile('FolderB/img1.jpg', 1024)])
+    await screen.findByText(/You dropped 2 folders/)
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, 2 tasks' }))
+    await screen.findByRole('dialog', { name: 'Create Task (1/2)' })
+
+    const createButton = screen.getByRole('button', { name: 'Create' })
+    fireEvent.click(createButton)
+    fireEvent.click(createButton)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    resolveCreate?.()
+  })
+
   it('prefills the task name from a dropped folder', async () => {
     renderWithProviders(<CreateTaskButton project={project} create={vi.fn()} />)
 
@@ -168,6 +191,35 @@ describe('CreateTaskButton', () => {
     expect(create).toHaveBeenCalledTimes(2)
     expect(create.mock.calls[0][0]).toBe('FolderA')
     expect(create.mock.calls[1][0]).toBe('FolderB')
+  })
+
+  it('disables the Create button immediately after the last queue item, so a click during the modal close transition cannot resubmit it', async () => {
+    const create = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(<CreateTaskButton project={project} create={create} />)
+
+    dropFiles([makeFolderFile('FolderA/img1.jpg', 1024), makeFolderFile('FolderB/img1.jpg', 1024)])
+    await screen.findByText(/You dropped 2 folders/)
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, 2 tasks' }))
+
+    await screen.findByRole('dialog', { name: 'Create Task (1/2)' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await screen.findByRole('dialog', { name: 'Create Task (2/2)' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    // Wait for the second (last) create() to resolve and advanceQueue() to run, same as the
+    // "steps through" test, but instead of waiting for the dialog to fully unmount, grab the
+    // Create button as soon as it's disabled - Mantine keeps the modal content mounted and
+    // interactive during its close transition, so this window is real and clickable.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Create Task/ })).not.toBeInTheDocument()
+    })
+    expect(create).toHaveBeenCalledTimes(2)
   })
 
   it('skips a folder without creating a task for it, and advances to the next', async () => {


### PR DESCRIPTION
## Summary
- Migrate the SQLite data layer from raw better-sqlite3 prepared statements to Drizzle ORM (schema + drizzle-kit migrations + query builder), fixing a real dev/e2e migrations-path bug found during verification.
- Add a shared `AsyncButton` guarding every create/delete/rename button (and the sample exporters) against double-submit, fixing two real bugs found via direct reproduction: a same-batch-click race in the guard itself, and a stale-data resubmission window during the multi-folder task queue's modal-close transition.
- Add a right-side drawer on the Labeler page listing the current sample's annotations, with click-to-select and click-to-delete.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (291 unit tests)
- [x] `pnpm test:e2e` (38 e2e tests; one intermittent timeout on rerun, passed cleanly in isolation — pre-existing flakiness unrelated to this branch)
- [x] Manually drove the built app via a Playwright script for each change: Drizzle migration path, AsyncButton double-submit guard (including the queue-close race), and the annotations drawer (select highlights on canvas, delete removes from both, canvas stays interactive while open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)