### PR TITLE
Remove flaky e2e job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
   workflow_dispatch:
 
-# Least-privilege default: neither job needs to write anything (no PR comments, no
+# Least-privilege default: the job doesn't need to write anything (no PR comments, no
 # pushes, no releases), so the GITHUB_TOKEN only gets read access to repo contents.
 permissions:
   contents: read
@@ -39,43 +39,3 @@ jobs:
 
       - name: Run unit tests
         run: pnpm exec vitest run
-
-  e2e-tests:
-    name: E2E tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      # Electron has no headless mode; Xvfb gives it a real (virtual) display to
-      # render into instead, so windows behave exactly as they do on a real desktop.
-      - name: Install Xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Run e2e tests
-        run: xvfb-run --auto-servernum pnpm run test:e2e
-
-      - name: Upload Playwright report
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: playwright-report
-          path: |
-            test-results/
-            playwright-report/
-          retention-days: 7


### PR DESCRIPTION
## Summary
- Removes the `e2e-tests` job from `.github/workflows/ci.yml`. It's been intermittently failing on timing/launch issues unrelated to real regressions (most recently on #8), and this repo already has a history of e2e flakiness (see the "raise test budget" / "remove flaky tests" commits on master).
- `unit-tests` stays as the only CI job. `pnpm test:e2e` still exists and runs fine locally on demand.

## Test plan
- N/A (CI config only, no product code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)