### PR TITLE
Tags, auto-label annotators, Labeler undo/redo, and several list-page improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@ out
 .eslintcache
 *.log*
 store
+userData
 .env
 .env.*
 e2e/screenshots
 test-results
 playwright-report
 *.tsbuildinfo
+app

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,7 @@
 # cv-label
 
 A desktop app for labeling image datasets for computer vision. Organize work into
-Projects → Tasks → Samples, and annotate images with bounding boxes or polygon masks
+Projects → Tasks → Samples, and annotate images with bounding boxes or polygons
 in a canvas-based labeler with pan/zoom and per-label colors.
 
 Built with Electron, React, and TypeScript. Data is stored locally in SQLite by

--- a/drizzle-app/0000_special_starfox.sql
+++ b/drizzle-app/0000_special_starfox.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `annotators` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`url` text NOT NULL,
+	`headers` text NOT NULL
+);

--- a/drizzle-app/meta/0000_snapshot.json
+++ b/drizzle-app/meta/0000_snapshot.json
@@ -1,0 +1,56 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e1d0d814-a477-478a-84d3-3549f62caf47",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "annotators": {
+      "name": "annotators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle-app/meta/_journal.json
+++ b/drizzle-app/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1785714153025,
+      "tag": "0000_special_starfox",
+      "breakpoints": true
+    }
+  ]
+}

--- a/drizzle.app.config.ts
+++ b/drizzle.app.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'sqlite',
+  schema: './src/main/appSchema.ts',
+  out: './drizzle-app'
+})

--- a/drizzle/0001_great_silk_fever.sql
+++ b/drizzle/0001_great_silk_fever.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `annotators` ADD `labelMapping` text DEFAULT '{}' NOT NULL;

--- a/drizzle/0002_little_wild_child.sql
+++ b/drizzle/0002_little_wild_child.sql
@@ -1,0 +1,1 @@
+DROP TABLE `annotators`;

--- a/drizzle/0003_previous_rick_jones.sql
+++ b/drizzle/0003_previous_rick_jones.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `tags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`projectId` text NOT NULL,
+	FOREIGN KEY (`projectId`) REFERENCES `projects`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_tags_projectId` ON `tags` (`projectId`);--> statement-breakpoint
+CREATE TABLE `task_tags` (
+	`taskId` text NOT NULL,
+	`tagId` text NOT NULL,
+	PRIMARY KEY(`taskId`, `tagId`),
+	FOREIGN KEY (`taskId`) REFERENCES `tasks`(`id`) ON UPDATE restrict ON DELETE cascade,
+	FOREIGN KEY (`tagId`) REFERENCES `tags`(`id`) ON UPDATE restrict ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_task_tags_tagId` ON `task_tags` (`tagId`);

--- a/drizzle/0004_polite_nico_minoru.sql
+++ b/drizzle/0004_polite_nico_minoru.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `idx_tags_project_name` ON `tags` (`projectId`,`name`);

--- a/drizzle/0005_rename_mask_to_polygon.sql
+++ b/drizzle/0005_rename_mask_to_polygon.sql
@@ -1,0 +1,4 @@
+-- Custom SQL migration file, put your code below! --
+-- Renames the polygon annotation type's stored value from 'mask' to 'polygon', matching
+-- the AnnotationType enum rename in src/shared/types.ts. Box annotations are untouched.
+UPDATE `annotations` SET `type` = 'polygon' WHERE `type` = 'mask';

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,523 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c0417a8a-e416-47b3-ba85-d2d7481a7a3a",
+  "prevId": "dcbcfb8d-82c4-4381-b3da-24d2ca0e4e1d",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "samples",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotators": {
+      "name": "annotators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelMapping": {
+          "name": "labelMapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotators_projectId": {
+          "name": "idx_annotators_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotators_projectId_projects_id_fk": {
+          "name": "annotators_projectId_projects_id_fk",
+          "tableFrom": "annotators",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "tableTo": "annotations",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "images",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,448 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "05397e14-10e1-4e08-bbe0-32de9af0d53f",
+  "prevId": "c0417a8a-e416-47b3-ba85-d2d7481a7a3a",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "samples",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "tableTo": "annotations",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "images",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,568 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "45279d78-7bbd-4699-bb88-bb99252470d9",
+  "prevId": "05397e14-10e1-4e08-bbe0-32de9af0d53f",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "samples",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "tableTo": "annotations",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "images",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_projectId": {
+          "name": "idx_tags_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tags_projectId_projects_id_fk": {
+          "name": "tags_projectId_projects_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_tags": {
+      "name": "task_tags",
+      "columns": {
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_task_tags_tagId": {
+          "name": "idx_task_tags_tagId",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_tags_taskId_tasks_id_fk": {
+          "name": "task_tags_taskId_tasks_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        },
+        "task_tags_tagId_tags_id_fk": {
+          "name": "task_tags_tagId_tags_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_tags_taskId_tagId_pk": {
+          "columns": [
+            "taskId",
+            "tagId"
+          ],
+          "name": "task_tags_taskId_tagId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,576 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6a5a04c1-755c-4ea6-98eb-391fdfcd9de4",
+  "prevId": "45279d78-7bbd-4699-bb88-bb99252470d9",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "samples",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "tableTo": "annotations",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "images",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_projectId": {
+          "name": "idx_tags_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        },
+        "idx_tags_project_name": {
+          "name": "idx_tags_project_name",
+          "columns": [
+            "projectId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_projectId_projects_id_fk": {
+          "name": "tags_projectId_projects_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_tags": {
+      "name": "task_tags",
+      "columns": {
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_task_tags_tagId": {
+          "name": "idx_task_tags_tagId",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_tags_taskId_tasks_id_fk": {
+          "name": "task_tags_taskId_tasks_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        },
+        "task_tags_tagId_tags_id_fk": {
+          "name": "task_tags_tagId_tags_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_tags_taskId_tagId_pk": {
+          "columns": [
+            "taskId",
+            "tagId"
+          ],
+          "name": "task_tags_taskId_tagId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,576 @@
+{
+  "id": "fd9de198-5512-49c7-a8c4-a0c4fafca726",
+  "prevId": "6a5a04c1-755c-4ea6-98eb-391fdfcd9de4",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sampleId": {
+          "name": "sampleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_annotations_sampleId": {
+          "name": "idx_annotations_sampleId",
+          "columns": [
+            "sampleId"
+          ],
+          "isUnique": false
+        },
+        "idx_annotations_labelId": {
+          "name": "idx_annotations_labelId",
+          "columns": [
+            "labelId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_labelId_labels_id_fk": {
+          "name": "annotations_labelId_labels_id_fk",
+          "tableFrom": "annotations",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "tableTo": "labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "annotations_sampleId_samples_id_fk": {
+          "name": "annotations_sampleId_samples_id_fk",
+          "tableFrom": "annotations",
+          "columnsFrom": [
+            "sampleId"
+          ],
+          "tableTo": "samples",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "labels": {
+      "name": "labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_labels_projectId": {
+          "name": "idx_labels_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "labels_projectId_projects_id_fk": {
+          "name": "labels_projectId_projects_id_fk",
+          "tableFrom": "labels",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "points": {
+      "name": "points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotationId": {
+          "name": "annotationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_points_annotationId": {
+          "name": "idx_points_annotationId",
+          "columns": [
+            "annotationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "points_annotationId_annotations_id_fk": {
+          "name": "points_annotationId_annotations_id_fk",
+          "tableFrom": "points",
+          "columnsFrom": [
+            "annotationId"
+          ],
+          "tableTo": "annotations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "samples": {
+      "name": "samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split": {
+          "name": "split",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_samples_taskId": {
+          "name": "idx_samples_taskId",
+          "columns": [
+            "taskId"
+          ],
+          "isUnique": false
+        },
+        "idx_samples_imageId": {
+          "name": "idx_samples_imageId",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "samples_imageId_images_id_fk": {
+          "name": "samples_imageId_images_id_fk",
+          "tableFrom": "samples",
+          "columnsFrom": [
+            "imageId"
+          ],
+          "tableTo": "images",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "samples_taskId_tasks_id_fk": {
+          "name": "samples_taskId_tasks_id_fk",
+          "tableFrom": "samples",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "tableTo": "tasks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_projectId": {
+          "name": "idx_tags_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        },
+        "idx_tags_project_name": {
+          "name": "idx_tags_project_name",
+          "columns": [
+            "projectId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_projectId_projects_id_fk": {
+          "name": "tags_projectId_projects_id_fk",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_tags": {
+      "name": "task_tags",
+      "columns": {
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_task_tags_tagId": {
+          "name": "idx_task_tags_tagId",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_tags_taskId_tasks_id_fk": {
+          "name": "task_tags_taskId_tasks_id_fk",
+          "tableFrom": "task_tags",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "tableTo": "tasks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        },
+        "task_tags_tagId_tags_id_fk": {
+          "name": "task_tags_tagId_tags_id_fk",
+          "tableFrom": "task_tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_tags_taskId_tagId_pk": {
+          "columns": [
+            "taskId",
+            "tagId"
+          ],
+          "name": "task_tags_taskId_tagId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_projectId": {
+          "name": "idx_tasks_projectId",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_projectId_projects_id_fk": {
+          "name": "tasks_projectId_projects_id_fk",
+          "tableFrom": "tasks",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "restrict",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,34 @@
       "when": 1785170896576,
       "tag": "0000_brief_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1785502659947,
+      "tag": "0001_great_silk_fever",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1785714224005,
+      "tag": "0002_little_wild_child",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1785717790383,
+      "tag": "0003_previous_rick_jones",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1785721088642,
+      "tag": "0004_polite_nico_minoru",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785721088642,
       "tag": "0004_polite_nico_minoru",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1786224075117,
+      "tag": "0005_rename_mask_to_polygon",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/labeler.spec.ts
+++ b/e2e/labeler.spec.ts
@@ -24,8 +24,8 @@ test.describe('Labeler', () => {
     await labelPage.setMode('Create Boxes')
     await expect(labelPage.modeRadio('Create Boxes')).toBeChecked()
 
-    await labelPage.setMode('Create Segments')
-    await expect(labelPage.modeRadio('Create Segments')).toBeChecked()
+    await labelPage.setMode('Create Polygon')
+    await expect(labelPage.modeRadio('Create Polygon')).toBeChecked()
 
     await labelPage.setMode('Select')
     await expect(labelPage.modeRadio('Select')).toBeChecked()
@@ -42,11 +42,11 @@ test.describe('Labeler', () => {
   })
 
   test('toggles the sample completed state', async ({ labelPage }) => {
-    await expect(labelPage.completedRadio('In Progress')).toBeChecked()
+    await expect(labelPage.completedButton).toHaveText('Mark Complete')
 
     await labelPage.setCompleted('Completed')
 
-    await expect(labelPage.completedRadio('Completed')).toBeChecked()
+    await expect(labelPage.completedButton).toHaveText('Mark In Progress')
   })
 
   test('navigates back to the samples page', async ({ labelPage, samplesPage }) => {
@@ -66,5 +66,64 @@ test.describe('Labeler', () => {
     // since there's nothing left there to hit-test against.
     await labelPage.rightClickCenter()
     await expect(labelPage.deleteAnnotationMenuItem).not.toBeVisible()
+  })
+
+  test('drags a box edge to resize it', async ({ labelPage }) => {
+    await labelPage.setMode('Create Boxes')
+    await labelPage.drawBoxAroundCenter(60)
+    await labelPage.setMode('Select')
+    await labelPage.clickCenter()
+
+    // A point just outside the original box shouldn't hit-test to it yet.
+    await labelPage.rightClickAt(100, 0)
+    await expect(labelPage.deleteAnnotationMenuItem).not.toBeVisible()
+
+    // Drag the midpoint of the box's right edge outward to resize it.
+    await labelPage.dragCanvas({ dx: 60, dy: 0 }, { dx: 150, dy: 0 })
+
+    // The same point is now inside the resized box.
+    await labelPage.rightClickAt(100, 0)
+    await expect(labelPage.deleteAnnotationMenuItem).toBeVisible()
+  })
+
+  test('drags a resized box edge again, still hit-testable after a move', async ({ labelPage }) => {
+    // Regression coverage for the box's derived corner/edge sentinel hit ids surviving a
+    // points replace (e.g. a move), not just a fresh selection.
+    await labelPage.setMode('Create Boxes')
+    await labelPage.drawBoxAroundCenter(60)
+    await labelPage.setMode('Select')
+    await labelPage.clickCenter()
+
+    // Move the whole box down and to the right.
+    await labelPage.dragCanvas({ dx: 0, dy: 0 }, { dx: 40, dy: 40 })
+
+    // Its right edge, now at its new position, should still be hit-testable.
+    await labelPage.rightClickAt(100, 40)
+    await expect(labelPage.deleteAnnotationMenuItem).toBeVisible()
+  })
+
+  test('duplicates a box annotation', async ({ labelPage }) => {
+    await labelPage.setMode('Create Boxes')
+    await labelPage.drawBoxAroundCenter()
+    await labelPage.setMode('Select')
+
+    await labelPage.duplicateAnnotationAtCenter()
+
+    await labelPage.openAnnotationsDrawer()
+    await expect(labelPage.annotationRow('Box 1')).toBeVisible()
+    await expect(labelPage.annotationRow('Box 2')).toBeVisible()
+  })
+
+  test('converts a box annotation to a polygon and back', async ({ labelPage }) => {
+    await labelPage.setMode('Create Boxes')
+    await labelPage.drawBoxAroundCenter()
+    await labelPage.setMode('Select')
+    await labelPage.openAnnotationsDrawer()
+
+    await labelPage.convertAnnotationTypeAtCenter()
+    await expect(labelPage.annotationRow('Polygon 1')).toBeVisible()
+
+    await labelPage.convertAnnotationTypeAtCenter()
+    await expect(labelPage.annotationRow('Box 1')).toBeVisible()
   })
 })

--- a/e2e/pages/LabelPage.ts
+++ b/e2e/pages/LabelPage.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test'
 
-export type LabelerModeName = 'Select' | 'Create Boxes' | 'Create Segments'
+export type LabelerModeName = 'Select' | 'Create Boxes' | 'Create Polygon'
 export type CompletedStateName = 'In Progress' | 'Completed'
 
 export class LabelPage {
@@ -12,6 +12,25 @@ export class LabelPage {
 
   get backButton() {
     return this.page.getByRole('button', { name: 'Back' })
+  }
+
+  get annotationsButton() {
+    return this.page.getByRole('button', { name: 'Annotations' })
+  }
+
+  get annotationsDrawerContent() {
+    return this.page.getByTestId('annotations-drawer-content')
+  }
+
+  async openAnnotationsDrawer() {
+    await this.annotationsButton.click()
+    await this.annotationsDrawerContent.waitFor()
+  }
+
+  /** A row's visible label, e.g. "Box 1" or "Polygon 2" - matches AnnotationsDrawer's own
+   *  `${type} ${index + 1}` text per annotation within its label group. */
+  annotationRow(text: string) {
+    return this.annotationsDrawerContent.getByText(text, { exact: true })
   }
 
   async back() {
@@ -29,10 +48,6 @@ export class LabelPage {
 
   labelRadio(labelName: string) {
     return this.page.getByRole('radio', { name: labelName })
-  }
-
-  completedRadio(state: CompletedStateName) {
-    return this.page.getByRole('radio', { name: state })
   }
 
   // Mantine's SegmentedControl keeps the native radio visually hidden and pairs it with
@@ -55,17 +70,28 @@ export class LabelPage {
     await this.clickOption(this.labelRadio(labelName))
   }
 
-  // Unlike setMode/selectLabel (a single synchronous zustand action), toggling
-  // "completed" goes through an optimistic update plus an async IPC round trip to
+  /** The single completed/in-progress toggle button - its label always names the *action*
+   *  the click would perform, not the current state (e.g. reads "Mark Complete" while the
+   *  sample is in progress). */
+  get completedButton() {
+    return this.page.getByRole('button', { name: /Mark (Complete|In Progress)/ })
+  }
+
+  private buttonLabelForCurrentState(state: CompletedStateName) {
+    return state === 'In Progress' ? 'Mark Complete' : 'Mark In Progress'
+  }
+
+  // Toggling completed goes through an optimistic update plus an async IPC round trip to
   // the main process before the UI reflects it - on a loaded CI runner that can
   // occasionally outlast even a generous assertion timeout. Retry the click itself
   // rather than trust one attempt to land within a fixed window.
   async setCompleted(state: CompletedStateName, maxAttempts = 3) {
-    const radio = this.completedRadio(state)
+    const targetLabel = this.buttonLabelForCurrentState(state)
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await this.clickOption(radio)
+      if ((await this.completedButton.textContent())?.trim() === targetLabel) return
+      await this.completedButton.click()
       for (let i = 0; i < 20; i++) {
-        if (await radio.isChecked()) return
+        if ((await this.completedButton.textContent())?.trim() === targetLabel) return
         await this.page.waitForTimeout(250)
       }
     }
@@ -100,13 +126,39 @@ export class LabelPage {
   }
 
   async rightClickCenter() {
+    await this.rightClickAt(0, 0)
+  }
+
+  /** Right-clicks a point offset from the canvas center by (dx, dy) canvas pixels -
+   *  e.g. to hit-test a spot on a resized annotation's edge. */
+  async rightClickAt(dx: number, dy: number) {
     const { x, y } = await this.canvasCenter()
-    await this.page.mouse.move(x, y)
-    await this.page.mouse.click(x, y, { button: 'right' })
+    await this.page.mouse.move(x + dx, y + dy)
+    await this.page.mouse.click(x + dx, y + dy, { button: 'right' })
+  }
+
+  /** Drags the mouse between two points offset from the canvas center by (dx, dy)
+   *  canvas pixels - e.g. to drag a selected box annotation's edge/corner handle. */
+  async dragCanvas(from: { dx: number; dy: number }, to: { dx: number; dy: number }, steps = 5) {
+    const { x, y } = await this.canvasCenter()
+    await this.page.mouse.move(x + from.dx, y + from.dy)
+    await this.page.mouse.down()
+    await this.page.mouse.move(x + to.dx, y + to.dy, { steps })
+    await this.page.mouse.up()
   }
 
   get deleteAnnotationMenuItem() {
     return this.page.getByText('Delete')
+  }
+
+  get duplicateAnnotationMenuItem() {
+    return this.page.getByText('Duplicate')
+  }
+
+  /** Matches either direction - its label always names the type the click would convert
+   *  *to*, not the annotation's current type. */
+  get convertAnnotationTypeMenuItem() {
+    return this.page.getByText(/Convert to (Polygon|Box)/)
   }
 
   /** Selects the annotation under the cursor and deletes it via the right-click menu. */
@@ -114,5 +166,20 @@ export class LabelPage {
     await this.clickCenter()
     await this.rightClickCenter()
     await this.deleteAnnotationMenuItem.click()
+  }
+
+  /** Selects the annotation under the cursor and duplicates it via the right-click menu. */
+  async duplicateAnnotationAtCenter() {
+    await this.clickCenter()
+    await this.rightClickCenter()
+    await this.duplicateAnnotationMenuItem.click()
+  }
+
+  /** Selects the annotation under the cursor and flips its Box/Polygon type via the
+   *  right-click menu. */
+  async convertAnnotationTypeAtCenter() {
+    await this.clickCenter()
+    await this.rightClickCenter()
+    await this.convertAnnotationTypeMenuItem.click()
   }
 }

--- a/e2e/pages/ProjectsPage.ts
+++ b/e2e/pages/ProjectsPage.ts
@@ -120,6 +120,20 @@ export class ProjectsPage {
     await this.editDialog.getByRole('button', { name: 'Save' }).click()
   }
 
+  /** Opens the edit dialog for an existing project and adds one or more new labels via
+   *  "Add Label", leaving the project name and existing labels untouched. */
+  async addLabels(name: string, newLabelNames: string[]) {
+    await this.row(name).click({ button: 'right' })
+    await this.page.getByText('Edit').click()
+
+    for (const labelName of newLabelNames) {
+      await this.editDialog.getByRole('button', { name: 'Add Label' }).click()
+      await this.editDialog.getByPlaceholder('Label Name').last().fill(labelName)
+    }
+
+    await this.editDialog.getByRole('button', { name: 'Save' }).click()
+  }
+
   /** Enters select mode (if not already in it) and selects the given projects via
    *  their row checkboxes. */
   async selectProjects(names: string[]) {

--- a/e2e/pages/TasksPage.ts
+++ b/e2e/pages/TasksPage.ts
@@ -51,6 +51,13 @@ export class TasksPage {
     return this.page.getByRole('button', { name: 'Export', exact: true })
   }
 
+  /** Every visible "Export" text on the page - the batch action bar's own button plus,
+   *  outside select mode only, a row's open context-menu entry. Callers assert a count
+   *  rather than presence, since the batch button alone already matches. */
+  get allExportTexts() {
+    return this.page.getByText('Export', { exact: true })
+  }
+
   /** The batch action bar's "Delete" button, visible once at least one task is selected. */
   get deleteSelectedButton() {
     return this.page.getByRole('button', { name: 'Delete', exact: true })
@@ -76,6 +83,22 @@ export class TasksPage {
 
   get renameDialog() {
     return this.page.getByRole('dialog', { name: 'Rename task' })
+  }
+
+  get manageTagsButton() {
+    return this.page.getByRole('button', { name: 'Manage Tags' })
+  }
+
+  get manageTagsDialog() {
+    return this.page.getByRole('dialog', { name: 'Manage Tags' })
+  }
+
+  get editTagsDialog() {
+    return this.page.getByRole('dialog', { name: 'Edit Tags' })
+  }
+
+  get batchTagsButton() {
+    return this.page.getByRole('button', { name: 'Tags', exact: true })
   }
 
   taskCheckbox(name: string) {
@@ -171,6 +194,42 @@ export class TasksPage {
     await this.exportDialog.waitFor({ state: 'hidden' })
   }
 
+  /** Exports a single task via its own context-menu "Export" entry - only offered
+   *  outside select mode. Otherwise the same save-dialog-stubbing caveat as exportTasks
+   *  applies. */
+  async exportTask(name: string) {
+    await this.row(name).click({ button: 'right' })
+    await this.page.getByText('Export', { exact: true }).click()
+    await this.exportDialog.waitFor()
+    await this.exportDialog.getByText('cv-label File').click()
+    await this.confirmExportButton.click()
+    await this.exportDialog.waitFor({ state: 'hidden' })
+  }
+
+  /** Copy Annotations is a routed page (not a modal, for width - see
+   *  CopyAnnotationsPage.tsx), so its own body content lives in the stack-router's usual
+   *  scroll container, distinguishing its in-page "Back" (destination picker, once in the
+   *  run step) from the page's top-bar "Back" (returns to this TasksPage). */
+  get copyAnnotationsContent() {
+    return this.page.getByTestId('basic-list-scroll-container').and(this.page.locator(':visible'))
+  }
+
+  /** Copies annotations from `sourceName`'s task into `destinationName`'s task via the
+   *  source task's own context-menu entry - picks the destination task, accepts the
+   *  default position-based sample mapping as-is, runs, then returns here (Done alone
+   *  doesn't leave the page - it returns to the destination picker for another run, same
+   *  as the auto-label modal's Done - so the top-bar Back is what navigates back). */
+  async copyAnnotations(sourceName: string, destinationName: string) {
+    await this.row(sourceName).click({ button: 'right' })
+    await this.page.getByText('Copy Annotations', { exact: true }).click()
+    await this.copyAnnotationsContent.getByPlaceholder('Select a task').click()
+    await this.page.getByRole('option', { name: destinationName }).click()
+    await this.copyAnnotationsContent.getByRole('button', { name: 'Continue' }).click()
+    await this.copyAnnotationsContent.getByRole('button', { name: 'Run' }).click()
+    await this.copyAnnotationsContent.getByRole('button', { name: 'Done' }).click()
+    await this.backButton.click()
+  }
+
   /** Selects the given tasks and deletes them all via the batch action bar. */
   async deleteSelectedTasks(names: string[]) {
     await this.selectTasks(names)
@@ -204,8 +263,58 @@ export class TasksPage {
 
   async rename(name: string, newName: string) {
     await this.row(name).click({ button: 'right' })
-    await this.page.getByText('Edit').click()
+    // Exact match - the row's context menu also has an "Edit Tags" item, which
+    // getByText('Edit') would otherwise match too (substring).
+    await this.page.getByText('Edit', { exact: true }).click()
     await this.renameDialog.getByLabel('Name').fill(newName)
     await this.renameDialog.getByRole('button', { name: 'Save' }).click()
+  }
+
+  /** Creates a project tag via the "Manage Tags" modal - the only place typing creates a
+   *  tag outright; everywhere else it's picked (or created inline) via the TagPicker
+   *  combobox. Leaves the modal open. */
+  async createTag(name: string) {
+    await this.manageTagsButton.click()
+    await this.manageTagsDialog.getByLabel('New tag').fill(name)
+    await this.manageTagsDialog.getByRole('button', { name: 'Add', exact: true }).click()
+    await this.manageTagsDialog.getByText(name).waitFor()
+  }
+
+  async closeManageTags() {
+    await this.manageTagsDialog.getByRole('button', { name: 'Close' }).click()
+  }
+
+  async openEditTags(taskName: string) {
+    await this.row(taskName).click({ button: 'right' })
+    await this.page.getByText('Edit Tags').click()
+    await this.editTagsDialog.waitFor()
+  }
+
+  /** Picks an existing tag by exact name from a TagPicker combobox inside the currently
+   *  open "Edit Tags" dialog. */
+  async pickExistingTag(comboboxLabel: string, tagName: string) {
+    await this.editTagsDialog.getByLabel(comboboxLabel).click()
+    await this.page.getByRole('option', { name: tagName, exact: true }).click()
+  }
+
+  /** Types a brand new tag name into a TagPicker combobox and clicks its "+ Create"
+   *  option, creating the tag and selecting it in one motion. */
+  async createTagInline(comboboxLabel: string, tagName: string) {
+    await this.editTagsDialog.getByLabel(comboboxLabel).fill(tagName)
+    await this.page.getByRole('option', { name: `+ Create "${tagName}"` }).click()
+  }
+
+  async saveTags() {
+    await this.editTagsDialog.getByRole('button', { name: 'Save' }).click()
+    await this.editTagsDialog.waitFor({ state: 'hidden' })
+  }
+
+  /** The tag badge shown on a task's own row (not the filter/picker dropdowns elsewhere
+   *  on the page) - scoped to the row's container via the shared Paper-styled Row. */
+  tagBadge(taskName: string, tagName: string) {
+    return this.page
+      .locator('.mantine-Paper-root')
+      .filter({ has: this.page.getByText(taskName, { exact: true }) })
+      .getByText(tagName, { exact: true })
   }
 }

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -76,6 +76,20 @@ test.describe('Projects page', () => {
     await expect(window.getByText('Yield Sign', { exact: true })).toBeVisible()
   })
 
+  test('adds a new label to an existing project via the edit dialog', async ({
+    projectsPage,
+    window
+  }) => {
+    await projectsPage.createProject('Street Signs', ['Stop Sign'])
+
+    await projectsPage.addLabels('Street Signs', ['Speed Limit'])
+
+    // The row's own label badges (LabelTags) reflect the newly-added label directly -
+    // the original label is still there too, untouched.
+    await expect(window.getByText('Speed Limit')).toBeVisible()
+    await expect(window.getByText('Stop Sign')).toBeVisible()
+  })
+
   test('checkboxes only appear after entering select mode, and clicking a row selects it instead of navigating', async ({
     projectsPage
   }) => {

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -140,6 +140,76 @@ test.describe('Tasks page', () => {
     }
   })
 
+  test('exports a single task via its context menu, outside select mode', async ({
+    tasksPage,
+    electronApp,
+    appDataDir
+  }) => {
+    const image = await createTestImage('sample-1')
+    const savePath = join(appDataDir, 'export-single.zip')
+    try {
+      await tasksPage.createTask('Batch 1', [image])
+
+      await electronApp.evaluate(({ dialog }, targetPath) => {
+        dialog.showSaveDialog = (async () => ({
+          canceled: false,
+          filePath: targetPath
+        })) as typeof dialog.showSaveDialog
+      }, savePath)
+
+      await tasksPage.exportTask('Batch 1')
+
+      expect(existsSync(savePath)).toBe(true)
+    } finally {
+      cleanupTestImage(image)
+    }
+  })
+
+  test('hides the per-task Export context-menu entry in select mode', async ({ tasksPage }) => {
+    const image = await createTestImage('sample-1')
+    try {
+      await tasksPage.createTask('Batch 1', [image])
+
+      await tasksPage.selectTasks(['Batch 1'])
+      await tasksPage.row('Batch 1').click({ button: 'right' })
+
+      await expect(tasksPage.allExportTexts).toHaveCount(1)
+    } finally {
+      cleanupTestImage(image)
+    }
+  })
+
+  test('copies annotations from one task to another via the context menu', async ({
+    tasksPage,
+    samplesPage,
+    labelPage
+  }) => {
+    const image = await createTestImage('sample-1')
+    try {
+      // Both tasks import the same file, so their one sample each shares the same
+      // dimensions - the copy flow's own dimension-match guard would otherwise skip it.
+      await tasksPage.createTask('English', [image])
+      await tasksPage.createTask('French', [image])
+
+      await tasksPage.open('English')
+      await samplesPage.label('sample-1')
+      await labelPage.setMode('Create Boxes')
+      await labelPage.drawBoxAroundCenter()
+      await labelPage.back()
+      await samplesPage.back()
+
+      await tasksPage.copyAnnotations('English', 'French')
+
+      await tasksPage.open('French')
+      await samplesPage.label('sample-1')
+      await labelPage.openAnnotationsDrawer()
+
+      await expect(labelPage.annotationRow('Box 1')).toBeVisible()
+    } finally {
+      cleanupTestImage(image)
+    }
+  })
+
   test('renames a task via the context menu', async ({ tasksPage }) => {
     const image = await createTestImage('sample-1')
     try {
@@ -168,6 +238,50 @@ test.describe('Tasks page', () => {
 
       await expect(tasksPage.row('Batch 2')).toBeVisible()
       await expect(tasksPage.row('Batch 1')).toBeVisible()
+    } finally {
+      cleanupTestImage(imageA)
+      cleanupTestImage(imageB)
+    }
+  })
+
+  test('creates a tag from Manage Tags, then picks and creates tags via the TagPicker combobox', async ({
+    tasksPage
+  }) => {
+    const image = await createTestImage('sample-1')
+    try {
+      await tasksPage.createTask('Batch 1', [image])
+
+      await tasksPage.createTag('Urgent')
+      await tasksPage.closeManageTags()
+
+      await tasksPage.openEditTags('Batch 1')
+      await tasksPage.pickExistingTag('Tags', 'Urgent')
+      await tasksPage.createTagInline('Tags', 'Needs Review')
+      await tasksPage.saveTags()
+
+      await expect(tasksPage.tagBadge('Batch 1', 'Urgent')).toBeVisible()
+      await expect(tasksPage.tagBadge('Batch 1', 'Needs Review')).toBeVisible()
+    } finally {
+      cleanupTestImage(image)
+    }
+  })
+
+  test('adds a newly-created tag to a batch of selected tasks via the Add combobox', async ({
+    tasksPage
+  }) => {
+    const imageA = await createTestImage('sample-a')
+    const imageB = await createTestImage('sample-b')
+    try {
+      await tasksPage.createTask('Batch 1', [imageA])
+      await tasksPage.createTask('Batch 2', [imageB])
+
+      await tasksPage.selectTasks(['Batch 1', 'Batch 2'])
+      await tasksPage.batchTagsButton.click()
+      await tasksPage.createTagInline('Add', 'Reviewed')
+      await tasksPage.saveTags()
+
+      await expect(tasksPage.tagBadge('Batch 1', 'Reviewed')).toBeVisible()
+      await expect(tasksPage.tagBadge('Batch 2', 'Reviewed')).toBeVisible()
     } finally {
       cleanupTestImage(imageA)
       cleanupTestImage(imageB)

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,8 @@ asarUnpack:
 extraResources:
   - from: drizzle
     to: drizzle
+  - from: drizzle-app
+    to: drizzle-app
 fileAssociations:
   - ext: cvlabel
     name: cv-label File

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "pnpm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3",
     "db:generate": "drizzle-kit generate",
+    "db:generate:app": "drizzle-kit generate --config drizzle.app.config.ts",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:win": "pnpm run build && electron-builder --win",
     "test": "vitest",
@@ -45,6 +46,7 @@
     "mantine-contextmenu": "^8.3.13",
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.5.0",
+    "react-virtuoso": "^4.18.11",
     "sharp": "^0.35.0",
     "tinycolor2": "^1.6.0",
     "uuid": "^13.0.2",
@@ -105,6 +107,10 @@
       {
         "from": "drizzle",
         "to": "drizzle"
+      },
+      {
+        "from": "drizzle-app",
+        "to": "drizzle-app"
       }
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.2.4)
+      react-virtuoso:
+        specifier: ^4.18.11
+        version: 4.18.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sharp:
         specifier: ^0.35.0
         version: 0.35.0
@@ -3886,6 +3889,12 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-virtuoso@4.18.11:
+    resolution: {integrity: sha512-Qeeq9vqa5seCxACvzbQTUeq3s2/Bu+VlwOMF0jfy3E/ZKHLiXWwJpXBhv2rckqYkvm1XRVFLCBMCmqCU8JNEJg==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -8570,6 +8579,11 @@ snapshots:
       use-latest: 1.3.0(@types/react@19.2.13)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
+
+  react-virtuoso@4.18.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 

--- a/src/main/appDatabase.ts
+++ b/src/main/appDatabase.ts
@@ -1,0 +1,100 @@
+// Will be loaded in a worker thread, cant use any electron API's
+import { IAnnotator, IAnnotatorUpdate, INewAnnotator } from '../shared/types'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { asc, eq } from 'drizzle-orm'
+import path from 'path'
+import fs from 'fs/promises'
+import assert from 'assert'
+import * as schema from './appSchema'
+
+console.log('App database loaded into worker', APP_PATH)
+
+assert(APP_PATH !== undefined, 'APP_PATH global was not defined')
+assert(MIGRATIONS_PATH !== undefined, 'MIGRATIONS_PATH global was not defined')
+
+// Sibling to store/database/data.db (see database.ts) - app-level data lives independently
+// of whichever IDataStore is currently active, so it gets its own top-level folder rather
+// than nesting under store/.
+const appPath = path.join(APP_PATH, 'app')
+const databasePath = path.join(appPath, 'database', 'app.db')
+
+await fs.mkdir(path.dirname(databasePath), { recursive: true })
+
+const sqlite = new Database(databasePath, { fileMustExist: false })
+
+sqlite.pragma('journal_mode = WAL')
+
+const db = drizzle(sqlite, { schema })
+
+migrate(db, { migrationsFolder: MIGRATIONS_PATH })
+
+const appDatabase = {
+  getAnnotators: async (): Promise<IAnnotator[]> => {
+    const annotators = await db.select().from(schema.annotators).orderBy(asc(schema.annotators.id))
+
+    return annotators.map<IAnnotator>((a) => ({
+      ...a,
+      headers: JSON.parse(a.headers)
+    }))
+  },
+
+  createAnnotator: async (
+    id: string,
+    name: string,
+    url: string,
+    headers: Record<string, string>
+  ): Promise<IAnnotator> => {
+    const newAnnotator: INewAnnotator = { id, name, url, headers }
+    db.insert(schema.annotators)
+      .values({ ...newAnnotator, headers: JSON.stringify(newAnnotator.headers) })
+      .run()
+    return { ...newAnnotator }
+  },
+
+  updateAnnotators: async (updates: IAnnotatorUpdate[]): Promise<IAnnotator[]> => {
+    return db.transaction((tx) => {
+      return updates.map((update) => {
+        const existing = tx
+          .select()
+          .from(schema.annotators)
+          .where(eq(schema.annotators.id, update.id))
+          .get()
+
+        if (existing === undefined) {
+          throw new Error(`annotator not found: ${update.id}`)
+        }
+
+        const nextName = update.name ?? existing.name
+        const nextUrl = update.url ?? existing.url
+        const nextHeaders =
+          update.headers !== undefined ? JSON.stringify(update.headers) : existing.headers
+
+        tx.update(schema.annotators)
+          .set({ name: nextName, url: nextUrl, headers: nextHeaders })
+          .where(eq(schema.annotators.id, existing.id))
+          .run()
+
+        return {
+          id: existing.id,
+          name: nextName,
+          url: nextUrl,
+          headers: JSON.parse(nextHeaders)
+        } satisfies IAnnotator
+      })
+    })
+  },
+
+  deleteAnnotators: async (annotatorIds: string[]): Promise<boolean[]> => {
+    db.transaction((tx) => {
+      for (const id of annotatorIds) {
+        tx.delete(schema.annotators).where(eq(schema.annotators.id, id)).run()
+      }
+    })
+    return annotatorIds.map(() => true)
+  }
+}
+
+// named exports (bindings)
+export const { getAnnotators, createAnnotator, updateAnnotators, deleteAnnotators } = appDatabase

--- a/src/main/appSchema.ts
+++ b/src/main/appSchema.ts
@@ -1,0 +1,11 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+/** Store-agnostic and project-agnostic - an annotator is just connection info (name/url/
+ *  headers). Its label vocabulary and mapping against a project's labels are never
+ *  persisted - see ExternalAnnotator.ts / useAnnotatorRuntime.ts. */
+export const annotators = sqliteTable('annotators', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  url: text('url').notNull(),
+  headers: text('headers').notNull()
+})

--- a/src/main/appStore.ts
+++ b/src/main/appStore.ts
@@ -1,0 +1,45 @@
+import url from 'node:url'
+import { importWorkerModule } from './worker'
+import { getAppPath, getAppMigrationsPath } from './utils'
+import appDatabaseWorkerPath from './appDatabase?modulePath'
+import { IAnnotator, IAnnotatorUpdate, IAppDataStore, IPCKeys } from '../shared/types'
+import { handleIpc } from './ipc'
+
+/** The always-on, store-agnostic counterpart to LocalStore - annotators live in their own
+ *  database, independent of whichever IDataStore is currently active (see
+ *  storeOrchestrator.ts), so this is instantiated once and never registered with it.
+ *  Lazily spawns its worker on first real use, same as LocalStore.ensureWorker(). */
+export class AppStore implements IAppDataStore {
+  #workerPromise?: Promise<typeof import('./appDatabase') & { terminate(): Promise<number> }>
+
+  private ensureWorker() {
+    this.#workerPromise ??= importWorkerModule<typeof import('./appDatabase')>(
+      url.pathToFileURL(appDatabaseWorkerPath),
+      { APP_PATH: getAppPath(), MIGRATIONS_PATH: getAppMigrationsPath() }
+    )
+    return this.#workerPromise
+  }
+
+  getAnnotators = async (): Promise<IAnnotator[]> => (await this.ensureWorker()).getAnnotators()
+
+  createAnnotator = async (
+    id: string,
+    name: string,
+    annotatorUrl: string,
+    headers: Record<string, string>
+  ): Promise<IAnnotator> =>
+    (await this.ensureWorker()).createAnnotator(id, name, annotatorUrl, headers)
+
+  updateAnnotators = async (updates: IAnnotatorUpdate[]): Promise<IAnnotator[]> =>
+    (await this.ensureWorker()).updateAnnotators(updates)
+
+  deleteAnnotators = async (annotatorIds: string[]): Promise<boolean[]> =>
+    (await this.ensureWorker()).deleteAnnotators(annotatorIds)
+}
+
+const appStore = new AppStore()
+
+handleIpc(IPCKeys.App_GetAnnotators, (...args) => appStore.getAnnotators(...args))
+handleIpc(IPCKeys.App_CreateAnnotator, (...args) => appStore.createAnnotator(...args))
+handleIpc(IPCKeys.App_UpdateAnnotators, (...args) => appStore.updateAnnotators(...args))
+handleIpc(IPCKeys.App_DeleteAnnotators, (...args) => appStore.deleteAnnotators(...args))

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -3,14 +3,13 @@ import {
   AnnotationType,
   ArchiveManifest,
   IAnnotation,
-  IAnnotator,
   IDataStore,
   INewAnnotation,
-  INewAnnotator,
   INewSample,
   IPoint,
   IProject,
   ISample,
+  ITag,
   ITask,
   LOCAL_STORE_ID,
   TrainingSplit
@@ -18,7 +17,7 @@ import {
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, count, eq, inArray } from 'drizzle-orm'
 import path from 'path'
 import fs from 'fs/promises'
 import { createReadStream, createWriteStream } from 'fs'
@@ -32,10 +31,6 @@ import { hashFile } from './utils_no_electron'
 import * as schema from './schema'
 
 console.log('Database loaded into worker', APP_PATH)
-declare global {
-  const APP_PATH: string
-  const MIGRATIONS_PATH: string
-}
 
 assert(APP_PATH !== undefined, 'APP_PATH global was not defined')
 assert(MIGRATIONS_PATH !== undefined, 'MIGRATIONS_PATH global was not defined')
@@ -410,10 +405,19 @@ const localStore: IDataStore = {
         for (const label of update.labels ?? []) {
           // Scoped to projectId as a defensive check - the renderer only ever sends a project's
           // own labels back, but this keeps a bad id from silently renaming a label in another project.
-          tx.update(schema.labels)
-            .set({ name: label.name })
+          const result = tx
+            .update(schema.labels)
+            .set({ name: label.name, color: label.color })
             .where(and(eq(schema.labels.id, label.id), eq(schema.labels.projectId, update.id)))
             .run()
+
+          // A label id the project doesn't have yet isn't a rename - it's a new label
+          // being added (EditProjectModal's "Add Label"), so insert it instead.
+          if (result.changes === 0) {
+            tx.insert(schema.labels)
+              .values({ id: label.id, name: label.name, color: label.color, projectId: update.id })
+              .run()
+          }
         }
 
         const project = tx.query.projects
@@ -442,11 +446,52 @@ const localStore: IDataStore = {
   },
 
   getTasksForProject: async (projectId) => {
-    return db
-      .select({ id: schema.tasks.id, name: schema.tasks.name })
+    // count(samples.id) skips the null produced by the left join for a task with no
+    // samples yet; count(samples.completedAt) counts only the non-null (completed) ones -
+    // both fall out of plain SQL COUNT-of-a-column semantics, no CASE/filter needed.
+    const taskRows = await db
+      .select({
+        id: schema.tasks.id,
+        name: schema.tasks.name,
+        sampleCount: count(schema.samples.id),
+        completedSampleCount: count(schema.samples.completedAt)
+      })
       .from(schema.tasks)
+      .leftJoin(schema.samples, eq(schema.samples.taskId, schema.tasks.id))
       .where(eq(schema.tasks.projectId, projectId))
+      .groupBy(schema.tasks.id)
       .orderBy(asc(schema.tasks.id))
+
+    if (taskRows.length === 0) {
+      return []
+    }
+
+    // A second, separate query rather than joining task_tags into the query above - that
+    // aggregate already GROUPs by task for the sample counts, and a many-to-many tags join
+    // would multiply rows before the GROUP BY and corrupt those counts.
+    const tagRows = await db
+      .select({
+        taskId: schema.taskTags.taskId,
+        id: schema.tags.id,
+        name: schema.tags.name
+      })
+      .from(schema.taskTags)
+      .innerJoin(schema.tags, eq(schema.taskTags.tagId, schema.tags.id))
+      .where(
+        inArray(
+          schema.taskTags.taskId,
+          taskRows.map((t) => t.id)
+        )
+      )
+
+    const tagsByTaskId = new Map<string, ITag[]>()
+    for (const row of tagRows) {
+      const list = tagsByTaskId.get(row.taskId) ?? []
+      list.push({ id: row.id, name: row.name })
+      tagsByTaskId.set(row.taskId, list)
+    }
+
+    return taskRows.map((task) => ({ ...task, tags: tagsByTaskId.get(task.id) ?? [] }))
   },
 
   updateTasks: async (updates) => {
@@ -475,13 +520,21 @@ const localStore: IDataStore = {
   },
 
   createTask: async (projectId, id, name, newSamples = []) => {
-    const task: ITask = { id, name }
+    // Newly created samples never carry a completedAt (INewSample has no such field -
+    // see cvLabelDatasetToSamples etc.), so completedSampleCount is always 0 here -
+    // cheaper than an extra aggregate query for a value we already know. A new task
+    // starts untagged.
+    const task: ITask = {
+      id,
+      name,
+      sampleCount: newSamples.length,
+      completedSampleCount: 0,
+      tags: []
+    }
 
     if (newSamples.length === 0) {
       db.transaction((tx) => {
-        tx.insert(schema.tasks)
-          .values({ ...task, projectId })
-          .run()
+        tx.insert(schema.tasks).values({ id, name, projectId }).run()
       })
       return task
     }
@@ -493,9 +546,7 @@ const localStore: IDataStore = {
     )
 
     const { insertedImagesIndex } = db.transaction((tx) => {
-      tx.insert(schema.tasks)
-        .values({ ...task, projectId })
-        .run()
+      tx.insert(schema.tasks).values({ id, name, projectId }).run()
       return insertSamplesWithImages(tx, task.id, newSamples, images)
     })
 
@@ -511,6 +562,77 @@ const localStore: IDataStore = {
       }
     })
     return taskIds.map(() => true)
+  },
+
+  getTagsForProject: async (projectId) => {
+    return db
+      .select({ id: schema.tags.id, name: schema.tags.name })
+      .from(schema.tags)
+      .where(eq(schema.tags.projectId, projectId))
+      .orderBy(asc(schema.tags.name))
+  },
+
+  createTag: async (projectId, id, name) => {
+    db.insert(schema.tags).values({ id, name, projectId }).run()
+    return { id, name }
+  },
+
+  updateTags: async (updates) => {
+    return db.transaction((tx) => {
+      return updates.map((update) => {
+        if (update.name !== undefined) {
+          tx.update(schema.tags)
+            .set({ name: update.name })
+            .where(eq(schema.tags.id, update.id))
+            .run()
+        }
+
+        const tag = tx
+          .select({ id: schema.tags.id, name: schema.tags.name })
+          .from(schema.tags)
+          .where(eq(schema.tags.id, update.id))
+          .get()
+
+        if (tag === undefined) {
+          throw new Error(`tag not found: ${update.id}`)
+        }
+
+        return tag
+      })
+    })
+  },
+
+  deleteTags: async (tagIds) => {
+    db.transaction((tx) => {
+      for (const id of tagIds) {
+        tx.delete(schema.tags).where(eq(schema.tags.id, id)).run()
+      }
+    })
+    return tagIds.map(() => true)
+  },
+
+  addTagsToTasks: async (taskIds, tagIds) => {
+    if (taskIds.length === 0 || tagIds.length === 0) return
+
+    db.transaction((tx) => {
+      for (const taskId of taskIds) {
+        for (const tagId of tagIds) {
+          tx.insert(schema.taskTags).values({ taskId, tagId }).onConflictDoNothing().run()
+        }
+      }
+    })
+  },
+
+  removeTagsFromTasks: async (taskIds, tagIds) => {
+    if (taskIds.length === 0 || tagIds.length === 0) return
+
+    db.transaction((tx) => {
+      tx.delete(schema.taskTags)
+        .where(
+          and(inArray(schema.taskTags.taskId, taskIds), inArray(schema.taskTags.tagId, tagIds))
+        )
+        .run()
+    })
   },
 
   getSamplesForTask: async (taskId) => {
@@ -704,41 +826,6 @@ const localStore: IDataStore = {
     return annotationsIds.map(() => true)
   },
 
-  getAnnotators: async (projectId) => {
-    const annotators = await db
-      .select({
-        id: schema.annotators.id,
-        name: schema.annotators.name,
-        url: schema.annotators.url,
-        headers: schema.annotators.headers
-      })
-      .from(schema.annotators)
-      .where(eq(schema.annotators.projectId, projectId))
-      .orderBy(asc(schema.annotators.id))
-
-    return annotators.map<IAnnotator>((a) => ({
-      ...a,
-      headers: JSON.parse(a.headers)
-    }))
-  },
-
-  createAnnotator: async (projectId, id, name, url, headers) => {
-    const newAnnotator: INewAnnotator = { id, name, url, headers }
-    db.insert(schema.annotators)
-      .values({ ...newAnnotator, headers: JSON.stringify(newAnnotator.headers), projectId })
-      .run()
-    return { ...newAnnotator }
-  },
-
-  deleteAnnotators: async (annotatorIds) => {
-    db.transaction((tx) => {
-      for (const id of annotatorIds) {
-        tx.delete(schema.annotators).where(eq(schema.annotators.id, id)).run()
-      }
-    })
-    return annotatorIds.map(() => true)
-  },
-
   replacePoints: async (annotationId, points) => {
     return db.transaction((tx) => {
       // Get current points for the annotation
@@ -839,6 +926,12 @@ export const {
   createTask,
   updateTasks,
   deleteTasks,
+  getTagsForProject,
+  createTag,
+  updateTags,
+  deleteTags,
+  addTagsToTasks,
+  removeTagsFromTasks,
   getSamplesForTask,
   getSamples,
   createSamples,
@@ -848,8 +941,5 @@ export const {
   createAnnotations,
   updateAnnotations,
   deleteAnnotations,
-  getAnnotators,
-  createAnnotator,
-  deleteAnnotators,
   replacePoints
 } = localStore

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,11 +2,25 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+import { getAppPath } from './utils'
 
-// e2e runs get their own isolated userData dir so their single-instance lock
-// doesn't collide with a real dev/production instance sharing the default one.
-if (process.env.CV_LABEL_APP_PATH) {
-  app.setPath('userData', join(process.env.CV_LABEL_APP_PATH, 'userData'))
+// Ties Electron's own userData dir (session storage, GPU cache, and - most importantly -
+// the lock file requestSingleInstanceLock() below uses) to the same working directory
+// getAppPath() already scopes the sqlite database/images to, but only once packaged or
+// under an explicit override - plain `pnpm dev` keeps Electron's own default userData
+// location rather than dumping Chromium's session/cache/blob-storage files in the repo
+// root just for running from source. Must run before requestSingleInstanceLock() -
+// Electron reads userData to place its lock file at that point.
+//
+// This makes the single-instance lock per-working-directory rather than global: two
+// packaged instances pointed at the same working directory can't run concurrently
+// (they'd corrupt the same sqlite database), but separate copies of the app in different
+// folders - e.g. a portable install run from two locations - are treated as independent
+// instances and can run side by side. e2e runs always set CV_LABEL_APP_PATH to their own
+// isolated temp dir per run, so they get the same per-working-directory isolation too,
+// unaffected by whichever way the packaged/dev branch goes.
+if (app.isPackaged || process.env.CV_LABEL_APP_PATH) {
+  app.setPath('userData', join(getAppPath(), 'userData'))
 }
 
 function createWindow(): void {
@@ -103,6 +117,7 @@ if (!gotSingleInstanceLock) {
 
 // Ipc based modules
 import './store'
+import './appStore'
 import './zip'
 import './system'
 import './scratchProtocol'

--- a/src/main/localStore.ts
+++ b/src/main/localStore.ts
@@ -7,7 +7,6 @@ import {
   ArchiveManifest,
   IAnnotation,
   IAnnotationUpdate,
-  IAnnotator,
   ILabel,
   INewAnnotation,
   INewSample,
@@ -17,6 +16,8 @@ import {
   IProjectUpdate,
   ISample,
   ISampleUpdate,
+  ITag,
+  ITagUpdate,
   ITask,
   ITaskUpdate
 } from '../shared/types'
@@ -75,6 +76,24 @@ export class LocalStore implements IMainDataStore {
   deleteTasks = async (taskIds: string[]): Promise<boolean[]> =>
     (await this.ensureWorker()).deleteTasks(taskIds)
 
+  getTagsForProject = async (projectId: string): Promise<ITag[]> =>
+    (await this.ensureWorker()).getTagsForProject(projectId)
+
+  createTag = async (projectId: string, id: string, name: string): Promise<ITag> =>
+    (await this.ensureWorker()).createTag(projectId, id, name)
+
+  updateTags = async (updates: ITagUpdate[]): Promise<ITag[]> =>
+    (await this.ensureWorker()).updateTags(updates)
+
+  deleteTags = async (tagIds: string[]): Promise<boolean[]> =>
+    (await this.ensureWorker()).deleteTags(tagIds)
+
+  addTagsToTasks = async (taskIds: string[], tagIds: string[]): Promise<void> =>
+    (await this.ensureWorker()).addTagsToTasks(taskIds, tagIds)
+
+  removeTagsFromTasks = async (taskIds: string[], tagIds: string[]): Promise<void> =>
+    (await this.ensureWorker()).removeTagsFromTasks(taskIds, tagIds)
+
   getSamplesForTask = async (taskId: string): Promise<ISample[]> =>
     (await this.ensureWorker()).getSamplesForTask(taskId)
 
@@ -103,21 +122,6 @@ export class LocalStore implements IMainDataStore {
 
   deleteAnnotations = async (annotationsIds: string[]): Promise<boolean[]> =>
     (await this.ensureWorker()).deleteAnnotations(annotationsIds)
-
-  getAnnotators = async (projectId: string): Promise<IAnnotator[]> =>
-    (await this.ensureWorker()).getAnnotators(projectId)
-
-  createAnnotator = async (
-    projectId: string,
-    id: string,
-    name: string,
-    annotatorUrl: string,
-    headers: Record<string, string>
-  ): Promise<IAnnotator> =>
-    (await this.ensureWorker()).createAnnotator(projectId, id, name, annotatorUrl, headers)
-
-  deleteAnnotators = async (annotatorIds: string[]): Promise<boolean[]> =>
-    (await this.ensureWorker()).deleteAnnotators(annotatorIds)
 
   replacePoints = async (annotationId: string, points: IPointReplacement[]): Promise<IPoint[]> =>
     (await this.ensureWorker()).replacePoints(annotationId, points)

--- a/src/main/schema.ts
+++ b/src/main/schema.ts
@@ -1,24 +1,18 @@
 import { relations } from 'drizzle-orm'
-import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex
+} from 'drizzle-orm/sqlite-core'
 
 export const projects = sqliteTable('projects', {
   id: text('id').primaryKey(),
   name: text('name').notNull()
 })
-
-export const annotators = sqliteTable(
-  'annotators',
-  {
-    id: text('id').primaryKey(),
-    name: text('name').notNull(),
-    url: text('url').notNull(),
-    headers: text('headers').notNull(),
-    projectId: text('projectId')
-      .notNull()
-      .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
-  },
-  (table) => [index('idx_annotators_projectId').on(table.projectId)]
-)
 
 export const tasks = sqliteTable(
   'tasks',
@@ -30,6 +24,39 @@ export const tasks = sqliteTable(
       .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
   },
   (table) => [index('idx_tasks_projectId').on(table.projectId)]
+)
+
+export const tags = sqliteTable(
+  'tags',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    projectId: text('projectId')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [
+    index('idx_tags_projectId').on(table.projectId),
+    // A project-global vocabulary, managed from one place (ManageTagsModal) - this is the
+    // DB-level guard against creating a literal duplicate name in the same project.
+    uniqueIndex('idx_tags_project_name').on(table.projectId, table.name)
+  ]
+)
+
+export const taskTags = sqliteTable(
+  'task_tags',
+  {
+    taskId: text('taskId')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade', onUpdate: 'restrict' }),
+    tagId: text('tagId')
+      .notNull()
+      .references(() => tags.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+  },
+  (table) => [
+    primaryKey({ columns: [table.taskId, table.tagId] }),
+    index('idx_task_tags_tagId').on(table.tagId)
+  ]
 )
 
 export const labels = sqliteTable(
@@ -109,16 +136,23 @@ export const points = sqliteTable(
 export const projectsRelations = relations(projects, ({ many }) => ({
   labels: many(labels),
   tasks: many(tasks),
-  annotators: many(annotators)
-}))
-
-export const annotatorsRelations = relations(annotators, ({ one }) => ({
-  project: one(projects, { fields: [annotators.projectId], references: [projects.id] })
+  tags: many(tags)
 }))
 
 export const tasksRelations = relations(tasks, ({ one, many }) => ({
   project: one(projects, { fields: [tasks.projectId], references: [projects.id] }),
-  samples: many(samples)
+  samples: many(samples),
+  taskTags: many(taskTags)
+}))
+
+export const tagsRelations = relations(tags, ({ one, many }) => ({
+  project: one(projects, { fields: [tags.projectId], references: [projects.id] }),
+  taskTags: many(taskTags)
+}))
+
+export const taskTagsRelations = relations(taskTags, ({ one }) => ({
+  task: one(tasks, { fields: [taskTags.taskId], references: [tasks.id] }),
+  tag: one(tags, { fields: [taskTags.tagId], references: [tags.id] })
 }))
 
 export const labelsRelations = relations(labels, ({ one }) => ({

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -70,6 +70,17 @@ handleIpc(IPCKeys.Store_CreateTask, (...args) => orchestrator.current.createTask
 handleIpc(IPCKeys.Store_UpdateTasks, (...args) => orchestrator.current.updateTasks(...args))
 handleIpc(IPCKeys.Store_DeleteTasks, (...args) => orchestrator.current.deleteTasks(...args))
 
+handleIpc(IPCKeys.Store_GetTagsForProject, (...args) =>
+  orchestrator.current.getTagsForProject(...args)
+)
+handleIpc(IPCKeys.Store_CreateTag, (...args) => orchestrator.current.createTag(...args))
+handleIpc(IPCKeys.Store_UpdateTags, (...args) => orchestrator.current.updateTags(...args))
+handleIpc(IPCKeys.Store_DeleteTags, (...args) => orchestrator.current.deleteTags(...args))
+handleIpc(IPCKeys.Store_AddTagsToTasks, (...args) => orchestrator.current.addTagsToTasks(...args))
+handleIpc(IPCKeys.Store_RemoveTagsFromTasks, (...args) =>
+  orchestrator.current.removeTagsFromTasks(...args)
+)
+
 handleIpc(IPCKeys.Store_GetSamplesForTask, (...args) =>
   orchestrator.current.getSamplesForTask(...args)
 )
@@ -89,12 +100,6 @@ handleIpc(IPCKeys.Store_UpdateAnnotations, (...args) =>
 )
 handleIpc(IPCKeys.Store_DeleteAnnotations, (...args) =>
   orchestrator.current.deleteAnnotations(...args)
-)
-
-handleIpc(IPCKeys.Store_GetAnnotators, (...args) => orchestrator.current.getAnnotators(...args))
-handleIpc(IPCKeys.Store_CreateAnnotator, (...args) => orchestrator.current.createAnnotator(...args))
-handleIpc(IPCKeys.Store_DeleteAnnotators, (...args) =>
-  orchestrator.current.deleteAnnotators(...args)
 )
 
 handleIpc(IPCKeys.Store_ReplacePoints, (...args) => orchestrator.current.replacePoints(...args))

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -18,3 +18,8 @@ export const getMigrationsPath = () =>
   app.isPackaged
     ? path.join(process.resourcesPath, 'drizzle')
     : path.join(mainDir, '..', '..', 'drizzle')
+
+export const getAppMigrationsPath = () =>
+  app.isPackaged
+    ? path.join(process.resourcesPath, 'drizzle-app')
+    : path.join(mainDir, '..', '..', 'drizzle-app')

--- a/src/main/worker/globals.d.ts
+++ b/src/main/worker/globals.d.ts
@@ -1,0 +1,10 @@
+// Ambient globals injected via `workerData` by importWorkerModule (see worker/index.ts) -
+// shared by every worker-thread module (database.ts, appDatabase.ts, ...) that reads them,
+// so each doesn't redeclare its own (which TS rejects as a duplicate block-scoped binding
+// once more than one such module is part of the same program).
+export {}
+
+declare global {
+  const APP_PATH: string
+  const MIGRATIONS_PATH: string
+}

--- a/src/main/worker/module_worker.ts
+++ b/src/main/worker/module_worker.ts
@@ -12,8 +12,6 @@ import { errorToString } from '../../shared/utils'
 if (isEntryFile(import.meta.url)) {
   for (const k of Object.keys(workerData)) {
     global[k] = workerData[k]
-
-    console.log('ADDING GLOBAL', k, workerData[k], global[k])
   }
 
   const respond = <T = unknown>(callRef: string, response: T) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,11 +1,20 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
-import { IDataStore, IExportApi, IFileUtils, IStoreManager, ISystem, IZip } from '@shared/types'
+import {
+  IAppDataStore,
+  IDataStore,
+  IExportApi,
+  IFileUtils,
+  IStoreManager,
+  ISystem,
+  IZip
+} from '@shared/types'
 
 declare global {
   interface Window {
     electron: ElectronAPI
     store: IDataStore
     storeManager: IStoreManager
+    appStore: IAppDataStore
     system: ISystem
     zip: IZip
     exportApi: IExportApi

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import {
   IDataStore,
   IStoreManager,
+  IAppDataStore,
   ISystem,
   IPCKeys,
   IZip,
@@ -30,6 +31,13 @@ const storeApi: IDataStore = {
   updateTasks: wrap(IPCKeys.Store_UpdateTasks),
   deleteTasks: wrap(IPCKeys.Store_DeleteTasks),
 
+  getTagsForProject: wrap(IPCKeys.Store_GetTagsForProject),
+  createTag: wrap(IPCKeys.Store_CreateTag),
+  updateTags: wrap(IPCKeys.Store_UpdateTags),
+  deleteTags: wrap(IPCKeys.Store_DeleteTags),
+  addTagsToTasks: wrap(IPCKeys.Store_AddTagsToTasks),
+  removeTagsFromTasks: wrap(IPCKeys.Store_RemoveTagsFromTasks),
+
   getSamplesForTask: wrap(IPCKeys.Store_GetSamplesForTask),
   getSamples: wrap(IPCKeys.Store_GetSamples),
   createSamples: wrap(IPCKeys.Store_CreateSamples),
@@ -41,16 +49,19 @@ const storeApi: IDataStore = {
   updateAnnotations: wrap(IPCKeys.Store_UpdateAnnotations),
   deleteAnnotations: wrap(IPCKeys.Store_DeleteAnnotations),
 
-  getAnnotators: wrap(IPCKeys.Store_GetAnnotators),
-  createAnnotator: wrap(IPCKeys.Store_CreateAnnotator),
-  deleteAnnotators: wrap(IPCKeys.Store_DeleteAnnotators),
-
   replacePoints: wrap(IPCKeys.Store_ReplacePoints)
 }
 
 const storeManagerApi: IStoreManager = {
   listStores: wrap(IPCKeys.Store_List),
   useStore: wrap(IPCKeys.Store_UseStore)
+}
+
+const appStoreApi: IAppDataStore = {
+  getAnnotators: wrap(IPCKeys.App_GetAnnotators),
+  createAnnotator: wrap(IPCKeys.App_CreateAnnotator),
+  updateAnnotators: wrap(IPCKeys.App_UpdateAnnotators),
+  deleteAnnotators: wrap(IPCKeys.App_DeleteAnnotators)
 }
 
 const systemApi: ISystem = {
@@ -93,6 +104,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('store', storeApi)
     contextBridge.exposeInMainWorld('storeManager', storeManagerApi)
+    contextBridge.exposeInMainWorld('appStore', appStoreApi)
     contextBridge.exposeInMainWorld('system', systemApi)
     contextBridge.exposeInMainWorld('zip', zipApi)
     contextBridge.exposeInMainWorld('exportApi', exportApi)
@@ -107,6 +119,8 @@ if (process.contextIsolated) {
   window.store = storeApi
   // @ts-ignore (define in dts)
   window.storeManager = storeManagerApi
+  // @ts-ignore (define in dts)
+  window.appStore = appStoreApi
   // @ts-ignore (define in dts)
   window.system = systemApi
   // @ts-ignore (define in dts)

--- a/src/renderer/src/__tests__/mockDataStore.ts
+++ b/src/renderer/src/__tests__/mockDataStore.ts
@@ -15,6 +15,13 @@ export const createMockDataStore = (): IDataStore => ({
   updateTasks: vi.fn().mockResolvedValue([]),
   deleteTasks: vi.fn().mockResolvedValue([]),
 
+  getTagsForProject: vi.fn().mockResolvedValue([]),
+  createTag: vi.fn(),
+  updateTags: vi.fn().mockResolvedValue([]),
+  deleteTags: vi.fn().mockResolvedValue([]),
+  addTagsToTasks: vi.fn().mockResolvedValue(undefined),
+  removeTagsFromTasks: vi.fn().mockResolvedValue(undefined),
+
   getSamplesForTask: vi.fn().mockResolvedValue([]),
   getSamples: vi.fn().mockResolvedValue([]),
   createSamples: vi.fn().mockResolvedValue([]),
@@ -25,10 +32,6 @@ export const createMockDataStore = (): IDataStore => ({
   createAnnotations: vi.fn().mockResolvedValue([]),
   updateAnnotations: vi.fn().mockResolvedValue([]),
   deleteAnnotations: vi.fn().mockResolvedValue([]),
-
-  getAnnotators: vi.fn().mockResolvedValue([]),
-  createAnnotator: vi.fn(),
-  deleteAnnotators: vi.fn().mockResolvedValue([]),
 
   replacePoints: vi.fn().mockResolvedValue([])
 })

--- a/src/renderer/src/__tests__/setup.ts
+++ b/src/renderer/src/__tests__/setup.ts
@@ -23,9 +23,70 @@ Object.defineProperty(window, 'matchMedia', {
   }))
 })
 
-// jsdom doesn't implement ResizeObserver; Mantine's ScrollArea and the Labeler both use it.
+// jsdom has no real layout engine - every element reports an all-zero rect, which is fine
+// for most components but breaks anything that sizes itself off real DOM geometry (e.g.
+// react-virtuoso's scroll-container measurement, which otherwise computes an empty
+// viewport and renders nothing). Give every element a plausible non-zero size.
+Element.prototype.getBoundingClientRect = vi.fn(function (this: Element) {
+  return {
+    width: 1000,
+    height: 800,
+    top: 0,
+    left: 0,
+    bottom: 800,
+    right: 1000,
+    x: 0,
+    y: 0,
+    toJSON: () => {}
+  }
+})
+
+// scrollHeight/clientHeight/offsetHeight/clientWidth/offsetWidth are separate,
+// hardcoded-to-0 getters in jsdom - they aren't derived from getBoundingClientRect, so
+// the stub above doesn't help them. react-virtuoso reads these directly (in addition to
+// ResizeObserver) for its own scroll/viewport bookkeeping, so without this it measures a
+// zero-height viewport and renders no rows at all.
+for (const prop of ['scrollHeight', 'clientHeight', 'offsetHeight'] as const) {
+  Object.defineProperty(Element.prototype, prop, { configurable: true, value: 800 })
+}
+for (const prop of ['clientWidth', 'offsetWidth'] as const) {
+  Object.defineProperty(Element.prototype, prop, { configurable: true, value: 1000 })
+}
+// jsdom also hardcodes offsetParent to null (real layout would return the nearest
+// positioned/laid-out ancestor) - react-virtuoso's own measurement callback bails out
+// entirely whenever offsetParent is null, on the assumption that means "not laid out
+// yet", so without this it never measures anything and renders zero rows.
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+  configurable: true,
+  get(this: HTMLElement) {
+    return this.parentElement
+  }
+})
+
+// jsdom doesn't implement ResizeObserver; Mantine's ScrollArea and the Labeler both use
+// it, as does react-virtuoso for the scroll container above. A real ResizeObserver fires
+// an initial observation right after observe() is called - this stub does the same (using
+// the geometry stubbed above) so consumers that only size themselves off that first
+// callback (rather than polling) still get a real, non-zero measurement in tests.
 class ResizeObserverStub {
-  observe = vi.fn()
+  #callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback
+  }
+
+  observe = (target: Element) => {
+    const rect = target.getBoundingClientRect()
+    const entry = {
+      target,
+      contentRect: rect,
+      borderBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+      contentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+      devicePixelContentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }]
+    } as unknown as ResizeObserverEntry
+    this.#callback([entry], this as unknown as ResizeObserver)
+  }
+
   unobserve = vi.fn()
   disconnect = vi.fn()
 }

--- a/src/renderer/src/__tests__/setup.ts
+++ b/src/renderer/src/__tests__/setup.ts
@@ -35,3 +35,18 @@ vi.stubGlobal('ResizeObserver', ResizeObserverStub)
 // calls it when navigating options, which otherwise throws from an internal timeout well
 // after the triggering test has already finished.
 Element.prototype.scrollIntoView = vi.fn()
+
+// jsdom doesn't implement OffscreenCanvas; useLabeler's store creates one unconditionally
+// on init (for hit-testing) even in tests that never render a canvas.
+class OffscreenCanvasStub {
+  width: number
+  height: number
+  constructor(width: number, height: number) {
+    this.width = width
+    this.height = height
+  }
+  getContext() {
+    return null
+  }
+}
+vi.stubGlobal('OffscreenCanvas', OffscreenCanvasStub)

--- a/src/renderer/src/api/ExternalAnnotator.ts
+++ b/src/renderer/src/api/ExternalAnnotator.ts
@@ -1,22 +1,153 @@
-export type ExternalAnnotatorLabel = {
-  id: string
-  name: string
+import { AnnotationType, IAnnotator, INewAnnotation, IPoint, ISample } from '@shared/types'
+import { arrayBufferToBase64, makeUUID } from '@shared/utils'
+import { normalizeAnnotationPoints } from '@renderer/hooks/useLabeler'
+import { imageExtensionFromUri } from '@renderer/components/sampleIO/exporters/imageExtensionFromUri'
+import type { AnnotatorAnnotation, AnnotatorLabel, AnnotatorPoint } from '@renderer/types'
+
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  bmp: 'image/bmp'
 }
 
-export class ExternalAnnotator {
-  name: string
-  baseUrl: string
+const withRoute = (baseUrl: string, route: string) => `${baseUrl.replace(/\/+$/, '')}${route}`
+
+const isAnnotatorLabel = (value: unknown): value is AnnotatorLabel =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as AnnotatorLabel).id === 'string' &&
+  typeof (value as AnnotatorLabel).name === 'string'
+
+const isAnnotatorPoint = (value: unknown): value is AnnotatorPoint =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as AnnotatorPoint).x === 'number' &&
+  typeof (value as AnnotatorPoint).y === 'number'
+
+const isAnnotatorAnnotation = (value: unknown): value is AnnotatorAnnotation =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as AnnotatorAnnotation).labelId === 'string' &&
+  typeof (value as AnnotatorAnnotation).type === 'string' &&
+  Array.isArray((value as AnnotatorAnnotation).points) &&
+  (value as AnnotatorAnnotation).points.every(isAnnotatorPoint)
+
+/** Calls an annotator server's `/connect` route to fetch its own label vocabulary. The
+ *  result is only ever held in memory while the user builds/edits a labelMapping - it's
+ *  never persisted, so this needs to be called again any time the mapping UI reopens. */
+export const connectToAnnotator = async (
+  url: string,
   headers: Record<string, string>
-  labels: Record<string, ExternalAnnotatorLabel>
-  constructor(
-    name: string,
-    baseUrl: string,
-    headers: Record<string, string> = {},
-    labels: Record<string, ExternalAnnotatorLabel> = {}
-  ) {
-    this.name = name
-    this.baseUrl = baseUrl
-    this.headers = headers
-    this.labels = labels
+): Promise<AnnotatorLabel[]> => {
+  const response = await fetch(withRoute(url, '/connect'), {
+    method: 'GET',
+    headers
+  })
+
+  if (!response.ok) {
+    throw new Error(`Annotator /connect failed: ${response.status} ${response.statusText}`)
   }
+
+  const data: unknown = await response.json()
+  const labels = (data as { labels?: unknown })?.labels
+
+  if (!Array.isArray(labels)) {
+    throw new Error('Annotator /connect response is missing a "labels" array')
+  }
+
+  return labels.filter(isAnnotatorLabel)
+}
+
+/** Resolves raw `/predict` output through an annotator's stored labelMapping into real
+ *  INewAnnotations. A prediction whose labelId has no mapping (or maps to null/"ignore"),
+ *  or that's otherwise malformed, is dropped and counted rather than guessed at. */
+export const mapPredictionsToAnnotations = (
+  predictions: unknown,
+  labelMapping: Record<string, string | null>
+): { annotations: INewAnnotation[]; skipped: number } => {
+  const annotations: INewAnnotation[] = []
+  let skipped = 0
+
+  if (!Array.isArray(predictions)) {
+    return { annotations, skipped }
+  }
+
+  for (const prediction of predictions) {
+    if (!isAnnotatorAnnotation(prediction)) {
+      skipped++
+      continue
+    }
+
+    const labelId = labelMapping[prediction.labelId]
+    const isValidType =
+      prediction.type === AnnotationType.Box || prediction.type === AnnotationType.Polygon
+    const hasEnoughPoints =
+      prediction.type === AnnotationType.Box
+        ? prediction.points.length === 2
+        : prediction.points.length >= 3
+
+    if (labelId === undefined || labelId === null || !isValidType || !hasEnoughPoints) {
+      skipped++
+      continue
+    }
+
+    const points: IPoint[] = prediction.points.map((point) => ({
+      id: makeUUID(),
+      x: point.x,
+      y: point.y
+    }))
+
+    const annotation: INewAnnotation = {
+      id: makeUUID(),
+      type: prediction.type,
+      labelId,
+      points
+    }
+
+    annotations.push(normalizeAnnotationPoints(annotation))
+  }
+
+  return { annotations, skipped }
+}
+
+/** Runs one sample through an annotator: reads its image bytes, POSTs them to /predict,
+ *  and resolves the response through labelMapping - built live for the current run, never
+ *  persisted (see hooks/useAnnotatorRuntime.ts). Throws on any network/parse failure so the
+ *  caller can attribute the failure to this sample. */
+export const runAnnotatorOnSample = async (
+  annotator: IAnnotator,
+  labelMapping: Record<string, string | null>,
+  sample: Pick<ISample, 'imageUri' | 'width' | 'height'>
+): Promise<{ annotations: INewAnnotation[]; skipped: number }> => {
+  const imageResponse = await fetch(sample.imageUri)
+  if (!imageResponse.ok) {
+    throw new Error(
+      `Failed to read sample image: ${imageResponse.status} ${imageResponse.statusText}`
+    )
+  }
+
+  const mimeType =
+    imageResponse.headers.get('content-type') ||
+    EXTENSION_MIME_TYPES[imageExtensionFromUri(sample.imageUri).toLowerCase()] ||
+    'application/octet-stream'
+
+  const image = arrayBufferToBase64(await imageResponse.arrayBuffer())
+
+  const predictResponse = await fetch(withRoute(annotator.url, '/predict'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...annotator.headers },
+    body: JSON.stringify({ image, mimeType, width: sample.width, height: sample.height })
+  })
+
+  if (!predictResponse.ok) {
+    throw new Error(
+      `Annotator /predict failed: ${predictResponse.status} ${predictResponse.statusText}`
+    )
+  }
+
+  const data: unknown = await predictResponse.json()
+  return mapPredictionsToAnnotations((data as { annotations?: unknown })?.annotations, labelMapping)
 }

--- a/src/renderer/src/api/__tests__/ExternalAnnotator.test.ts
+++ b/src/renderer/src/api/__tests__/ExternalAnnotator.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { AnnotationType, IAnnotator, ISample, TrainingSplit } from '@shared/types'
+import {
+  connectToAnnotator,
+  mapPredictionsToAnnotations,
+  runAnnotatorOnSample
+} from '../ExternalAnnotator'
+
+const jsonResponse = (body: unknown, init: { ok?: boolean; status?: number } = {}) => ({
+  ok: init.ok ?? true,
+  status: init.status ?? 200,
+  statusText: 'status',
+  headers: new Headers(),
+  json: () => Promise.resolve(body),
+  arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+})
+
+describe('connectToAnnotator', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('gets <url>/connect and returns the reported labels', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ labels: [{ id: '0', name: 'cat' }] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const labels = await connectToAnnotator('https://example.com/model/', { 'X-Api-Key': 'k' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/model/connect',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ 'X-Api-Key': 'k' })
+      })
+    )
+    expect(labels).toEqual([{ id: '0', name: 'cat' }])
+  })
+
+  it('drops malformed label entries', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ labels: [{ id: '0', name: 'cat' }, { id: 1, name: 'bad-id' }, 'nope'] })
+        )
+    )
+
+    const labels = await connectToAnnotator('https://example.com', {})
+    expect(labels).toEqual([{ id: '0', name: 'cat' }])
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({}, { ok: false, status: 500 })))
+    await expect(connectToAnnotator('https://example.com', {})).rejects.toThrow(/connect failed/)
+  })
+
+  it('throws when the response has no labels array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ oops: true })))
+    await expect(connectToAnnotator('https://example.com', {})).rejects.toThrow(/labels/)
+  })
+})
+
+describe('mapPredictionsToAnnotations', () => {
+  const labelMapping = { '0': 'project-label-1', '1': null }
+
+  it('resolves a mapped box prediction into a normalized annotation', () => {
+    const { annotations, skipped } = mapPredictionsToAnnotations(
+      [
+        {
+          labelId: '0',
+          type: AnnotationType.Box,
+          points: [
+            { x: 80, y: 90 },
+            { x: 10, y: 20 }
+          ]
+        }
+      ],
+      labelMapping
+    )
+
+    expect(skipped).toBe(0)
+    expect(annotations).toHaveLength(1)
+    const [annotation] = annotations
+    expect(annotation.labelId).toBe('project-label-1')
+    expect(annotation.type).toBe(AnnotationType.Box)
+    // normalizeAnnotationPoints reorders box corners to [min, max]
+    expect(annotation.points[0]).toMatchObject({ x: 10, y: 20 })
+    expect(annotation.points[1]).toMatchObject({ x: 80, y: 90 })
+    expect(annotation.points[0].id).toEqual(expect.any(String))
+  })
+
+  it('skips a prediction whose labelId has no mapping entry', () => {
+    const { annotations, skipped } = mapPredictionsToAnnotations(
+      [
+        {
+          labelId: 'unknown',
+          type: AnnotationType.Box,
+          points: [
+            { x: 0, y: 0 },
+            { x: 1, y: 1 }
+          ]
+        }
+      ],
+      labelMapping
+    )
+    expect(annotations).toHaveLength(0)
+    expect(skipped).toBe(1)
+  })
+
+  it('skips a prediction explicitly mapped to null (ignored)', () => {
+    const { annotations, skipped } = mapPredictionsToAnnotations(
+      [
+        {
+          labelId: '1',
+          type: AnnotationType.Box,
+          points: [
+            { x: 0, y: 0 },
+            { x: 1, y: 1 }
+          ]
+        }
+      ],
+      labelMapping
+    )
+    expect(annotations).toHaveLength(0)
+    expect(skipped).toBe(1)
+  })
+
+  it('skips a box with the wrong number of points', () => {
+    const { annotations, skipped } = mapPredictionsToAnnotations(
+      [{ labelId: '0', type: AnnotationType.Box, points: [{ x: 0, y: 0 }] }],
+      labelMapping
+    )
+    expect(annotations).toHaveLength(0)
+    expect(skipped).toBe(1)
+  })
+
+  it('accepts a polygon with 3+ points', () => {
+    const { annotations, skipped } = mapPredictionsToAnnotations(
+      [
+        {
+          labelId: '0',
+          type: AnnotationType.Polygon,
+          points: [
+            { x: 0, y: 0 },
+            { x: 5, y: 0 },
+            { x: 5, y: 5 }
+          ]
+        }
+      ],
+      labelMapping
+    )
+    expect(skipped).toBe(0)
+    expect(annotations).toHaveLength(1)
+    expect(annotations[0].points).toHaveLength(3)
+  })
+
+  it('skips malformed prediction shapes and non-array input', () => {
+    expect(mapPredictionsToAnnotations('nope', labelMapping)).toEqual({
+      annotations: [],
+      skipped: 0
+    })
+    expect(mapPredictionsToAnnotations([{ labelId: '0' }], labelMapping)).toEqual({
+      annotations: [],
+      skipped: 1
+    })
+  })
+})
+
+describe('runAnnotatorOnSample', () => {
+  const annotator: IAnnotator = {
+    id: 'a1',
+    name: 'Test annotator',
+    url: 'https://example.com',
+    headers: { Authorization: 'Bearer token' }
+  }
+  const labelMapping = { '0': 'project-label-1' }
+
+  const sample: ISample = {
+    id: 's1',
+    name: 'sample.png',
+    split: TrainingSplit.Train,
+    annotations: [],
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+    imageUri: 'image://local/s1.png',
+    width: 100,
+    height: 100
+  }
+
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches the sample image, posts base64 bytes to /predict, and maps the result', async () => {
+    const bytes = new Uint8Array([1, 2, 3]).buffer
+    const imageHeaders = new Headers({ 'content-type': 'image/png' })
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: imageHeaders,
+        arrayBuffer: () => Promise.resolve(bytes)
+      })
+      .mockResolvedValueOnce(
+        jsonResponse({
+          annotations: [
+            {
+              labelId: '0',
+              type: AnnotationType.Box,
+              points: [
+                { x: 0, y: 0 },
+                { x: 1, y: 1 }
+              ]
+            }
+          ]
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await runAnnotatorOnSample(annotator, labelMapping, sample)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, sample.imageUri)
+    const [predictUrl, predictInit] = fetchMock.mock.calls[1]
+    expect(predictUrl).toBe('https://example.com/predict')
+    expect(predictInit.headers).toEqual(expect.objectContaining({ Authorization: 'Bearer token' }))
+    const body = JSON.parse(predictInit.body)
+    expect(body).toMatchObject({ mimeType: 'image/png', width: 100, height: 100 })
+    expect(typeof body.image).toBe('string')
+
+    expect(result.skipped).toBe(0)
+    expect(result.annotations).toHaveLength(1)
+    expect(result.annotations[0].labelId).toBe('project-label-1')
+  })
+
+  it('throws if the sample image cannot be fetched', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+    )
+    await expect(runAnnotatorOnSample(annotator, labelMapping, sample)).rejects.toThrow(
+      /sample image/
+    )
+  })
+
+  it('throws if /predict responds with a non-ok status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'image/png' }),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(runAnnotatorOnSample(annotator, labelMapping, sample)).rejects.toThrow(
+      /predict failed/
+    )
+  })
+})

--- a/src/renderer/src/components/BasicListPage.tsx
+++ b/src/renderer/src/components/BasicListPage.tsx
@@ -1,6 +1,13 @@
 import { styled } from '@linaria/react'
 import { Flex, Space } from '@mantine/core'
-import { useLayoutEffect, useRef, type PropsWithChildren, type FC, type ReactNode } from 'react'
+import {
+  useLayoutEffect,
+  useRef,
+  type PropsWithChildren,
+  type FC,
+  type ReactNode,
+  type RefObject
+} from 'react'
 
 const TopArea = styled.div`
   display: flex;
@@ -8,6 +15,20 @@ const TopArea = styled.div`
   width: 60%;
   max-width: 1000px;
   /* padding: 0% max(20%, 100px); */
+`
+
+// Shared by every list page's toolbar (Projects/Tasks/Samples): a left-hand action-button
+// group and a right-hand filter/search group. flex-wrap lets the right group drop to its
+// own line instead of being squeezed off-screen once the left group grows past one row
+// (e.g. select mode's batch action buttons) - TopArea's fixed width doesn't grow with them.
+export const BasicListPageTopBar = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 `
 
 const ContentArea = styled.div`
@@ -46,11 +67,28 @@ const ScrollContainer = styled.div`
 
 export type BasicListPageProps = {
   top: ReactNode
+  /** Lets a caller share this page's scroll element with something outside it - a
+   *  virtualizer (see VirtualizedItemList) needs the actual scrolling DOM node to measure
+   *  against, which this component otherwise keeps entirely to itself. Optional: a page
+   *  that isn't virtualizing its content doesn't need to provide one. */
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
+  /** Relaxes the default 60%/1000px column cap to 90%/1400px - for a page whose content
+   *  genuinely needs more horizontal room than a plain list of rows (e.g.
+   *  CopyAnnotationsPage's side-by-side thumbnail/select mapping rows), rather than one
+   *  that's just a list and should stay narrow like Projects/Tasks/Samples. */
+  wide?: boolean
 }
 
-export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({ children, top }) => {
-  const scrollRef = useRef<HTMLDivElement>(null)
+export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({
+  children,
+  top,
+  scrollContainerRef,
+  wide
+}) => {
+  const ownScrollRef = useRef<HTMLDivElement>(null)
+  const scrollRef = scrollContainerRef ?? ownScrollRef
   const scrollTopRef = useRef(0)
+  const widthStyle = wide ? { width: '90%', maxWidth: 1400 } : undefined
 
   // Restores scrollTop on setup (mount, and the resetup that happens when this page's
   // <Activity> boundary goes from hidden back to visible - see the ScrollContainer comment).
@@ -66,7 +104,7 @@ export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({ child
   return (
     <Container>
       <Flex direction={'column'} w={'100%'} h={'100%'} align={'center'}>
-        <TopArea>{top}</TopArea>
+        <TopArea style={widthStyle}>{top}</TopArea>
         <Space h="md" />
         <ScrollContainer
           ref={scrollRef}
@@ -80,7 +118,7 @@ export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({ child
             scrollTopRef.current = el.scrollTop
           }}
         >
-          <ContentArea>{children}</ContentArea>
+          <ContentArea style={widthStyle}>{children}</ContentArea>
         </ScrollContainer>
       </Flex>
     </Container>

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -8,6 +8,7 @@ import {
   MdLabel,
   MdOutlineSmartToy
 } from 'react-icons/md'
+import { FaFileExport } from 'react-icons/fa'
 import { useContextMenu } from 'mantine-contextmenu'
 
 const ROW_PADDING = '14px 18px'
@@ -53,6 +54,9 @@ export type BasicListPageItemProps = {
   onManageAnnotators?: () => void
   onAutoLabel?: () => void
   onEditTags?: () => void
+  /** Exports just this item - only offered outside select mode, where batch export
+   *  (acting on the whole selection instead) takes over. */
+  onExport?: () => void
   onDelete?: () => void
   /** Whether the list is currently in select mode - while true, clicking the row
    *  anywhere (not just the checkbox) toggles selection instead of firing onClick, and
@@ -82,6 +86,7 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
   onManageAnnotators,
   onAutoLabel,
   onEditTags,
+  onExport,
   onDelete,
   selectMode,
   selected,
@@ -119,6 +124,9 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
       : []),
     ...(onEditTags
       ? [{ key: 'edit-tags', icon: <MdLabel size={16} />, title: 'Edit Tags', onClick: onEditTags }]
+      : []),
+    ...(onExport && !selectMode
+      ? [{ key: 'export', icon: <FaFileExport size={16} />, title: 'Export', onClick: onExport }]
       : []),
     ...(onDelete
       ? [

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -3,6 +3,7 @@ import { Checkbox, Group, Paper, Skeleton, Text, ThemeIcon } from '@mantine/core
 import type { FC, MouseEventHandler, ReactNode } from 'react'
 import {
   MdChevronRight,
+  MdContentCopy,
   MdDeleteOutline,
   MdEdit,
   MdLabel,
@@ -57,6 +58,9 @@ export type BasicListPageItemProps = {
   /** Exports just this item - only offered outside select mode, where batch export
    *  (acting on the whole selection instead) takes over. */
   onExport?: () => void
+  /** Copies this item's samples' annotations into another task - only offered outside
+   *  select mode, same as onExport (both are inherently single-source actions). */
+  onCopyAnnotations?: () => void
   onDelete?: () => void
   /** Whether the list is currently in select mode - while true, clicking the row
    *  anywhere (not just the checkbox) toggles selection instead of firing onClick, and
@@ -87,6 +91,7 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
   onAutoLabel,
   onEditTags,
   onExport,
+  onCopyAnnotations,
   onDelete,
   selectMode,
   selected,
@@ -127,6 +132,16 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
       : []),
     ...(onExport && !selectMode
       ? [{ key: 'export', icon: <FaFileExport size={16} />, title: 'Export', onClick: onExport }]
+      : []),
+    ...(onCopyAnnotations && !selectMode
+      ? [
+          {
+            key: 'copy-annotations',
+            icon: <MdContentCopy size={16} />,
+            title: 'Copy Annotations',
+            onClick: onCopyAnnotations
+          }
+        ]
       : []),
     ...(onDelete
       ? [

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@linaria/react'
 import { Checkbox, Group, Paper, Skeleton, Text, ThemeIcon } from '@mantine/core'
 import type { FC, MouseEventHandler, ReactNode } from 'react'
-import { MdChevronRight, MdDeleteOutline, MdEdit } from 'react-icons/md'
+import { MdChevronRight, MdDeleteOutline, MdEdit, MdOutlineSmartToy } from 'react-icons/md'
 import { useContextMenu } from 'mantine-contextmenu'
 
 const ROW_PADDING = '14px 18px'
@@ -44,6 +44,8 @@ export type BasicListPageItemProps = {
   tags?: ReactNode
   onClick: () => void
   onEdit?: () => void
+  onManageAnnotators?: () => void
+  onAutoLabel?: () => void
   onDelete?: () => void
   /** Whether the list is currently in select mode - while true, clicking the row
    *  anywhere (not just the checkbox) toggles selection instead of firing onClick, and
@@ -66,6 +68,8 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
   tags,
   onClick,
   onEdit,
+  onManageAnnotators,
+  onAutoLabel,
   onDelete,
   selectMode,
   selected,
@@ -79,6 +83,26 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
   const editDeleteItems = [
     ...(onEdit
       ? [{ key: 'edit', icon: <MdEdit size={16} />, title: 'Edit', onClick: onEdit }]
+      : []),
+    ...(onManageAnnotators
+      ? [
+          {
+            key: 'manage-annotators',
+            icon: <MdOutlineSmartToy size={16} />,
+            title: 'Manage Annotators',
+            onClick: onManageAnnotators
+          }
+        ]
+      : []),
+    ...(onAutoLabel
+      ? [
+          {
+            key: 'auto-label',
+            icon: <MdOutlineSmartToy size={16} />,
+            title: 'Auto-label',
+            onClick: onAutoLabel
+          }
+        ]
       : []),
     ...(onDelete
       ? [

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -1,7 +1,13 @@
 import { styled } from '@linaria/react'
 import { Checkbox, Group, Paper, Skeleton, Text, ThemeIcon } from '@mantine/core'
 import type { FC, MouseEventHandler, ReactNode } from 'react'
-import { MdChevronRight, MdDeleteOutline, MdEdit, MdOutlineSmartToy } from 'react-icons/md'
+import {
+  MdChevronRight,
+  MdDeleteOutline,
+  MdEdit,
+  MdLabel,
+  MdOutlineSmartToy
+} from 'react-icons/md'
 import { useContextMenu } from 'mantine-contextmenu'
 
 const ROW_PADDING = '14px 18px'
@@ -46,6 +52,7 @@ export type BasicListPageItemProps = {
   onEdit?: () => void
   onManageAnnotators?: () => void
   onAutoLabel?: () => void
+  onEditTags?: () => void
   onDelete?: () => void
   /** Whether the list is currently in select mode - while true, clicking the row
    *  anywhere (not just the checkbox) toggles selection instead of firing onClick, and
@@ -53,6 +60,10 @@ export type BasicListPageItemProps = {
   selectMode?: boolean
   selected?: boolean
   onSelectedChange?: (selected: boolean) => void
+  /** Enters select mode with just this item selected - the context menu's entry point
+   *  into selection outside select mode, where the All/Above/Below variants below
+   *  wouldn't yet make sense (there's no anchor item, and nothing else is selected). */
+  onSelect?: () => void
   /** Selects every currently visible (filtered) item. */
   onSelectAll?: () => void
   /** Selects this item and every visible item above it. */
@@ -70,10 +81,12 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
   onEdit,
   onManageAnnotators,
   onAutoLabel,
+  onEditTags,
   onDelete,
   selectMode,
   selected,
   onSelectedChange,
+  onSelect,
   onSelectAll,
   onSelectAbove,
   onSelectBelow
@@ -104,6 +117,9 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
           }
         ]
       : []),
+    ...(onEditTags
+      ? [{ key: 'edit-tags', icon: <MdLabel size={16} />, title: 'Edit Tags', onClick: onEditTags }]
+      : []),
     ...(onDelete
       ? [
           {
@@ -116,15 +132,23 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
         ]
       : [])
   ]
-  const selectionItems = [
-    ...(onSelectAll ? [{ key: 'select-all', title: 'Select All', onClick: onSelectAll }] : []),
-    ...(onSelectAbove
-      ? [{ key: 'select-above', title: 'Select Above', onClick: onSelectAbove }]
-      : []),
-    ...(onSelectBelow
-      ? [{ key: 'select-below', title: 'Select Below', onClick: onSelectBelow }]
-      : [])
-  ]
+  // Outside select mode, the All/Above/Below variants have no anchor to make sense of yet
+  // (nothing else is selected) - a single generic "Select" entry (via onSelect) is the
+  // only selection action offered until the list is already in select mode, at which
+  // point the fuller batch-selection variants take over.
+  const selectionItems = selectMode
+    ? [
+        ...(onSelectAll ? [{ key: 'select-all', title: 'Select All', onClick: onSelectAll }] : []),
+        ...(onSelectAbove
+          ? [{ key: 'select-above', title: 'Select Above', onClick: onSelectAbove }]
+          : []),
+        ...(onSelectBelow
+          ? [{ key: 'select-below', title: 'Select Below', onClick: onSelectBelow }]
+          : [])
+      ]
+    : onSelect
+      ? [{ key: 'select', title: 'Select', onClick: onSelect }]
+      : []
   const contextMenuItems = [
     ...editDeleteItems,
     ...(editDeleteItems.length > 0 && selectionItems.length > 0 ? [{ key: 'divider' }] : []),

--- a/src/renderer/src/components/Labeler.tsx
+++ b/src/renderer/src/components/Labeler.tsx
@@ -1,11 +1,23 @@
 import { styled } from '@linaria/react'
-import { LabelerStore, normalizeAnnotationPoints } from '@renderer/hooks/useLabeler'
+import {
+  axisMaskedMoveDelta,
+  BOX_CORNER_HANDLE_BOTTOM_LEFT,
+  BOX_CORNER_HANDLE_TOP_RIGHT,
+  BOX_EDGE_BOTTOM,
+  BOX_EDGE_LEFT,
+  BOX_EDGE_RIGHT,
+  BOX_EDGE_TOP,
+  LabelerStore,
+  normalizeAnnotationPoints
+} from '@renderer/hooks/useLabeler'
 import { LabelerMode } from '@renderer/types'
 import { AnnotationType, IAnnotation, IPoint, OmitV2 } from '@shared/types'
 import { PointerEventHandler, RefObject, useCallback, useEffect, useRef } from 'react'
 import { StoreApi, UseBoundStore } from 'zustand'
 import { ContextMenuItemOptions, useContextMenu } from 'mantine-contextmenu'
-import { MdDeleteOutline } from 'react-icons/md'
+import { MdContentCopy, MdDeleteOutline } from 'react-icons/md'
+import { BsBoundingBoxCircles } from 'react-icons/bs'
+import { PiPolygonLight } from 'react-icons/pi'
 import { tools } from './labeler/tools'
 import { PointerResult, type LabelerToolContext } from './labeler/types'
 
@@ -182,6 +194,22 @@ const drawSelectedHitHandles = (
   }
 
   if (selectedAnnotation.type === AnnotationType.Box) {
+    // Edge hit-test lines, drawn before the corner circles below so a corner's hit
+    // area wins over an overlapping edge at the same pixels.
+    const boxCorners = getBoxPoints(points)
+    const edgeSentinels = [BOX_EDGE_TOP, BOX_EDGE_RIGHT, BOX_EDGE_BOTTOM, BOX_EDGE_LEFT]
+    for (let i = 0; i < boxCorners.length; i++) {
+      const hitId = state.selectedAnnotationLineHitIds.getByValue(edgeSentinels[i])
+      if (hitId === undefined) continue
+      drawLine(
+        hitTestCtx,
+        boxCorners[i],
+        boxCorners[(i + 1) % boxCorners.length],
+        hitId,
+        HIT_TEST_LINE_WIDTH
+      )
+    }
+
     drawCircle(
       hitTestCtx,
       points[0],
@@ -196,6 +224,33 @@ const drawSelectedHitHandles = (
       CONTROL_POINT_CIRCLE_RADIUS,
       0
     )
+
+    // The 2 derived corners (top-right/bottom-left) - purely visual/hit-test handles,
+    // don't correspond to a real IPoint (see BOX_CORNER_HANDLE_TOP_RIGHT).
+    const topRightHitId = state.selectedAnnotationControlHitIds.getByValue(
+      BOX_CORNER_HANDLE_TOP_RIGHT
+    )
+    const bottomLeftHitId = state.selectedAnnotationControlHitIds.getByValue(
+      BOX_CORNER_HANDLE_BOTTOM_LEFT
+    )
+    if (topRightHitId !== undefined) {
+      drawCircle(
+        hitTestCtx,
+        { x: points[1].x, y: points[0].y },
+        topRightHitId,
+        CONTROL_POINT_CIRCLE_RADIUS,
+        0
+      )
+    }
+    if (bottomLeftHitId !== undefined) {
+      drawCircle(
+        hitTestCtx,
+        { x: points[0].x, y: points[1].y },
+        bottomLeftHitId,
+        CONTROL_POINT_CIRCLE_RADIUS,
+        0
+      )
+    }
     return
   }
 
@@ -286,6 +341,32 @@ const drawCreationPreview = (
   }
 }
 
+const HOVER_DIM_ALPHA = 0.55
+const HOVER_OUTLINE_WIDTH = 3
+
+/** Dims the whole canvas - since this runs on the annotation canvas layer (stacked above
+ *  the image canvas), it darkens both the image and every other annotation already drawn
+ *  this frame. Deliberately driven by "is the mouse anywhere over the AnnotationsDrawer",
+ *  not "is this specific row hovered": keying the dim itself off a single row would flash
+ *  off/on every time the cursor crosses the gap between two rows on its way from one to
+ *  another - this way the dim stays on continuously and only the cutout below moves. */
+const dimCanvas = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
+  ctx.fillStyle = `rgba(0, 0, 0, ${HOVER_DIM_ALPHA})`
+  ctx.fillRect(0, 0, width, height)
+}
+
+/** Cuts a hole exactly matching a shape out of whatever's already been drawn (namely
+ *  dimCanvas's overlay) via a destination-out composite, exposing the image and that
+ *  shape's own fill/outline at full brightness underneath. */
+const cutoutShape = (ctx: CanvasRenderingContext2D, shapePoints: OmitV2<IPoint, 'id'>[]) => {
+  if (shapePoints.length < 2) return
+
+  const restoreComposite = ctx.globalCompositeOperation
+  ctx.globalCompositeOperation = 'destination-out'
+  drawPolygon(ctx, shapePoints, 'rgba(0, 0, 0, 1)', true)
+  ctx.globalCompositeOperation = restoreComposite
+}
+
 const drawCrosshair = (
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -371,6 +452,28 @@ const useLabelerContextMenu = (store: UseBoundStore<StoreApi<LabelerStore>>) => 
             })
           }
         }
+
+        menuOptions.push({
+          key: 'duplicate',
+          icon: <MdContentCopy size={16} />,
+          title: 'Duplicate',
+          onClick: () => store.getState().duplicateAnnotation(resolvedTargetAnnotation.id)
+        })
+
+        menuOptions.push({
+          key: 'convert-type',
+          icon:
+            resolvedTargetAnnotation.type === AnnotationType.Box ? (
+              <PiPolygonLight size={16} />
+            ) : (
+              <BsBoundingBoxCircles size={16} />
+            ),
+          title:
+            resolvedTargetAnnotation.type === AnnotationType.Box
+              ? 'Convert to Polygon'
+              : 'Convert to Box',
+          onClick: () => store.getState().convertAnnotationType(resolvedTargetAnnotation.id)
+        })
 
         menuOptions.push({
           key: 'delete',
@@ -634,13 +737,15 @@ const useCanvasDraw = (
 
       if (selectedAnnotation !== null && state.pointIdsBeingMoved !== null) {
         selectedAnnotation = structuredClone(selectedAnnotation)
-        const pointsBeingMoved = new Set(state.pointIdsBeingMoved ?? [])
-        const [dx, dy] = state.moveCurrent
         for (const point of selectedAnnotation.points) {
-          if (pointsBeingMoved.has(point.id)) {
-            point.x += dx
-            point.y += dy
-          }
+          const [dx, dy] = axisMaskedMoveDelta(
+            point.id,
+            state.pointIdsBeingMoved,
+            state.pointIdsBeingMovedAxis,
+            state.moveCurrent
+          )
+          point.x += dx
+          point.y += dy
         }
 
         selectedAnnotation = normalizeAnnotationPoints(selectedAnnotation)
@@ -669,7 +774,7 @@ const useCanvasDraw = (
                   }
                   break
 
-                case AnnotationType.Mask:
+                case AnnotationType.Polygon:
                   {
                     drawPolygon(hitTestCtx, points, hitId, true)
                   }
@@ -692,7 +797,7 @@ const useCanvasDraw = (
                 drawSelectedHitHandles(selectedAnnotation, hitTestCtx, state, points)
                 break
 
-              case AnnotationType.Mask:
+              case AnnotationType.Polygon:
                 drawSelectedHitHandles(selectedAnnotation, hitTestCtx, state, points)
                 break
             }
@@ -738,7 +843,7 @@ const useCanvasDraw = (
               }
               break
 
-            case AnnotationType.Mask:
+            case AnnotationType.Polygon:
               {
                 drawPolygon(
                   annotationCtx,
@@ -776,12 +881,24 @@ const useCanvasDraw = (
             case AnnotationType.Box:
               {
                 drawControlCircle(annotationCtx, points[0], CONTROL_POINT_CIRCLE_RADIUS)
-
                 drawControlCircle(annotationCtx, points[1], CONTROL_POINT_CIRCLE_RADIUS)
+
+                // Purely visual - the other 2 corners of the box, derived from the same
+                // 2 real points, so dragging them still only ever produces 2 real points.
+                drawControlCircle(
+                  annotationCtx,
+                  { x: points[1].x, y: points[0].y },
+                  CONTROL_POINT_CIRCLE_RADIUS
+                )
+                drawControlCircle(
+                  annotationCtx,
+                  { x: points[0].x, y: points[1].y },
+                  CONTROL_POINT_CIRCLE_RADIUS
+                )
               }
               break
 
-            case AnnotationType.Mask:
+            case AnnotationType.Polygon:
               {
                 for (const point of points) {
                   drawControlCircle(annotationCtx, point, CONTROL_POINT_CIRCLE_RADIUS)
@@ -792,6 +909,47 @@ const useCanvasDraw = (
         }
 
         drawCreationPreview(annotationCtx, state, xScale, yScale)
+
+        let hoveredAnnotation: IAnnotation | null = null
+        if (state.hoveredAnnotationId !== null) {
+          hoveredAnnotation =
+            selectedAnnotation?.id === state.hoveredAnnotationId
+              ? selectedAnnotation
+              : (state.sample
+                  ?.resolve()
+                  .annotations.resolve()
+                  [state.hoveredAnnotationId]?.resolve() ?? null)
+        }
+
+        if (state.isAnnotationsDrawerHovered) {
+          dimCanvas(annotationCtx, width, height)
+
+          if (hoveredAnnotation !== null) {
+            const hoveredPoints = transformPoints(
+              hoveredAnnotation.points,
+              state.imageRect.x,
+              state.imageRect.y,
+              xScale,
+              yScale
+            )
+            const spotlightShape =
+              hoveredAnnotation.type === AnnotationType.Box
+                ? getBoxPoints(hoveredPoints)
+                : hoveredPoints
+
+            cutoutShape(annotationCtx, spotlightShape)
+
+            // Re-draws the spotlighted annotation's outline crisp and undimmed on top of
+            // the cutout, thicker than normal so it reads clearly as the focused shape.
+            drawPolygon(
+              annotationCtx,
+              spotlightShape,
+              state.labelsMap[hoveredAnnotation.labelId]?.color ?? '#ffffff',
+              false,
+              HOVER_OUTLINE_WIDTH
+            )
+          }
+        }
 
         if (state.showHitTestDebugOverlay) {
           annotationCtx.globalAlpha = HIT_TEST_OVERLAY_ALPHA
@@ -804,7 +962,7 @@ const useCanvasDraw = (
     const crosshairCtx = crosshairCanvasElement.getContext('2d')
     if (crosshairCtx !== null) {
       crosshairCtx.clearRect(0, 0, width, height)
-      if (state.mode === LabelerMode.CreateBox || state.mode === LabelerMode.CreateMask) {
+      if (state.mode === LabelerMode.CreateBox || state.mode === LabelerMode.CreatePolygon) {
         drawCrosshair(crosshairCtx, state.mousePos[0], state.mousePos[1], width, height)
       }
     }

--- a/src/renderer/src/components/VirtualizedItemList.tsx
+++ b/src/renderer/src/components/VirtualizedItemList.tsx
@@ -1,0 +1,66 @@
+import { Box } from '@mantine/core'
+import { Virtuoso } from 'react-virtuoso'
+import { useEffect, useLayoutEffect, useState, type ReactNode, type RefObject } from 'react'
+
+export type VirtualizedItemListProps<T> = {
+  items: T[]
+  getKey: (item: T, index: number) => string
+  renderItem: (item: T, index: number) => ReactNode
+  /** The actual scrolling DOM element these rows live inside - see
+   *  BasicListPage's scrollContainerRef. */
+  scrollContainerRef: RefObject<HTMLDivElement | null>
+  /** A first-paint guess before a row has ever been measured - rows are re-measured
+   *  after mount, so this only affects the very first layout/scrollbar-size estimate,
+   *  not correctness. */
+  estimateSize?: number
+}
+
+/** Renders only the rows currently scrolled into view (plus a look-ahead buffer)
+ *  instead of the full list - the DOM cost of a `BasicListPageItem` row (icon, tags,
+ *  progress bar, context menu) doesn't scale with dataset size this way. Row heights
+ *  aren't uniform (badges/progress bars add lines) - react-virtuoso (rather than
+ *  @tanstack/react-virtual, which this used previously) is built specifically to
+ *  measure/reflow variable-height rows without the visible jump a coarser estimate
+ *  can cause when fast scrolling outruns measurement. */
+export function VirtualizedItemList<T>({
+  items,
+  getKey,
+  renderItem,
+  scrollContainerRef,
+  estimateSize = 90
+}: VirtualizedItemListProps<T>) {
+  // scrollContainerRef.current is still null during this render (refs attach at
+  // commit, same as any other ref) - resolve it into state so Virtuoso never has a
+  // render where it falls back to creating its own internal scroller before swapping
+  // to the real one (BasicListPage's ScrollContainer, which also owns manual
+  // scrollTop save/restore across this page's Activity hide/show).
+  const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null)
+  useLayoutEffect(() => {
+    setScrollParent(scrollContainerRef.current)
+  }, [scrollContainerRef])
+  // If scrollContainerRef's owner is an ancestor that mounts in this same commit
+  // (rather than one already mounted from an earlier commit, e.g. behind a loading
+  // gate), its ref isn't attached yet when the layout effect above runs - refs attach
+  // bottom-up, so a descendant's layout effect can fire before an ancestor's own ref
+  // does. A plain effect runs strictly after every layout effect in the commit has
+  // finished (including that ancestor's), so it's guaranteed to see the real value
+  // once the layout-effect attempt above came back empty.
+  useEffect(() => {
+    if (scrollParent === null) setScrollParent(scrollContainerRef.current)
+  }, [scrollContainerRef, scrollParent])
+
+  if (scrollParent === null) return null
+
+  return (
+    <Virtuoso
+      customScrollParent={scrollParent}
+      data={items}
+      computeItemKey={(index, item) => getKey(item, index)}
+      defaultItemHeight={estimateSize}
+      // Look-ahead buffer, in pixels: measures/renders rows before they're ever
+      // visible, so fast scrolling is less likely to outrun measurement.
+      increaseViewportBy={{ top: 400, bottom: 400 }}
+      itemContent={(index, item) => <Box pb="md">{renderItem(item, index)}</Box>}
+    />
+  )
+}

--- a/src/renderer/src/components/__tests__/BasicListPageItem.test.tsx
+++ b/src/renderer/src/components/__tests__/BasicListPageItem.test.tsx
@@ -49,6 +49,76 @@ describe('BasicListPageItem', () => {
     expect(onDelete).toHaveBeenCalledTimes(1)
   })
 
+  it('shows an Export option on right-click outside select mode, and calls onExport when chosen', () => {
+    const onExport = vi.fn()
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onExport={onExport}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+    fireEvent.click(screen.getByText('Export'))
+
+    expect(onExport).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the Export option in select mode', () => {
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onExport={vi.fn()}
+        selectMode
+        selected={false}
+        onSelectedChange={vi.fn()}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+
+    expect(screen.queryByText('Export')).not.toBeInTheDocument()
+  })
+
+  it('shows a Copy Annotations option on right-click outside select mode, and calls onCopyAnnotations when chosen', () => {
+    const onCopyAnnotations = vi.fn()
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onCopyAnnotations={onCopyAnnotations}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+    fireEvent.click(screen.getByText('Copy Annotations'))
+
+    expect(onCopyAnnotations).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the Copy Annotations option in select mode', () => {
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onCopyAnnotations={vi.fn()}
+        selectMode
+        selected={false}
+        onSelectedChange={vi.fn()}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+
+    expect(screen.queryByText('Copy Annotations')).not.toBeInTheDocument()
+  })
+
   it('does not show a context menu when onDelete is not provided', () => {
     renderWithProviders(
       <BasicListPageItem icon={<MdFolder />} title="Street Signs" onClick={vi.fn()} />
@@ -184,7 +254,29 @@ describe('BasicListPageItem', () => {
     expect(onClick).not.toHaveBeenCalled()
   })
 
-  it('shows Select All/Above/Below on right-click when provided, and calls the right one', () => {
+  it('shows a single Select option on right-click outside select mode, and calls onSelect', () => {
+    const onSelect = vi.fn()
+    const onSelectAll = vi.fn()
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onSelect={onSelect}
+        onSelectAll={onSelectAll}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+
+    expect(screen.queryByText('Select All')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Select'))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelectAll).not.toHaveBeenCalled()
+  })
+
+  it('shows Select All/Above/Below on right-click in select mode, and calls the right one', () => {
     const onSelectAll = vi.fn()
     const onSelectAbove = vi.fn()
     const onSelectBelow = vi.fn()
@@ -193,6 +285,9 @@ describe('BasicListPageItem', () => {
         icon={<MdFolder />}
         title="Street Signs"
         onClick={vi.fn()}
+        selectMode
+        selected={false}
+        onSelectedChange={vi.fn()}
         onSelectAll={onSelectAll}
         onSelectAbove={onSelectAbove}
         onSelectBelow={onSelectBelow}
@@ -207,6 +302,46 @@ describe('BasicListPageItem', () => {
     expect(onSelectBelow).not.toHaveBeenCalled()
   })
 
+  it('shows a Manage Annotators option on right-click and calls it when chosen', () => {
+    const onManageAnnotators = vi.fn()
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onManageAnnotators={onManageAnnotators}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+    fireEvent.click(screen.getByText('Manage Annotators'))
+
+    expect(onManageAnnotators).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows edit, manage annotators and delete together, and clicking one does not trigger the others', () => {
+    const onEdit = vi.fn()
+    const onManageAnnotators = vi.fn()
+    const onDelete = vi.fn()
+    renderWithProviders(
+      <BasicListPageItem
+        icon={<MdFolder />}
+        title="Street Signs"
+        onClick={vi.fn()}
+        onEdit={onEdit}
+        onManageAnnotators={onManageAnnotators}
+        onDelete={onDelete}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+    fireEvent.click(screen.getByText('Manage Annotators'))
+
+    expect(onManageAnnotators).toHaveBeenCalledTimes(1)
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
   it('shows both edit/delete and select-helper items together in the context menu', () => {
     renderWithProviders(
       <BasicListPageItem
@@ -215,6 +350,9 @@ describe('BasicListPageItem', () => {
         onClick={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
+        selectMode
+        selected={false}
+        onSelectedChange={vi.fn()}
         onSelectAll={vi.fn()}
       />
     )

--- a/src/renderer/src/components/__tests__/VirtualizedItemList.test.tsx
+++ b/src/renderer/src/components/__tests__/VirtualizedItemList.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import { useRef } from 'react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { VirtualizedItemList } from '../VirtualizedItemList'
+
+type Item = { id: string; label: string }
+
+const Harness = ({ items }: { items: Item[] }) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={scrollContainerRef} data-testid="scroll-container" style={{ height: 400 }}>
+      <VirtualizedItemList
+        items={items}
+        getKey={(item) => item.id}
+        renderItem={(item) => <div>{item.label}</div>}
+        scrollContainerRef={scrollContainerRef}
+      />
+    </div>
+  )
+}
+
+describe('VirtualizedItemList', () => {
+  it('renders every item via renderItem', async () => {
+    renderWithProviders(
+      <Harness
+        items={[
+          { id: '1', label: 'Alpha' },
+          { id: '2', label: 'Beta' }
+        ]}
+      />
+    )
+    const list = within(await screen.findByTestId('scroll-container'))
+
+    expect(await list.findByText('Alpha')).toBeInTheDocument()
+    expect(list.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the list is empty', async () => {
+    renderWithProviders(<Harness items={[]} />)
+    const scrollContainer = await screen.findByTestId('scroll-container')
+
+    expect(scrollContainer.textContent).toBe('')
+  })
+
+  it('reflects item updates and additions on rerender', async () => {
+    const { rerender } = renderWithProviders(<Harness items={[{ id: '1', label: 'Alpha' }]} />)
+    let list = within(await screen.findByTestId('scroll-container'))
+    await list.findByText('Alpha')
+
+    rerender(
+      <Harness
+        items={[
+          { id: '1', label: 'Alpha Renamed' },
+          { id: '2', label: 'Beta' }
+        ]}
+      />
+    )
+
+    list = within(screen.getByTestId('scroll-container'))
+    expect(await list.findByText('Alpha Renamed')).toBeInTheDocument()
+    expect(list.getByText('Beta')).toBeInTheDocument()
+    expect(list.queryByText('Alpha')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/annotators/AnnotatorsModal.tsx
+++ b/src/renderer/src/components/annotators/AnnotatorsModal.tsx
@@ -1,0 +1,606 @@
+import { useEffect, useMemo, useRef, useState, type FC } from 'react'
+import {
+  ActionIcon,
+  Button,
+  Group,
+  Modal,
+  Progress,
+  ScrollArea,
+  Select,
+  Stack,
+  Text,
+  TextInput
+} from '@mantine/core'
+import toast from 'react-hot-toast'
+import { MdAdd, MdDeleteOutline, MdSettings } from 'react-icons/md'
+import { IoMdArrowBack } from 'react-icons/io'
+import type { IAnnotator, IProject, ITask } from '@shared/types'
+import { errorToString, makeUUID } from '@shared/utils'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
+import { useAnnotators } from '@renderer/hooks/useAnnotators'
+import { useAnnotatorRuntime } from '@renderer/hooks/useAnnotatorRuntime'
+import { useRunAnnotator, type RunAnnotatorProgress } from '@renderer/hooks/useRunAnnotator'
+import { connectToAnnotator } from '@renderer/api/ExternalAnnotator'
+import { findLabelIdByName } from '@renderer/components/sampleIO/importers/matchLabel'
+import type { AnnotatorLabel, OptimisticSample } from '@renderer/types'
+import { ZIndex } from '@renderer/zIndex'
+
+const IGNORE_VALUE = '__ignore__'
+
+type HeaderRow = { id: string; key: string; value: string }
+
+type Step =
+  | { step: 'list' }
+  | { step: 'form'; name: string; url: string; headerRows: HeaderRow[] }
+  | { step: 'run'; annotator: IAnnotator; samples: OptimisticSample[] }
+  | { step: 'edit'; annotator: IAnnotator; name: string; url: string; headerRows: HeaderRow[] }
+
+/** Best-effort mapping by matching an annotator's label names against a project's own -
+ *  never persisted, only used to seed the in-memory mapping the first time an annotator
+ *  runs against a given project (see useAnnotatorRuntime.ts). */
+const guessMapping = (
+  labels: AnnotatorLabel[],
+  project: IProject
+): Record<string, string | null> => {
+  const mapping: Record<string, string | null> = {}
+  for (const label of labels) {
+    mapping[label.id] = findLabelIdByName(project.labels, label.name) ?? null
+  }
+  return mapping
+}
+
+const summarize = (progress: RunAnnotatorProgress) => {
+  const labeled = progress.completed - progress.failures.length
+  const parts = [`${progress.created} annotation${progress.created === 1 ? '' : 's'} added`]
+  parts.push(`across ${labeled} image${labeled === 1 ? '' : 's'}`)
+  if (progress.skipped > 0) parts.push(`${progress.skipped} prediction(s) skipped`)
+  if (progress.alreadyLabeled > 0) parts.push(`${progress.alreadyLabeled} already labeled`)
+  if (progress.failures.length > 0) parts.push(`${progress.failures.length} failed`)
+  return parts.join(', ')
+}
+
+type AnnotatorFieldsValue = { name: string; url: string; headerRows: HeaderRow[] }
+
+type AnnotatorFormFieldsProps = {
+  value: AnnotatorFieldsValue
+  onChange: (value: AnnotatorFieldsValue) => void
+}
+
+/** Name/URL/headers fields - shared between the "Add Annotator" form and the settings/cog
+ *  "edit" screen, which differ only in what they do with the result (create vs. update). */
+const AnnotatorFormFields: FC<AnnotatorFormFieldsProps> = ({ value, onChange }) => (
+  <>
+    <TextInput
+      label="Name"
+      value={value.name}
+      onChange={(e) => onChange({ ...value, name: e.target.value })}
+      data-autofocus
+    />
+    <TextInput
+      label="URL"
+      description="Base URL - must expose GET <url>/connect and POST <url>/predict"
+      placeholder="https://example.com/my-model"
+      value={value.url}
+      onChange={(e) => onChange({ ...value, url: e.target.value })}
+    />
+    <Stack gap="xs">
+      <Text size="sm" fw={500}>
+        Headers
+      </Text>
+      {value.headerRows.map((row) => (
+        <Group key={row.id} wrap="nowrap">
+          <TextInput
+            flex={1}
+            placeholder="Header name"
+            value={row.key}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                headerRows: value.headerRows.map((r) =>
+                  r.id === row.id ? { ...r, key: e.target.value } : r
+                )
+              })
+            }
+          />
+          <TextInput
+            flex={1}
+            placeholder="Value"
+            value={row.value}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                headerRows: value.headerRows.map((r) =>
+                  r.id === row.id ? { ...r, value: e.target.value } : r
+                )
+              })
+            }
+          />
+          <ActionIcon
+            aria-label="Remove header"
+            variant="subtle"
+            color="red"
+            onClick={() =>
+              onChange({ ...value, headerRows: value.headerRows.filter((r) => r.id !== row.id) })
+            }
+          >
+            <MdDeleteOutline size={16} />
+          </ActionIcon>
+        </Group>
+      ))}
+      <Button
+        size="xs"
+        variant="subtle"
+        leftSection={<MdAdd />}
+        onClick={() =>
+          onChange({
+            ...value,
+            headerRows: [...value.headerRows, { id: makeUUID(), key: '', value: '' }]
+          })
+        }
+      >
+        Add Header
+      </Button>
+    </Stack>
+  </>
+)
+
+type AnnotatorMappingFieldsProps = {
+  project: IProject
+  labels: AnnotatorLabel[]
+  mapping: Record<string, string | null>
+  onChangeMapping: (labelId: string, value: string) => void
+}
+
+/** The per-label "map to a project label, or Ignore" editor - shared between the pre-run
+ *  review screen and the settings/cog "edit" screen, both of which just read/write the
+ *  same in-memory (annotatorId, projectId) mapping via different entry points. */
+const AnnotatorMappingFields: FC<AnnotatorMappingFieldsProps> = ({
+  project,
+  labels,
+  mapping,
+  onChangeMapping
+}) => (
+  <Stack gap="sm">
+    <Text size="sm" c="dimmed">
+      Map each of this annotator&apos;s labels to a project label, or leave it as Ignore.
+    </Text>
+    {labels.length === 0 && (
+      <Text size="sm" c="dimmed">
+        This annotator reported no labels.
+      </Text>
+    )}
+    <ScrollArea style={{ maxHeight: 260 }} type="always" scrollbars="y">
+      <Stack gap="sm">
+        {labels.map((label) => (
+          <Group key={label.id} wrap="nowrap">
+            <Text size="sm" flex={1} truncate>
+              {label.name}
+            </Text>
+            <Select
+              flex={1}
+              data={[
+                { value: IGNORE_VALUE, label: 'Ignore' },
+                ...project.labels.map((l) => ({ value: l.id, label: l.name }))
+              ]}
+              value={mapping[label.id] ?? IGNORE_VALUE}
+              onChange={(value) => onChangeMapping(label.id, value ?? IGNORE_VALUE)}
+              comboboxProps={{ zIndex: ZIndex.actionModalContent }}
+              allowDeselect={false}
+            />
+          </Group>
+        ))}
+      </Stack>
+    </ScrollArea>
+  </Stack>
+)
+
+type AnnotatorRunStepProps = {
+  project: IProject
+  samples: OptimisticSample[]
+  annotator: IAnnotator
+  /** Owned by the parent (not this component) so it survives this component's own
+   *  mount/unmount as the modal steps back and forth, and so a run that should start
+   *  immediately (a mapping was already known) can be kicked off from the click handler
+   *  that made that call, rather than this component re-deriving the same decision in a
+   *  mount effect - see AnnotatorsModal's own startRun. */
+  run: ReturnType<typeof useRunAnnotator>['run']
+  progress: RunAnnotatorProgress
+  isRunning: boolean
+  /** Whether a run has been kicked off at all - distinct from isRunning (flips back once
+   *  finished) and from progress.total (legitimately 0 when every sample was already
+   *  labeled), so this is the only reliable "show progress vs. show the mapping editor"
+   *  signal. See useRunAnnotator's own hasRun for why it isn't derived from progress. */
+  hasRun: boolean
+  /** Also used by the post-run "Done" button - returns to the annotator list rather than
+   *  closing the whole modal, so the user can run another annotator without reopening it. */
+  onBack: () => void
+}
+
+const AnnotatorRunStep: FC<AnnotatorRunStepProps> = ({
+  project,
+  samples,
+  annotator,
+  run,
+  progress,
+  isRunning,
+  hasRun,
+  onBack
+}) => {
+  const entry = useAnnotatorRuntime((s) => s.entries[annotator.id])
+  const setMapping = useAnnotatorRuntime((s) => s.setMapping)
+  const mapping = entry?.mappingByProjectId[project.id] ?? {}
+
+  // Fires exactly on a running -> finished transition, never on mount - wasRunning starts
+  // false regardless of whether a run was already under way when this component mounted,
+  // so an in-progress run finishing is the only thing that can flip it from true to false.
+  const wasRunning = useRef(false)
+  useEffect(() => {
+    if (wasRunning.current && !isRunning) {
+      toast.success(summarize(progress))
+    }
+    wasRunning.current = isRunning
+  }, [isRunning, progress])
+
+  const labels = entry?.labels ?? []
+
+  const percent = progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 100
+
+  if (hasRun) {
+    return (
+      <Stack gap="lg">
+        <Progress value={percent} animated={isRunning} />
+        <Text size="sm" c="dimmed" ta="center">
+          {isRunning ? `Labeling… ${progress.completed}/${progress.total}` : summarize(progress)}
+        </Text>
+        {progress.failures.length > 0 && !isRunning && (
+          <Stack gap={4}>
+            {progress.failures.map((failure) => (
+              <Text key={failure.sampleId} size="xs" c="red">
+                {failure.sampleName}: {failure.error}
+              </Text>
+            ))}
+          </Stack>
+        )}
+        <Group justify="flex-end">
+          <Button disabled={isRunning} onClick={onBack}>
+            Done
+          </Button>
+        </Group>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text size="sm" c="dimmed">
+        Runs against every sample in this set that has no annotations yet ({samples.length} sample
+        {samples.length === 1 ? '' : 's'} selected).
+      </Text>
+      <AnnotatorMappingFields
+        project={project}
+        labels={labels}
+        mapping={mapping}
+        onChangeMapping={(labelId, value) =>
+          setMapping(annotator.id, project.id, {
+            ...mapping,
+            [labelId]: value === IGNORE_VALUE ? null : value
+          })
+        }
+      />
+      <Group justify="flex-end">
+        <Button variant="outline" leftSection={<IoMdArrowBack />} onClick={onBack}>
+          Back
+        </Button>
+        <AsyncButton onClick={() => run(annotator, mapping, samples)}>Run</AsyncButton>
+      </Group>
+    </Stack>
+  )
+}
+
+export type AnnotatorsModalProps = {
+  opened: boolean
+  project: IProject
+  /** Only passed when there's something to run against - when absent, the modal is
+   *  management-only (no per-row Run action), e.g. ProjectsPage's context-menu entry.
+   *  Usually a single task (a samples-page run), but a batch run kicked off from the
+   *  Tasks page can pass several at once. */
+  tasks?: ITask[]
+  samples?: OptimisticSample[]
+  onClose: () => void
+}
+
+export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
+  opened,
+  project,
+  tasks,
+  samples,
+  onClose
+}) => {
+  const { items, isLoading, create, update, remove } = useAnnotators()
+  const activate = useAnnotatorRuntime((s) => s.activate)
+  const setMapping = useAnnotatorRuntime((s) => s.setMapping)
+  const forget = useAnnotatorRuntime((s) => s.forget)
+  // Owned here rather than by AnnotatorRunStep so a run whose mapping is already known can
+  // be kicked off directly from the click that decided that (see startRun below), instead
+  // of threading an "autoStart" flag through the Step union for a mount effect to interpret.
+  const taskIds = useMemo(() => tasks?.map((t) => t.id) ?? [], [tasks])
+  const { run, reset: resetRun, progress, isRunning, hasRun } = useRunAnnotator(taskIds)
+  const [step, setStep] = useState<Step>({ step: 'list' })
+  const [wasOpened, setWasOpened] = useState(opened)
+  const [pendingDelete, setPendingDelete] = useState<IAnnotator | null>(null)
+  // Only meaningful while step.step === 'edit' - read unconditionally (selector itself
+  // branches) since hooks can't be called conditionally.
+  const editRuntimeEntry = useAnnotatorRuntime((s) =>
+    step.step === 'edit' ? s.entries[step.annotator.id] : undefined
+  )
+
+  if (opened !== wasOpened) {
+    setWasOpened(opened)
+    if (opened) {
+      setStep({ step: 'list' })
+    }
+  }
+
+  const canRun = tasks !== undefined && tasks.length > 0 && samples !== undefined
+
+  const openForm = () => setStep({ step: 'form', name: '', url: '', headerRows: [] })
+
+  const headerRowsToRecord = (rows: HeaderRow[]): Record<string, string> =>
+    Object.fromEntries(
+      rows.filter((row) => row.key.trim().length > 0).map((row) => [row.key.trim(), row.value])
+    )
+
+  const connectFromForm = async () => {
+    if (step.step !== 'form') return
+    const name = step.name.trim()
+    const url = step.url.trim()
+    if (name.length === 0 || url.length === 0) {
+      toast.error('Name and URL are required')
+      return
+    }
+
+    const headers = headerRowsToRecord(step.headerRows)
+    try {
+      const labels = await connectToAnnotator(url, headers)
+      const id = await create(name, url, headers)
+      activate(id, labels)
+      setStep({ step: 'list' })
+    } catch (error) {
+      toast.error(errorToString(error))
+    }
+  }
+
+  /** Connects (if this annotator hasn't been activated yet this session) and seeds a
+   *  best-effort mapping for the current project (if one isn't already known) - shared by
+   *  the Run and settings/cog flows, which differ only in what they do once activated. */
+  const ensureActivated = async (annotator: IAnnotator): Promise<AnnotatorLabel[] | undefined> => {
+    let labels = useAnnotatorRuntime.getState().entries[annotator.id]?.labels
+    if (labels === undefined) {
+      try {
+        labels = await connectToAnnotator(annotator.url, annotator.headers)
+        activate(annotator.id, labels)
+      } catch (error) {
+        toast.error(errorToString(error))
+        return undefined
+      }
+    }
+
+    if (
+      useAnnotatorRuntime.getState().entries[annotator.id]?.mappingByProjectId[project.id] ===
+      undefined
+    ) {
+      setMapping(annotator.id, project.id, guessMapping(labels, project))
+    }
+
+    return labels
+  }
+
+  const startRun = async (annotator: IAnnotator) => {
+    if (tasks === undefined || tasks.length === 0 || samples === undefined) return
+
+    // Captured before ensureActivated seeds a fresh guess - only a mapping that was
+    // already known (not one just guessed by this very call) should skip the review step.
+    const hadMapping =
+      useAnnotatorRuntime.getState().entries[annotator.id]?.mappingByProjectId[project.id] !==
+      undefined
+
+    const labels = await ensureActivated(annotator)
+    if (labels === undefined) return
+
+    // Clears out whatever an earlier run in this same modal session left behind - run/
+    // progress/isRunning live in this component now, not remounted fresh per visit to the
+    // 'run' step, so a stale finished (or in-progress) state would otherwise leak into the
+    // next one, however it starts.
+    resetRun()
+    setStep({ step: 'run', annotator, samples })
+
+    if (hadMapping) {
+      // Not awaited on purpose: this only needs to kick the run off, the same way the
+      // manual "Run" button does - blocking here would keep the list row's own Run button
+      // spinning for the whole run instead of just the connect step above.
+      const mapping =
+        useAnnotatorRuntime.getState().entries[annotator.id]?.mappingByProjectId[project.id] ?? {}
+      void run(annotator, mapping, samples)
+    }
+  }
+
+  const openEdit = async (annotator: IAnnotator) => {
+    setStep({
+      step: 'edit',
+      annotator,
+      name: annotator.name,
+      url: annotator.url,
+      headerRows: Object.entries(annotator.headers).map(([key, value]) => ({
+        id: makeUUID(),
+        key,
+        value
+      }))
+    })
+    await ensureActivated(annotator)
+  }
+
+  const saveEdit = async () => {
+    if (step.step !== 'edit') return
+    const name = step.name.trim()
+    const url = step.url.trim()
+    if (name.length === 0 || url.length === 0) {
+      toast.error('Name and URL are required')
+      return
+    }
+
+    const headers = headerRowsToRecord(step.headerRows)
+    // A changed URL means a possibly different service - the cached labels/mapping for
+    // the old one are no longer trustworthy, so drop them and let the next Run/edit
+    // reconnect fresh.
+    if (url !== step.annotator.url) {
+      forget(step.annotator.id)
+    }
+    await update(step.annotator.id, name, url, headers)
+    setStep({ step: 'list' })
+  }
+
+  const listTitle = canRun ? 'Auto-label' : 'Manage Annotators'
+  const title =
+    step.step === 'form' ? 'Connect Annotator' : step.step === 'run' ? 'Auto-label' : listTitle
+
+  return (
+    <>
+      <ConfirmDeleteModal
+        opened={pendingDelete !== null}
+        entityName="annotator"
+        itemName={pendingDelete?.name}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => {
+          if (pendingDelete === null) return Promise.resolve()
+          const id = pendingDelete.id
+          return remove(id).then(() => forget(id))
+        }}
+      />
+      <Modal
+        opened={opened}
+        onClose={onClose}
+        title={title}
+        centered
+        closeOnClickOutside={false}
+        zIndex={ZIndex.actionModal}
+      >
+        {step.step === 'list' && (
+          <Stack gap="lg">
+            <Stack gap="xs">
+              {!isLoading && items.length === 0 && (
+                <Text c="dimmed" size="sm">
+                  No annotators configured yet.
+                </Text>
+              )}
+              {items.map((annotator) => (
+                <Group key={annotator.id} justify="space-between" wrap="nowrap">
+                  <Stack gap={0} style={{ minWidth: 0 }}>
+                    <Text fw={500} truncate>
+                      {annotator.name}
+                    </Text>
+                    <Text size="xs" c="dimmed" truncate>
+                      {annotator.url}
+                    </Text>
+                  </Stack>
+                  <Group gap="xs" wrap="nowrap">
+                    {canRun && (
+                      <AsyncButton size="xs" variant="outline" onClick={() => startRun(annotator)}>
+                        Run
+                      </AsyncButton>
+                    )}
+                    <ActionIcon
+                      aria-label={`Edit ${annotator.name}`}
+                      variant="subtle"
+                      onClick={() => openEdit(annotator)}
+                    >
+                      <MdSettings size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      aria-label={`Delete ${annotator.name}`}
+                      variant="subtle"
+                      color="red"
+                      onClick={() => setPendingDelete(annotator)}
+                    >
+                      <MdDeleteOutline size={16} />
+                    </ActionIcon>
+                  </Group>
+                </Group>
+              ))}
+            </Stack>
+            <Group justify="space-between">
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+              <Button leftSection={<MdAdd />} onClick={openForm}>
+                Add Annotator
+              </Button>
+            </Group>
+          </Stack>
+        )}
+
+        {step.step === 'form' && (
+          <Stack gap="lg">
+            <AnnotatorFormFields
+              value={step}
+              onChange={(next) => setStep({ step: 'form', ...next })}
+            />
+            <Group justify="flex-end">
+              <Button
+                variant="outline"
+                leftSection={<IoMdArrowBack />}
+                onClick={() => setStep({ step: 'list' })}
+              >
+                Back
+              </Button>
+              <AsyncButton onClick={connectFromForm}>Connect</AsyncButton>
+            </Group>
+          </Stack>
+        )}
+
+        {step.step === 'run' && (
+          <AnnotatorRunStep
+            project={project}
+            samples={step.samples}
+            annotator={step.annotator}
+            run={run}
+            progress={progress}
+            isRunning={isRunning}
+            hasRun={hasRun}
+            onBack={() => setStep({ step: 'list' })}
+          />
+        )}
+
+        {step.step === 'edit' && (
+          <Stack gap="lg">
+            <AnnotatorFormFields
+              value={step}
+              onChange={(next) => setStep({ step: 'edit', annotator: step.annotator, ...next })}
+            />
+            <AnnotatorMappingFields
+              project={project}
+              labels={editRuntimeEntry?.labels ?? []}
+              mapping={editRuntimeEntry?.mappingByProjectId[project.id] ?? {}}
+              onChangeMapping={(labelId, value) =>
+                setMapping(step.annotator.id, project.id, {
+                  ...(editRuntimeEntry?.mappingByProjectId[project.id] ?? {}),
+                  [labelId]: value === IGNORE_VALUE ? null : value
+                })
+              }
+            />
+            <Group justify="flex-end">
+              <Button
+                variant="outline"
+                leftSection={<IoMdArrowBack />}
+                onClick={() => setStep({ step: 'list' })}
+              >
+                Back
+              </Button>
+              <AsyncButton onClick={saveEdit}>Save</AsyncButton>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </>
+  )
+}

--- a/src/renderer/src/components/annotators/__tests__/AnnotatorsModal.test.tsx
+++ b/src/renderer/src/components/annotators/__tests__/AnnotatorsModal.test.tsx
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { AnnotationType, IAnnotation, IProject, ISample, ITask, TrainingSplit } from '@shared/types'
+import { OptimisticObject } from '@renderer/util/optimistic_object'
+import { OptimisticSample } from '@renderer/types'
+import { useAnnotatorRuntime } from '@renderer/hooks/useAnnotatorRuntime'
+
+const {
+  getAnnotators,
+  createAnnotator,
+  updateAnnotators,
+  deleteAnnotators,
+  connectToAnnotator,
+  runAnnotatorOnSample,
+  createAnnotations
+} = vi.hoisted(() => ({
+  getAnnotators: vi.fn(),
+  createAnnotator: vi.fn(),
+  updateAnnotators: vi.fn(),
+  deleteAnnotators: vi.fn(),
+  connectToAnnotator: vi.fn(),
+  runAnnotatorOnSample: vi.fn(),
+  createAnnotations: vi.fn()
+}))
+
+vi.mock('@renderer/api/ExternalAnnotator', () => ({ connectToAnnotator, runAnnotatorOnSample }))
+
+vi.mock('@renderer/hooks/useAppStore', async () => {
+  const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
+  const store = { ...createMockDataStore(), createAnnotations }
+  const state = { store }
+  const useAppStore = Object.assign((selector: (s: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+  return { useAppStore }
+})
+
+import { AnnotatorsModal } from '../AnnotatorsModal'
+
+const project: IProject = {
+  id: 'p1',
+  name: 'Street Signs',
+  labels: [
+    { id: 'l1', name: 'Person', color: '#ff0000' },
+    { id: 'l2', name: 'Car', color: '#00ff00' }
+  ]
+}
+const task: ITask = { id: 't1', name: 'Batch 1' }
+
+const annotatorA = { id: 'a1', name: 'Model A', url: 'https://example.com/a', headers: {} }
+const annotatorB = { id: 'a2', name: 'Model B', url: 'https://example.com/b', headers: {} }
+
+const makeSample = (id: string): OptimisticSample => {
+  const base: ISample = {
+    id,
+    name: id,
+    imageUri: `image://local/${id}.png`,
+    split: TrainingSplit.Train,
+    width: 100,
+    height: 100,
+    annotations: [],
+    completedAt: null,
+    createdAt: new Date().toISOString()
+  }
+  return new OptimisticObject({
+    ...base,
+    annotations: new OptimisticObject({}, true)
+  })
+}
+
+beforeEach(() => {
+  getAnnotators.mockReset().mockResolvedValue([])
+  createAnnotator.mockReset().mockResolvedValue(undefined)
+  updateAnnotators.mockReset().mockResolvedValue([])
+  deleteAnnotators.mockReset().mockResolvedValue([true])
+  connectToAnnotator.mockReset()
+  runAnnotatorOnSample.mockReset()
+  createAnnotations.mockReset().mockResolvedValue([])
+  window.appStore = {
+    getAnnotators,
+    createAnnotator,
+    updateAnnotators,
+    deleteAnnotators
+  } as unknown as typeof window.appStore
+  useAnnotatorRuntime.setState({ entries: {} })
+})
+
+describe('AnnotatorsModal', () => {
+  it('connects and saves a new global annotator (no projectId or mapping persisted)', async () => {
+    connectToAnnotator.mockResolvedValue([{ id: '0', name: 'person' }])
+
+    renderWithProviders(<AnnotatorsModal opened project={project} onClose={vi.fn()} />)
+
+    await screen.findByText('No annotators configured yet.')
+    fireEvent.click(screen.getByRole('button', { name: 'Add Annotator' }))
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'My Model' } })
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://example.com/model' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    await waitFor(() => expect(createAnnotator).toHaveBeenCalledTimes(1))
+    expect(createAnnotator).toHaveBeenCalledWith(
+      expect.any(String),
+      'My Model',
+      'https://example.com/model',
+      {}
+    )
+  })
+
+  it('shows an error and stays on the form when connecting fails', async () => {
+    connectToAnnotator.mockRejectedValue(new Error('network down'))
+
+    renderWithProviders(<AnnotatorsModal opened project={project} onClose={vi.fn()} />)
+
+    await screen.findByText('No annotators configured yet.')
+    fireEvent.click(screen.getByRole('button', { name: 'Add Annotator' }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'My Model' } })
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'https://example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    await waitFor(() => expect(connectToAnnotator).toHaveBeenCalled())
+    expect(screen.getByLabelText('URL')).toBeInTheDocument()
+    expect(createAnnotator).not.toHaveBeenCalled()
+  })
+
+  it('deletes an annotator after confirming', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+
+    renderWithProviders(<AnnotatorsModal opened project={project} onClose={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Model A' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deleteAnnotators).toHaveBeenCalledWith(['a1']))
+  })
+
+  it('opens the settings screen prefilled, connects for the mapping, and saves edits', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+    connectToAnnotator.mockResolvedValue([{ id: '0', name: 'person' }])
+
+    renderWithProviders(<AnnotatorsModal opened project={project} onClose={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit Model A' }))
+
+    expect(screen.getByLabelText('Name')).toHaveValue('Model A')
+    expect(screen.getByLabelText('URL')).toHaveValue('https://example.com/a')
+    // The mapping editor connects using the still-unchanged url/headers, same as Run does.
+    await waitFor(() =>
+      expect(connectToAnnotator).toHaveBeenCalledWith('https://example.com/a', {})
+    )
+    await screen.findByText('person')
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Model' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateAnnotators).toHaveBeenCalledWith([
+        { id: 'a1', name: 'Renamed Model', url: 'https://example.com/a', headers: {} }
+      ])
+    )
+  })
+
+  it('forgets the cached activation when the URL is changed on save', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+    connectToAnnotator.mockResolvedValue([])
+
+    renderWithProviders(
+      <AnnotatorsModal
+        opened
+        project={project}
+        tasks={[task]}
+        samples={[makeSample('s1')]}
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit Model A' }))
+    await waitFor(() => expect(connectToAnnotator).toHaveBeenCalledTimes(1))
+
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://example.com/a-new' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(updateAnnotators).toHaveBeenCalledTimes(1))
+
+    // Back on the list - Running now reconnects, since the cached activation was for the
+    // old URL.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+    await waitFor(() => expect(connectToAnnotator).toHaveBeenCalledTimes(2))
+    expect(connectToAnnotator).toHaveBeenLastCalledWith('https://example.com/a', {})
+  })
+
+  it('hides the Run action when no task/samples are given (management-only usage)', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+
+    renderWithProviders(<AnnotatorsModal opened project={project} onClose={vi.fn()} />)
+
+    await screen.findByText('Model A')
+    expect(screen.queryByRole('button', { name: 'Run' })).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Manage Annotators' })).toBeInTheDocument()
+  })
+
+  it('connects and guesses a mapping by name before running', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+    connectToAnnotator.mockResolvedValue([
+      { id: '0', name: 'person' },
+      { id: '1', name: 'bicycle' }
+    ])
+    runAnnotatorOnSample.mockResolvedValue({
+      annotations: [{ id: 'ann1', type: AnnotationType.Box, labelId: 'l1', points: [] }],
+      skipped: 0
+    })
+
+    renderWithProviders(
+      <AnnotatorsModal
+        opened
+        project={project}
+        tasks={[task]}
+        samples={[makeSample('s1')]}
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+
+    await screen.findByText('person')
+    expect(connectToAnnotator).toHaveBeenCalledWith('https://example.com/a', {})
+    // "person" auto-guesses to the same-named project label; "bicycle" has no match so it
+    // defaults to Ignore.
+    expect(screen.getByDisplayValue('Person')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Ignore')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() =>
+      expect(runAnnotatorOnSample).toHaveBeenCalledWith(
+        annotatorA,
+        { '0': 'l1', '1': null },
+        expect.objectContaining({ id: 's1' })
+      )
+    )
+    expect(await screen.findByText(/1 annotation added/)).toBeInTheDocument()
+  })
+
+  it('skips samples that already have annotations and reports them separately', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+    connectToAnnotator.mockResolvedValue([])
+
+    const labeled = makeSample('labeled')
+    labeled.resolve().annotations.update({
+      ann1: new OptimisticObject<IAnnotation>({
+        id: 'ann1',
+        type: AnnotationType.Box,
+        labelId: 'l1',
+        points: []
+      })
+    })
+
+    renderWithProviders(
+      <AnnotatorsModal
+        opened
+        project={project}
+        tasks={[task]}
+        samples={[labeled]}
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+    await screen.findByRole('button', { name: 'Back' })
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    expect(await screen.findByText(/1 already labeled/)).toBeInTheDocument()
+    expect(runAnnotatorOnSample).not.toHaveBeenCalled()
+  })
+
+  it('runs a specific annotator among several without touching the others', async () => {
+    getAnnotators.mockResolvedValue([annotatorA, annotatorB])
+    connectToAnnotator.mockResolvedValue([])
+    runAnnotatorOnSample.mockResolvedValue({ annotations: [], skipped: 0 })
+
+    renderWithProviders(
+      <AnnotatorsModal
+        opened
+        project={project}
+        tasks={[task]}
+        samples={[makeSample('s1')]}
+        onClose={vi.fn()}
+      />
+    )
+
+    await screen.findByText('Model B')
+    const runButtons = screen.getAllByRole('button', { name: 'Run' })
+    fireEvent.click(runButtons[1])
+
+    await screen.findByRole('button', { name: 'Back' })
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() =>
+      expect(runAnnotatorOnSample).toHaveBeenCalledWith(annotatorB, {}, expect.anything())
+    )
+    expect(connectToAnnotator).toHaveBeenCalledWith('https://example.com/b', {})
+    expect(connectToAnnotator).not.toHaveBeenCalledWith('https://example.com/a', {})
+  })
+
+  it('reuses a previously activated annotator without reconnecting, keeping the remap', async () => {
+    getAnnotators.mockResolvedValue([annotatorA])
+    connectToAnnotator.mockResolvedValue([{ id: '0', name: 'truck' }])
+    runAnnotatorOnSample.mockResolvedValue({ annotations: [], skipped: 0 })
+
+    renderWithProviders(
+      <AnnotatorsModal
+        opened
+        project={project}
+        tasks={[task]}
+        samples={[makeSample('s1')]}
+        onClose={vi.fn()}
+      />
+    )
+
+    // First run: connects, remaps "truck" (no name match) from Ignore to Car.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+    await screen.findByText('truck')
+    expect(connectToAnnotator).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByDisplayValue('Ignore'))
+    fireEvent.click(await screen.findByText('Car'))
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+    await waitFor(() => expect(runAnnotatorOnSample).toHaveBeenCalledTimes(1))
+
+    // Back to the list, run the same annotator again - since a mapping is already known
+    // for this project, it skips the review screen entirely and runs immediately, reusing
+    // the remap from the first run (no second connect either).
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+
+    expect(screen.queryByDisplayValue('Car')).not.toBeInTheDocument()
+    await waitFor(() => expect(runAnnotatorOnSample).toHaveBeenCalledTimes(2))
+    expect(runAnnotatorOnSample).toHaveBeenLastCalledWith(
+      annotatorA,
+      { '0': 'l2' },
+      expect.anything()
+    )
+    expect(connectToAnnotator).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/labeler/createPolygonTool.ts
+++ b/src/renderer/src/components/labeler/createPolygonTool.ts
@@ -1,6 +1,6 @@
 import { PointerResult, type LabelerTool } from './types'
 
-export const createMaskTool: LabelerTool = {
+export const createPolygonTool: LabelerTool = {
   onPointerDown(ctx, pos) {
     ctx.store.getState().onConfirmPoint(pos.x, pos.y)
     return PointerResult.Consumed

--- a/src/renderer/src/components/labeler/selectTool.ts
+++ b/src/renderer/src/components/labeler/selectTool.ts
@@ -1,4 +1,5 @@
 import { clamp } from '@mantine/hooks'
+import { AnnotationType } from '@shared/types'
 import { PointerResult, type LabelerTool } from './types'
 
 const MAX_BITMAP_COORDINATE = 9_000_000
@@ -32,7 +33,13 @@ export const selectTool: LabelerTool = {
 
     let controlPointId = hit.controlPointId
     if (hit.lineControlPointId !== null) {
-      controlPointId = state.addControlPoint(hit.lineControlPointId, pos.x, pos.y) ?? null
+      // A Box only ever has 2 real points - its "lines" are edges, draggable to resize
+      // rather than a place to insert a new point (unlike a Polygon's lines).
+      if (state.selectedAnnotation.resolve().type === AnnotationType.Box) {
+        controlPointId = hit.lineControlPointId
+      } else {
+        controlPointId = state.addControlPoint(hit.lineControlPointId, pos.x, pos.y) ?? null
+      }
     }
 
     // Move a single control point.

--- a/src/renderer/src/components/labeler/tools.ts
+++ b/src/renderer/src/components/labeler/tools.ts
@@ -2,12 +2,12 @@ import { LabelerMode } from '@renderer/types'
 import type { LabelerTool } from './types'
 import { selectTool } from './selectTool'
 import { createBoxTool } from './createBoxTool'
-import { createMaskTool } from './createMaskTool'
+import { createPolygonTool } from './createPolygonTool'
 
 export const tools: Record<LabelerMode, LabelerTool> = {
   [LabelerMode.Select]: selectTool,
   [LabelerMode.CreateBox]: createBoxTool,
-  [LabelerMode.CreateMask]: createMaskTool
+  [LabelerMode.CreatePolygon]: createPolygonTool
 }
 
 export { PointerResult } from './types'

--- a/src/renderer/src/components/sampleIO/LabelMapper.tsx
+++ b/src/renderer/src/components/sampleIO/LabelMapper.tsx
@@ -1,0 +1,60 @@
+import { Group, ScrollArea, Select, Stack, Text } from '@mantine/core'
+import type { ILabel } from '@shared/types'
+import { ZIndex } from '@renderer/zIndex'
+
+const EXCLUDE_VALUE = '__exclude__'
+
+export type LabelMapperProps<K extends string | number> = {
+  /** Rows to map - a source class/label for importers, or the project's own labels for
+   *  exporters (where `items` and `options` are the same list). */
+  items: { id: K; name: string }[]
+  /** Selectable mapping targets - always the project's labels. */
+  options: ILabel[]
+  /** `null` means the item is explicitly excluded; an item absent from the map means no
+   *  choice has been made yet (only meaningful where there's no auto-fill default). */
+  mapping: Map<K, string | null>
+  onChange: (id: K, target: string | null) => void
+  /** Label for the "don't include this" option - importers use the default "Ignore",
+   *  exporters pass "Don't Export". */
+  excludeLabel?: string
+  disabled?: boolean
+}
+
+/** One `Text` + `Select` row per item, letting each be mapped to one of `options` or
+ *  excluded entirely. Shared by every importer (source class -> project label) and
+ *  exporter (project label -> itself, another label to merge into, or excluded). */
+export const LabelMapper = <K extends string | number>({
+  items,
+  options,
+  mapping,
+  onChange,
+  excludeLabel = 'Ignore',
+  disabled
+}: LabelMapperProps<K>) => (
+  <ScrollArea style={{ maxHeight: 260 }} type="always" scrollbars="y">
+    <Stack gap="sm">
+      {items.map((item) => (
+        <Group key={item.id} wrap="nowrap">
+          <Text size="sm" flex={1} truncate>
+            {item.name}
+          </Text>
+          <Select
+            flex={1}
+            data={[
+              { value: EXCLUDE_VALUE, label: excludeLabel },
+              ...options.map((label) => ({ value: label.id, label: label.name }))
+            ]}
+            value={mapping.get(item.id) ?? EXCLUDE_VALUE}
+            onChange={(value) => onChange(item.id, value === EXCLUDE_VALUE ? null : value)}
+            // These importers/exporters all live inside a modal - without an explicit
+            // zIndex above the modal's own, this dropdown renders behind the modal body
+            // and can't be clicked.
+            comboboxProps={{ zIndex: ZIndex.actionModalContent }}
+            disabled={disabled}
+            allowDeselect={false}
+          />
+        </Group>
+      ))}
+    </Stack>
+  </ScrollArea>
+)

--- a/src/renderer/src/components/sampleIO/__tests__/LabelMapper.test.tsx
+++ b/src/renderer/src/components/sampleIO/__tests__/LabelMapper.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { ILabel } from '@shared/types'
+import { LabelMapper } from '../LabelMapper'
+
+const options: ILabel[] = [
+  { id: 'l1', name: 'Person', color: '#ff0000' },
+  { id: 'l2', name: 'Car', color: '#00ff00' }
+]
+
+describe('LabelMapper', () => {
+  it('renders one row per item, showing its currently mapped target', () => {
+    renderWithProviders(
+      <LabelMapper
+        items={[
+          { id: 1, name: 'person' },
+          { id: 2, name: 'car' }
+        ]}
+        options={options}
+        mapping={
+          new Map([
+            [1, 'l1'],
+            [2, 'l2']
+          ])
+        }
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('person')).toBeInTheDocument()
+    expect(screen.getByText('car')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Person')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Car')).toBeInTheDocument()
+  })
+
+  it('defaults an unmapped item to the exclude option', () => {
+    renderWithProviders(
+      <LabelMapper
+        items={[{ id: 1, name: 'truck' }]}
+        options={options}
+        mapping={new Map()}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue('Ignore')).toBeInTheDocument()
+  })
+
+  it('uses a custom exclude label when provided', () => {
+    renderWithProviders(
+      <LabelMapper
+        items={[{ id: 1, name: 'Person' }]}
+        options={options}
+        mapping={new Map()}
+        onChange={vi.fn()}
+        excludeLabel="Don't Export"
+      />
+    )
+
+    expect(screen.getByDisplayValue("Don't Export")).toBeInTheDocument()
+  })
+
+  it('reports null when the exclude option is chosen', () => {
+    const onChange = vi.fn()
+    renderWithProviders(
+      <LabelMapper
+        items={[{ id: 1, name: 'person' }]}
+        options={options}
+        mapping={new Map([[1, 'l1']])}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Person'))
+    fireEvent.click(screen.getByText('Ignore'))
+
+    expect(onChange).toHaveBeenCalledWith(1, null)
+  })
+
+  it('reports the target id when a real option is chosen', () => {
+    const onChange = vi.fn()
+    renderWithProviders(
+      <LabelMapper
+        items={[{ id: 1, name: 'person' }]}
+        options={options}
+        mapping={new Map()}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Ignore'))
+    fireEvent.click(screen.getByText('Car'))
+
+    expect(onChange).toHaveBeenCalledWith(1, 'l2')
+  })
+})

--- a/src/renderer/src/components/sampleIO/exporters/__tests__/annotationShape.test.ts
+++ b/src/renderer/src/components/sampleIO/exporters/__tests__/annotationShape.test.ts
@@ -34,8 +34,8 @@ describe('exportShapePoints', () => {
       { id: 'p1', x: 300, y: 150 }
     ]
   }
-  const mask: Pick<IAnnotation, 'type' | 'points'> = {
-    type: AnnotationType.Mask,
+  const polygon: Pick<IAnnotation, 'type' | 'points'> = {
+    type: AnnotationType.Polygon,
     points: [
       { id: 'p0', x: 0, y: 0 },
       { id: 'p1', x: 10, y: 0 },
@@ -43,14 +43,14 @@ describe('exportShapePoints', () => {
     ]
   }
 
-  it('in Box mode, flattens both Box and Mask annotations to their bounding rectangle corners', () => {
+  it('in Box mode, flattens both Box and Polygon annotations to their bounding rectangle corners', () => {
     expect(exportShapePoints(box, ExportShape.Box)).toEqual([
       { x: 100, y: 50 },
       { x: 300, y: 50 },
       { x: 300, y: 150 },
       { x: 100, y: 150 }
     ])
-    expect(exportShapePoints(mask, ExportShape.Box)).toEqual([
+    expect(exportShapePoints(polygon, ExportShape.Box)).toEqual([
       { x: 0, y: 0 },
       { x: 10, y: 0 },
       { x: 10, y: 10 },
@@ -58,8 +58,8 @@ describe('exportShapePoints', () => {
     ])
   })
 
-  it('in Segment mode, keeps a Mask real outline but still boxes a Box (it has no other shape)', () => {
-    expect(exportShapePoints(mask, ExportShape.Segment)).toBe(mask.points)
+  it('in Segment mode, keeps a Polygon real outline but still boxes a Box (it has no other shape)', () => {
+    expect(exportShapePoints(polygon, ExportShape.Segment)).toBe(polygon.points)
     expect(exportShapePoints(box, ExportShape.Segment)).toEqual([
       { x: 100, y: 50 },
       { x: 300, y: 50 },

--- a/src/renderer/src/components/sampleIO/exporters/__tests__/exportBaseName.test.ts
+++ b/src/renderer/src/components/sampleIO/exporters/__tests__/exportBaseName.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { IProject, ITask } from '@shared/types'
+import { exportBaseName } from '../exportBaseName'
+
+const project: IProject = { id: 'p1', name: 'Street Signs', labels: [] }
+
+describe('exportBaseName', () => {
+  it("uses the task's own name when exporting a single task", () => {
+    const tasks: ITask[] = [{ id: 't1', name: 'Batch 1' }]
+
+    expect(exportBaseName(project, tasks)).toBe('Batch 1')
+  })
+
+  it('falls back to the project name when exporting more than one task', () => {
+    const tasks: ITask[] = [
+      { id: 't1', name: 'Batch 1' },
+      { id: 't2', name: 'Batch 2' }
+    ]
+
+    expect(exportBaseName(project, tasks)).toBe('Street Signs')
+  })
+
+  it('falls back to the project name when exporting zero tasks', () => {
+    expect(exportBaseName(project, [])).toBe('Street Signs')
+  })
+})

--- a/src/renderer/src/components/sampleIO/exporters/__tests__/labelRouting.test.ts
+++ b/src/renderer/src/components/sampleIO/exporters/__tests__/labelRouting.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { ILabel } from '@shared/types'
+import { buildIncludedLabelsAndIndex } from '../labelRouting'
+
+const labels: ILabel[] = [
+  { id: 'l1', name: 'Person', color: '#ff0000' },
+  { id: 'l2', name: 'Car', color: '#00ff00' },
+  { id: 'l3', name: 'Truck', color: '#0000ff' }
+]
+
+describe('buildIncludedLabelsAndIndex', () => {
+  it('identity mapping keeps every label, each at its own index', () => {
+    const mapping = new Map(labels.map((l) => [l.id, l.id]))
+    const { includedLabels, labelIdToIndex } = buildIncludedLabelsAndIndex(labels, mapping)
+
+    expect(includedLabels).toEqual(labels)
+    expect(Object.fromEntries(labelIdToIndex)).toEqual({ l1: 0, l2: 1, l3: 2 })
+  })
+
+  it('a label mapped to null is excluded and dropped from routing', () => {
+    const mapping = new Map([
+      ['l1', 'l1'],
+      ['l2', null],
+      ['l3', 'l3']
+    ])
+    const { includedLabels, labelIdToIndex } = buildIncludedLabelsAndIndex(labels, mapping)
+
+    expect(includedLabels.map((l) => l.id)).toEqual(['l1', 'l3'])
+    expect(labelIdToIndex.has('l2')).toBe(false)
+    expect(labelIdToIndex.get('l1')).toBe(0)
+    expect(labelIdToIndex.get('l3')).toBe(1)
+  })
+
+  it('two labels mapped to the same target merge into one included label and index', () => {
+    const mapping = new Map([
+      ['l1', 'l2'],
+      ['l2', 'l2'],
+      ['l3', null]
+    ])
+    const { includedLabels, labelIdToIndex } = buildIncludedLabelsAndIndex(labels, mapping)
+
+    expect(includedLabels.map((l) => l.id)).toEqual(['l2'])
+    expect(labelIdToIndex.get('l1')).toBe(0)
+    expect(labelIdToIndex.get('l2')).toBe(0)
+    expect(labelIdToIndex.has('l3')).toBe(false)
+  })
+
+  it('a source label absent from the mapping is treated as excluded', () => {
+    const mapping = new Map([['l1', 'l1']])
+    const { includedLabels, labelIdToIndex } = buildIncludedLabelsAndIndex(labels, mapping)
+
+    expect(includedLabels.map((l) => l.id)).toEqual(['l1'])
+    expect(labelIdToIndex.has('l2')).toBe(false)
+    expect(labelIdToIndex.has('l3')).toBe(false)
+  })
+
+  it('preserves the original labels order in includedLabels regardless of mapping insertion order', () => {
+    const mapping = new Map([
+      ['l3', 'l3'],
+      ['l1', 'l1']
+    ])
+    const { includedLabels } = buildIncludedLabelsAndIndex(labels, mapping)
+
+    expect(includedLabels.map((l) => l.id)).toEqual(['l1', 'l3'])
+  })
+})

--- a/src/renderer/src/components/sampleIO/exporters/annotationShape.ts
+++ b/src/renderer/src/components/sampleIO/exporters/annotationShape.ts
@@ -41,15 +41,15 @@ const rectangleCorners = (box: BoundingBox): { x: number; y: number }[] => [
 ]
 
 /** The polygon to export for an annotation under the given shape mode. In Segment mode a
- *  Mask keeps its real outline and a Box becomes its own 4 corners (a box has no shape
- *  beyond its rectangle). In Box mode every annotation - Mask included - is flattened to
- *  its bounding rectangle's corners, discarding a Mask's actual outline. Either way every
- *  annotation produces a usable shape, unlike formats that can only carry one kind. */
+ *  Polygon keeps its real outline and a Box becomes its own 4 corners (a box has no shape
+ *  beyond its rectangle). In Box mode every annotation - Polygon included - is flattened
+ *  to its bounding rectangle's corners, discarding a Polygon's actual outline. Either way
+ *  every annotation produces a usable shape, unlike formats that can only carry one kind. */
 export const exportShapePoints = (
   annotation: Pick<IAnnotation, 'type' | 'points'>,
   shape: ExportShape
 ): { x: number; y: number }[] => {
-  if (shape === ExportShape.Segment && annotation.type === AnnotationType.Mask) {
+  if (shape === ExportShape.Segment && annotation.type === AnnotationType.Polygon) {
     return annotation.points
   }
   return rectangleCorners(boundingBoxOf(annotation.points))

--- a/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
@@ -6,7 +6,10 @@ import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { ArchiveManifest, ISample } from '@shared/types'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
+import { exportBaseName } from '../exportBaseName'
 import { LabeledSegmentedControl } from '../../LabeledSegmentedControl'
+import { LabelMapper } from '../../LabelMapper'
+import { buildIncludedLabelsAndIndex } from '../labelRouting'
 import {
   buildCocoAnnotations,
   buildCocoCategories,
@@ -39,6 +42,9 @@ export const CocoExporterComponent = ({
   const [phase, setPhase] = useState<ExportPhase>('preparing')
   const [progress, setProgress] = useState(0)
   const [shape, setShape] = useState<CocoShapeMode>(CocoShapeMode.Native)
+  const [mapping, setMapping] = useState<Map<string, string | null>>(
+    new Map(project.labels.map((label) => [label.id, label.id]))
+  )
 
   useEffect(
     () =>
@@ -52,8 +58,14 @@ export const CocoExporterComponent = ({
     setPhase('preparing')
     setProgress(0)
     try {
-      const labelIdToCategoryId = new Map(project.labels.map((label, i) => [label.id, i + 1]))
-      const categories = buildCocoCategories(project.labels)
+      const { includedLabels, labelIdToIndex } = buildIncludedLabelsAndIndex(
+        project.labels,
+        mapping
+      )
+      const categories = buildCocoCategories(includedLabels)
+      const labelIdToCategoryId = new Map(
+        [...labelIdToIndex].map(([labelId, index]) => [labelId, index + 1])
+      )
 
       const samplesByTask = await Promise.all(tasks.map((task) => getSamplesForTask(task.id)))
       const samples = samplesByTask.flat()
@@ -104,7 +116,10 @@ export const CocoExporterComponent = ({
       }
 
       setPhase('exporting')
-      const saved = await window.exportApi.runExport(`${project.name}-coco-export.zip`, manifest)
+      const saved = await window.exportApi.runExport(
+        `${exportBaseName(project, tasks)}-coco-export.zip`,
+        manifest
+      )
 
       if (saved) {
         onComplete()
@@ -121,13 +136,21 @@ export const CocoExporterComponent = ({
         Exports {tasks.length} task{tasks.length === 1 ? '' : 's'} as a COCO-format zip, split into
         train/valid/test folders, each with its own images and <code>_annotations.coco.json</code>.
         Every annotation always gets a bbox; choose whether its segmentation is forced to boxes,
-        forced to polygons, or left as-is (a plain Box has none, a Mask keeps its real outline).
+        forced to polygons, or left as-is (a plain Box has none, a Polygon keeps its real outline).
       </Text>
       <LabeledSegmentedControl
         label="Shape"
         value={shape}
         options={COCO_SHAPE_OPTIONS}
         onChange={setShape}
+        disabled={isExporting}
+      />
+      <LabelMapper
+        items={project.labels}
+        options={project.labels}
+        mapping={mapping}
+        onChange={(id, value) => setMapping((current) => new Map(current).set(id, value))}
+        excludeLabel="Don't Export"
         disabled={isExporting}
       />
       {isExporting && (

--- a/src/renderer/src/components/sampleIO/exporters/coco/__tests__/CocoExporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/coco/__tests__/CocoExporterComponent.test.tsx
@@ -69,7 +69,8 @@ describe('CocoExporterComponent', () => {
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
     expect(runExport).toHaveBeenCalledTimes(1)
     const [suggestedName, manifest] = runExport.mock.calls[0]
-    expect(suggestedName).toBe('Street Signs-coco-export.zip')
+    // A single task exported alone suggests that task's own name, not the project's.
+    expect(suggestedName).toBe('Batch 1-coco-export.zip')
     expect(manifest.imageEntries).toEqual([
       { path: 'train/s1.jpg', imageUri: 'cv-label-image://s1.jpg' }
     ])
@@ -92,6 +93,27 @@ describe('CocoExporterComponent', () => {
       ],
       categories: [{ id: 1, name: 'Stop Sign', supercategory: 'none' }]
     })
+  })
+
+  it('suggests the project name when exporting more than one task', async () => {
+    const onComplete = vi.fn()
+    const multipleTasks: ITask[] = [...tasks, { id: 't2', name: 'Batch 2' }]
+
+    renderWithProviders(
+      <CocoExporterComponent
+        project={project}
+        tasks={multipleTasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([sample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const [suggestedName] = runExport.mock.calls[0]
+    expect(suggestedName).toBe('Street Signs-coco-export.zip')
   })
 
   it('switches to Segments and gives a plain Box a synthesized rectangular segmentation', async () => {
@@ -120,13 +142,13 @@ describe('CocoExporterComponent', () => {
     expect(annotations[0].segmentation).toEqual([[10, 20, 110, 20, 110, 70, 10, 70]])
   })
 
-  it("switches to Bounding Boxes and discards a Mask annotation's real outline", async () => {
-    const maskSample: ISample = {
+  it("switches to Bounding Boxes and discards a Polygon annotation's real outline", async () => {
+    const polygonSample: ISample = {
       ...sample,
       annotations: [
         {
           id: 'a1',
-          type: AnnotationType.Mask,
+          type: AnnotationType.Polygon,
           labelId: 'l1',
           points: [
             { id: 'p0', x: 0, y: 0 },
@@ -142,7 +164,7 @@ describe('CocoExporterComponent', () => {
       <CocoExporterComponent
         project={project}
         tasks={tasks}
-        getSamplesForTask={vi.fn().mockResolvedValue([maskSample])}
+        getSamplesForTask={vi.fn().mockResolvedValue([polygonSample])}
         onComplete={onComplete}
         onCancel={vi.fn()}
       />
@@ -160,6 +182,113 @@ describe('CocoExporterComponent', () => {
 
     expect(annotations[0].bbox).toEqual([0, 0, 20, 10])
     expect(annotations[0].segmentation).toEqual([])
+  })
+
+  it("excludes a label marked Don't Export: its annotations and category are dropped, the image stays", async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        {
+          id: 'a2',
+          type: AnnotationType.Box,
+          labelId: 'l2',
+          points: [
+            { id: 'p2', x: 0, y: 0 },
+            { id: 'p3', x: 5, y: 5 }
+          ]
+        }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <CocoExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: "Don't Export" }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    expect(manifest.imageEntries).toEqual([
+      { path: 'train/s1.jpg', imageUri: 'cv-label-image://s1.jpg' }
+    ])
+    const { annotations, categories } = JSON.parse(
+      manifest.textEntries.find((e: { path: string }) => e.path === 'train/_annotations.coco.json')
+        .content
+    )
+    expect(categories).toEqual([{ id: 1, name: 'Stop Sign', supercategory: 'none' }])
+    expect(annotations).toHaveLength(1)
+    expect(annotations[0].category_id).toBe(1)
+  })
+
+  it('merges one label into another: both end up under a single category', async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        {
+          id: 'a2',
+          type: AnnotationType.Box,
+          labelId: 'l2',
+          points: [
+            { id: 'p2', x: 0, y: 0 },
+            { id: 'p3', x: 5, y: 5 }
+          ]
+        }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <CocoExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: 'Stop Sign' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    const { annotations, categories } = JSON.parse(
+      manifest.textEntries.find((e: { path: string }) => e.path === 'train/_annotations.coco.json')
+        .content
+    )
+    expect(categories).toEqual([{ id: 1, name: 'Stop Sign', supercategory: 'none' }])
+    expect(annotations).toHaveLength(2)
+    expect(annotations.every((a: { category_id: number }) => a.category_id === 1)).toBe(true)
   })
 
   it('does not call onComplete when the user cancels the save dialog', async () => {

--- a/src/renderer/src/components/sampleIO/exporters/coco/__tests__/buildCoco.test.ts
+++ b/src/renderer/src/components/sampleIO/exporters/coco/__tests__/buildCoco.test.ts
@@ -37,7 +37,7 @@ describe('buildCocoAnnotations', () => {
     { id: 'p0', x: 10, y: 20 },
     { id: 'p1', x: 110, y: 70 }
   ])
-  const mask = makeAnnotation(AnnotationType.Mask, 'l1', [
+  const polygon = makeAnnotation(AnnotationType.Polygon, 'l1', [
     { id: 'p0', x: 0, y: 0 },
     { id: 'p1', x: 20, y: 0 },
     { id: 'p2', x: 20, y: 10 },
@@ -67,9 +67,9 @@ describe('buildCocoAnnotations', () => {
       ])
     })
 
-    it('keeps a Mask annotation as its own polygon, deriving bbox and area from it', () => {
+    it('keeps a Polygon annotation as its own polygon, deriving bbox and area from it', () => {
       const [entry] = buildCocoAnnotations(
-        [mask],
+        [polygon],
         1,
         new Map([['l1', 1]]),
         nextId(),
@@ -96,9 +96,9 @@ describe('buildCocoAnnotations', () => {
       expect(entry.segmentation).toEqual([])
     })
 
-    it('flattens a Mask annotation to its bounding box, discarding the real outline', () => {
+    it('flattens a Polygon annotation to its bounding box, discarding the real outline', () => {
       const [entry] = buildCocoAnnotations(
-        [mask],
+        [polygon],
         1,
         new Map([['l1', 1]]),
         nextId(),
@@ -125,9 +125,9 @@ describe('buildCocoAnnotations', () => {
       expect(entry.segmentation).toEqual([])
     })
 
-    it('keeps a Mask annotation as its real outline', () => {
+    it('keeps a Polygon annotation as its real outline', () => {
       const [entry] = buildCocoAnnotations(
-        [mask],
+        [polygon],
         1,
         new Map([['l1', 1]]),
         nextId(),

--- a/src/renderer/src/components/sampleIO/exporters/coco/buildCoco.ts
+++ b/src/renderer/src/components/sampleIO/exporters/coco/buildCoco.ts
@@ -4,7 +4,7 @@ import { boundingBoxOf, exportShapePoints, ExportShape, polygonArea } from '../a
 /** Unlike YOLO's fixed-column label lines, a COCO annotation entry can carry a bbox and
  *  an independent (optional) segmentation, so it supports a third choice beyond forcing
  *  every annotation to one shape: Native, which leaves each annotation's segmentation as
- *  whatever it actually has - none for a Box, its real outline for a Mask. */
+ *  whatever it actually has - none for a Box, its real outline for a Polygon. */
 export enum CocoShapeMode {
   Box = 'box',
   Segment = 'segment',
@@ -50,10 +50,11 @@ const cocoSegmentationFor = (
 
 /** Converts one sample's annotations to COCO annotation entries. `bbox` is always the
  *  annotation's own bounding box. `segmentation` depends on the mode: Box discards any
- *  shape entirely (pure detection data, even for a Mask); Segment gives every annotation
- *  a polygon (a Box's own 4 corners, synthesized, if it has no real one); Native leaves a
- *  Box with no segmentation (it never had one) and a Mask with its real outline. `area`
- *  uses the real polygon's area only when that's what's actually being exported. */
+ *  shape entirely (pure detection data, even for a Polygon); Segment gives every
+ *  annotation a polygon (a Box's own 4 corners, synthesized, if it has no real one);
+ *  Native leaves a Box with no segmentation (it never had one) and a Polygon with its
+ *  real outline. `area` uses the real polygon's area only when that's what's actually
+ *  being exported. */
 export const buildCocoAnnotations = (
   annotations: IAnnotation[],
   imageId: number,
@@ -69,7 +70,7 @@ export const buildCocoAnnotations = (
     if (categoryId === undefined) continue
 
     const box = boundingBoxOf(annotation.points)
-    const isRealPolygon = mode !== CocoShapeMode.Box && annotation.type === AnnotationType.Mask
+    const isRealPolygon = mode !== CocoShapeMode.Box && annotation.type === AnnotationType.Polygon
 
     result.push({
       id: nextAnnotationId(),

--- a/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
@@ -6,6 +6,9 @@ import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { ArchiveManifest } from '@shared/types'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
+import { exportBaseName } from '../exportBaseName'
+import { LabelMapper } from '../../LabelMapper'
+import { buildIncludedLabelsAndIndex } from '../labelRouting'
 import { buildCvLabelManifest, cvLabelImagePath, type CvLabelManifestSample } from './buildCvLabel'
 
 // 'preparing' covers fetching samples and building the manifest, plus the native save
@@ -23,6 +26,9 @@ export const CvLabelJsonExporterComponent = ({
   const [isExporting, setIsExporting] = useState(false)
   const [phase, setPhase] = useState<ExportPhase>('preparing')
   const [progress, setProgress] = useState(0)
+  const [mapping, setMapping] = useState<Map<string, string | null>>(
+    new Map(project.labels.map((label) => [label.id, label.id]))
+  )
 
   useEffect(
     () =>
@@ -36,6 +42,8 @@ export const CvLabelJsonExporterComponent = ({
     setPhase('preparing')
     setProgress(0)
     try {
+      const { includedLabels } = buildIncludedLabelsAndIndex(project.labels, mapping)
+
       const samplesByTask = await Promise.all(tasks.map((task) => getSamplesForTask(task.id)))
       const samples = samplesByTask.flat()
 
@@ -52,7 +60,10 @@ export const CvLabelJsonExporterComponent = ({
           id: sample.id,
           name: sample.name,
           split: sample.split,
-          annotations: sample.annotations,
+          annotations: sample.annotations.flatMap((annotation) => {
+            const target = mapping.get(annotation.labelId)
+            return target ? [{ ...annotation, labelId: target }] : []
+          }),
           createdAt: sample.createdAt,
           width: sample.width,
           height: sample.height,
@@ -62,11 +73,14 @@ export const CvLabelJsonExporterComponent = ({
 
       manifest.textEntries.push({
         path: 'manifest.json',
-        content: buildCvLabelManifest(project.labels, manifestSamples)
+        content: buildCvLabelManifest(includedLabels, manifestSamples)
       })
 
       setPhase('exporting')
-      const saved = await window.exportApi.runExport(`${project.name}.cvlabel`, manifest)
+      const saved = await window.exportApi.runExport(
+        `${exportBaseName(project, tasks)}.cvlabel`,
+        manifest
+      )
 
       if (saved) {
         onComplete()
@@ -84,6 +98,14 @@ export const CvLabelJsonExporterComponent = ({
         file - a flat list of samples and their labels, independent of task structure. Re-importing
         works into any project via a label-mapping step.
       </Text>
+      <LabelMapper
+        items={project.labels}
+        options={project.labels}
+        mapping={mapping}
+        onChange={(id, value) => setMapping((current) => new Map(current).set(id, value))}
+        excludeLabel="Don't Export"
+        disabled={isExporting}
+      />
       {isExporting && (
         <Stack gap={4}>
           {phase === 'preparing' ? (

--- a/src/renderer/src/components/sampleIO/exporters/cvLabelJson/__tests__/CvLabelJsonExporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/cvLabelJson/__tests__/CvLabelJsonExporterComponent.test.tsx
@@ -61,7 +61,8 @@ describe('CvLabelJsonExporterComponent', () => {
     expect(getSamplesForTask).toHaveBeenCalledWith('t1')
     expect(runExport).toHaveBeenCalledTimes(1)
     const [suggestedName, manifest] = runExport.mock.calls[0]
-    expect(suggestedName).toBe('Street Signs.cvlabel')
+    // A single task exported alone suggests that task's own name, not the project's.
+    expect(suggestedName).toBe('Batch 1.cvlabel')
     expect(manifest.imageEntries).toEqual([
       { path: 'images/s1.png', imageUri: 'cv-label-image://s1.png' }
     ])
@@ -84,6 +85,115 @@ describe('CvLabelJsonExporterComponent', () => {
         }
       ]
     })
+  })
+
+  it('suggests the project name when exporting more than one task', async () => {
+    const onComplete = vi.fn()
+    const multipleTasks: ITask[] = [...tasks, { id: 't2', name: 'Batch 2' }]
+
+    renderWithProviders(
+      <CvLabelJsonExporterComponent
+        project={project}
+        tasks={multipleTasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([sample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const [suggestedName] = runExport.mock.calls[0]
+    expect(suggestedName).toBe('Street Signs.cvlabel')
+  })
+
+  it("excludes a label marked Don't Export: its annotations drop, the label list shrinks", async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        { id: 'a2', type: AnnotationType.Box, labelId: 'l2', points: [] }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <CvLabelJsonExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: "Don't Export" }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    const manifestJson = JSON.parse(
+      manifest.textEntries.find((e: { path: string }) => e.path === 'manifest.json').content
+    )
+    expect(manifestJson.labels).toEqual([{ id: 'l1', name: 'Stop Sign' }])
+    expect(manifestJson.samples[0].annotations).toHaveLength(1)
+    expect(manifestJson.samples[0].annotations[0].labelId).toBe('l1')
+  })
+
+  it('merges one label into another: the merged annotation is remapped to the target', async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        { id: 'a2', type: AnnotationType.Box, labelId: 'l2', points: [] }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <CvLabelJsonExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: 'Stop Sign' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    const manifestJson = JSON.parse(
+      manifest.textEntries.find((e: { path: string }) => e.path === 'manifest.json').content
+    )
+    expect(manifestJson.labels).toEqual([{ id: 'l1', name: 'Stop Sign' }])
+    expect(manifestJson.samples[0].annotations).toHaveLength(2)
+    expect(
+      manifestJson.samples[0].annotations.every((a: { labelId: string }) => a.labelId === 'l1')
+    ).toBe(true)
   })
 
   it('does not call onComplete when the user cancels the save dialog', async () => {

--- a/src/renderer/src/components/sampleIO/exporters/exportBaseName.ts
+++ b/src/renderer/src/components/sampleIO/exporters/exportBaseName.ts
@@ -1,0 +1,8 @@
+import type { IProject, ITask } from '@shared/types'
+
+/** The file/folder base name to suggest for an export - a single task's own name when
+ *  exporting just that one task (the common case from a per-task "Export" action), since
+ *  the project name would be redundant/less specific there. Falls back to the project's
+ *  name once more than one task is involved, where no single task name would make sense. */
+export const exportBaseName = (project: IProject, tasks: ITask[]): string =>
+  tasks.length === 1 ? tasks[0].name : project.name

--- a/src/renderer/src/components/sampleIO/exporters/labelRouting.ts
+++ b/src/renderer/src/components/sampleIO/exporters/labelRouting.ts
@@ -1,0 +1,31 @@
+import { ILabel } from '@shared/types'
+
+/** Turns a LabelMapper mapping (every project label -> itself, another label to merge
+ *  into, or `null` to exclude) into what an exporter needs: the distinct set of labels
+ *  that actually end up in the export, in a stable order, plus a routing table from
+ *  every *source* label id to that target's index. A label mapped to `null` is simply
+ *  absent from `labelIdToIndex`, so it's dropped by the same skip-if-missing logic the
+ *  Coco/Yolo builders already use for an unmapped id. Two labels mapped to the same
+ *  target route to the same index (merge). */
+export const buildIncludedLabelsAndIndex = (
+  labels: ILabel[],
+  mapping: Map<string, string | null>
+): { includedLabels: ILabel[]; labelIdToIndex: Map<string, number> } => {
+  const targetIds = new Set<string>()
+  for (const target of mapping.values()) {
+    if (target !== null) targetIds.add(target)
+  }
+
+  const includedLabels = labels.filter((label) => targetIds.has(label.id))
+  const targetIdToIndex = new Map(includedLabels.map((label, index) => [label.id, index]))
+
+  const labelIdToIndex = new Map<string, number>()
+  for (const label of labels) {
+    const target = mapping.get(label.id)
+    if (target === null || target === undefined) continue
+    const index = targetIdToIndex.get(target)
+    if (index !== undefined) labelIdToIndex.set(label.id, index)
+  }
+
+  return { includedLabels, labelIdToIndex }
+}

--- a/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
@@ -6,8 +6,11 @@ import { AsyncButton } from '@renderer/components/AsyncButton'
 import type { ArchiveManifest } from '@shared/types'
 import type { SampleExporterComponentProps } from '../../types'
 import { imageExtensionFromUri } from '../imageExtensionFromUri'
+import { exportBaseName } from '../exportBaseName'
 import { ExportShape } from '../annotationShape'
 import { LabeledSegmentedControl } from '../../LabeledSegmentedControl'
+import { LabelMapper } from '../../LabelMapper'
+import { buildIncludedLabelsAndIndex } from '../labelRouting'
 import { buildYoloDataYaml, yoloImagePath, yoloLabelFileContent, yoloLabelPath } from './buildYolo'
 
 const YOLO_SHAPE_OPTIONS: SegmentedControlItem[] = [
@@ -31,6 +34,9 @@ export const YoloExporterComponent = ({
   const [phase, setPhase] = useState<ExportPhase>('preparing')
   const [progress, setProgress] = useState(0)
   const [shape, setShape] = useState<ExportShape>(ExportShape.Box)
+  const [mapping, setMapping] = useState<Map<string, string | null>>(
+    new Map(project.labels.map((label) => [label.id, label.id]))
+  )
 
   useEffect(
     () =>
@@ -44,7 +50,10 @@ export const YoloExporterComponent = ({
     setPhase('preparing')
     setProgress(0)
     try {
-      const labelIdToClassId = new Map(project.labels.map((label, id) => [label.id, id]))
+      const { includedLabels, labelIdToIndex: labelIdToClassId } = buildIncludedLabelsAndIndex(
+        project.labels,
+        mapping
+      )
 
       const samplesByTask = await Promise.all(tasks.map((task) => getSamplesForTask(task.id)))
       const samples = samplesByTask.flat()
@@ -70,10 +79,13 @@ export const YoloExporterComponent = ({
         })
       }
 
-      manifest.textEntries.push({ path: 'data.yaml', content: buildYoloDataYaml(project.labels) })
+      manifest.textEntries.push({ path: 'data.yaml', content: buildYoloDataYaml(includedLabels) })
 
       setPhase('exporting')
-      const saved = await window.exportApi.runExport(`${project.name}-yolo-export.zip`, manifest)
+      const saved = await window.exportApi.runExport(
+        `${exportBaseName(project, tasks)}-yolo-export.zip`,
+        manifest
+      )
 
       if (saved) {
         onComplete()
@@ -96,6 +108,14 @@ export const YoloExporterComponent = ({
         value={shape}
         options={YOLO_SHAPE_OPTIONS}
         onChange={setShape}
+        disabled={isExporting}
+      />
+      <LabelMapper
+        items={project.labels}
+        options={project.labels}
+        mapping={mapping}
+        onChange={(id, value) => setMapping((current) => new Map(current).set(id, value))}
+        excludeLabel="Don't Export"
         disabled={isExporting}
       />
       {isExporting && (

--- a/src/renderer/src/components/sampleIO/exporters/yolo/__tests__/YoloExporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/__tests__/YoloExporterComponent.test.tsx
@@ -67,7 +67,8 @@ describe('YoloExporterComponent', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Export' }))
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
-    expect(runExport).toHaveBeenCalledWith('Street Signs-yolo-export.zip', {
+    // A single task exported alone suggests that task's own name, not the project's.
+    expect(runExport).toHaveBeenCalledWith('Batch 1-yolo-export.zip', {
       textEntries: [
         { path: 'labels/train/s1.txt', content: '0 0.500000 0.333333 0.500000 0.333333\n' },
         {
@@ -78,6 +79,27 @@ describe('YoloExporterComponent', () => {
       ],
       imageEntries: [{ path: 'images/train/s1.jpg', imageUri: 'cv-label-image://s1.jpg' }]
     })
+  })
+
+  it('suggests the project name when exporting more than one task', async () => {
+    const onComplete = vi.fn()
+    const multipleTasks: ITask[] = [...tasks, { id: 't2', name: 'Batch 2' }]
+
+    renderWithProviders(
+      <YoloExporterComponent
+        project={project}
+        tasks={multipleTasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([sample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const [suggestedName] = runExport.mock.calls[0]
+    expect(suggestedName).toBe('Street Signs-yolo-export.zip')
   })
 
   it('switches to Segments and exports the box as its own 4-corner polygon', async () => {
@@ -102,6 +124,113 @@ describe('YoloExporterComponent', () => {
       path: 'labels/train/s1.txt',
       content: '0 0.250000 0.166667 0.750000 0.166667 0.750000 0.500000 0.250000 0.500000\n'
     })
+  })
+
+  it("excludes a label marked Don't Export: its label line and data.yaml entry are dropped", async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        {
+          id: 'a2',
+          type: AnnotationType.Box,
+          labelId: 'l2',
+          points: [
+            { id: 'p2', x: 0, y: 0 },
+            { id: 'p3', x: 40, y: 20 }
+          ]
+        }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <YoloExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: "Don't Export" }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    const labelEntry = manifest.textEntries.find(
+      (e: { path: string }) => e.path === 'labels/train/s1.txt'
+    )
+    expect(labelEntry.content.trim().split('\n')).toHaveLength(1)
+    expect(labelEntry.content).toMatch(/^0 /)
+    const dataYaml = manifest.textEntries.find((e: { path: string }) => e.path === 'data.yaml')
+    expect(dataYaml.content).toContain('Stop Sign')
+    expect(dataYaml.content).not.toContain('Yield Sign')
+  })
+
+  it('merges one label into another: both label lines share a single class id', async () => {
+    const twoLabelProject: IProject = {
+      id: 'p1',
+      name: 'Street Signs',
+      labels: [
+        { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+        { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+      ]
+    }
+    const twoLabelSample: ISample = {
+      ...sample,
+      annotations: [
+        ...sample.annotations,
+        {
+          id: 'a2',
+          type: AnnotationType.Box,
+          labelId: 'l2',
+          points: [
+            { id: 'p2', x: 0, y: 0 },
+            { id: 'p3', x: 40, y: 20 }
+          ]
+        }
+      ]
+    }
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <YoloExporterComponent
+        project={twoLabelProject}
+        tasks={tasks}
+        getSamplesForTask={vi.fn().mockResolvedValue([twoLabelSample])}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByDisplayValue('Yield Sign'))
+    fireEvent.click(await screen.findByRole('option', { name: 'Stop Sign' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const manifest = runExport.mock.calls[0][1]
+    const labelEntry = manifest.textEntries.find(
+      (e: { path: string }) => e.path === 'labels/train/s1.txt'
+    )
+    const lines = labelEntry.content.trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines.every((line: string) => line.startsWith('0 '))).toBe(true)
+    const dataYaml = manifest.textEntries.find((e: { path: string }) => e.path === 'data.yaml')
+    expect(dataYaml.content).toContain('Stop Sign')
+    expect(dataYaml.content).not.toContain('Yield Sign')
   })
 
   it('does not call onComplete when the user cancels the save dialog', async () => {

--- a/src/renderer/src/components/sampleIO/exporters/yolo/__tests__/buildYolo.test.ts
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/__tests__/buildYolo.test.ts
@@ -56,9 +56,9 @@ describe('yoloLabelFileContent in Box mode', () => {
     )
   })
 
-  it('flattens a Mask annotation to its own bounding box, rather than skipping it', () => {
+  it('flattens a Polygon annotation to its own bounding box, rather than skipping it', () => {
     const annotations = [
-      makeAnnotation(AnnotationType.Mask, 'l1', [
+      makeAnnotation(AnnotationType.Polygon, 'l1', [
         { id: 'p0', x: 0, y: 0 },
         { id: 'p1', x: 10, y: 0 },
         { id: 'p2', x: 10, y: 10 }
@@ -85,9 +85,9 @@ describe('yoloLabelFileContent in Segment mode', () => {
     ).toBe('0 0.250000 0.250000 0.750000 0.250000 0.750000 0.750000 0.250000 0.750000\n')
   })
 
-  it('keeps a Mask annotation as its real polygon', () => {
+  it('keeps a Polygon annotation as its real polygon', () => {
     const annotations = [
-      makeAnnotation(AnnotationType.Mask, 'l1', [
+      makeAnnotation(AnnotationType.Polygon, 'l1', [
         { id: 'p0', x: 0, y: 0 },
         { id: 'p1', x: 10, y: 0 },
         { id: 'p2', x: 10, y: 10 }

--- a/src/renderer/src/components/sampleIO/exporters/yolo/buildYolo.ts
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/buildYolo.ts
@@ -17,10 +17,10 @@ export const buildYoloDataYaml = (labels: ILabel[]): string =>
   })
 
 /** One label line per annotation, normalized to [0,1]. In Box mode every annotation
- *  (Mask included) becomes a `class cx cy w h` bounding box; in Segment mode it becomes
- *  a `class x1 y1 x2 y2 ... xn yn` polygon - a Box's own 4 corners, or a Mask's real
- *  outline. Either way nothing is skipped, unlike the plain detection format's usual
- *  box-only restriction. */
+ *  (Polygon included) becomes a `class cx cy w h` bounding box; in Segment mode it
+ *  becomes a `class x1 y1 x2 y2 ... xn yn` polygon - a Box's own 4 corners, or a
+ *  Polygon's real outline. Either way nothing is skipped, unlike the plain detection
+ *  format's usual box-only restriction. */
 export const yoloLabelFileContent = (
   annotations: IAnnotation[],
   labelIdToClassId: Map<string, number>,

--- a/src/renderer/src/components/sampleIO/importers/__tests__/virtualFileSystem.test.ts
+++ b/src/renderer/src/components/sampleIO/importers/__tests__/virtualFileSystem.test.ts
@@ -104,16 +104,22 @@ describe('virtualFilesFromExtractedZip', () => {
     expect(deleteFile).not.toHaveBeenCalled()
   })
 
-  it('throws a clear error rather than silently misbehaving when the file has no real path', async () => {
-    installFakeFileSystem()
+  it('falls back to writing the file bytes to scratch when it has no real path (e.g. a drag-and-drop-reconstructed File)', async () => {
+    const { writeFile, deleteFile } = installFakeFileSystem()
     window.fileUtils.getPathForFile = () => ''
     const zip = new JSZip()
     zip.file('img1.jpg', 'x')
     const zipFile = new File([await zip.generateAsync({ type: 'arraybuffer' })], 'dataset.zip')
 
-    await expect(virtualFilesFromExtractedZip(zipFile, '/scratch')).rejects.toThrow(
-      'Could not resolve a real path'
-    )
+    const files = await virtualFilesFromExtractedZip(zipFile, '/scratch')
+
+    expect(files.map((f) => f.path)).toEqual(['img1.jpg'])
+    // The staged copy of the zip itself was written into scratchDir and then removed
+    // before listing, so it isn't returned alongside the zip's own extracted entries.
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    const [stagedPath] = writeFile.mock.calls[0]
+    expect(stagedPath.startsWith('/scratch/')).toBe(true)
+    expect(deleteFile).toHaveBeenCalledWith(stagedPath)
   })
 
   it('rejects blob() for a disk-backed entry rather than silently misreading it', async () => {

--- a/src/renderer/src/components/sampleIO/importers/coco/CocoImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/coco/CocoImporterComponent.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState, type ChangeEvent, type FC } from 'react'
-import { Button, Group, Loader, Progress, ScrollArea, Select, Stack, Text } from '@mantine/core'
+import { Button, Group, Loader, Progress, Stack, Text } from '@mantine/core'
 import toast from 'react-hot-toast'
 import { FaFileZipper, FaFolderOpen } from 'react-icons/fa6'
 import type { SampleImporterComponentProps } from '../../types'
-import { ZIndex } from '@renderer/zIndex'
+import { LabelMapper } from '../../LabelMapper'
 import { findLabelIdByName } from '../matchLabel'
 import {
   virtualFilesFromExtractedZip,
@@ -30,7 +30,7 @@ export const CocoImporterComponent: FC<SampleImporterComponentProps> = ({
   onCancel
 }) => {
   const [state, setState] = useState<WizardState>({ step: 'select-source' })
-  const [labelByClassId, setLabelByClassId] = useState<Map<number, string>>(new Map())
+  const [labelByClassId, setLabelByClassId] = useState<Map<number, string | null>>(new Map())
   const zipInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
   const scratchDirRef = useRef<string | null>(null)
@@ -63,7 +63,7 @@ export const CocoImporterComponent: FC<SampleImporterComponentProps> = ({
             c.id,
             findLabelIdByName(project.labels, c.name) ?? project.labels[0]?.id
           ]) as [number, string | undefined][]
-        ) as Map<number, string>
+        ) as Map<number, string | null>
       )
       setState({ step: 'mapping', classes, pairs })
     } catch (error) {
@@ -197,39 +197,22 @@ export const CocoImporterComponent: FC<SampleImporterComponentProps> = ({
           This project has no labels yet - add one before importing.
         </Text>
       )}
-      <ScrollArea style={{ maxHeight: 260 }} type="always" scrollbars="y">
-        <Stack gap="sm">
-          {classes.map((cocoClass) => (
-            <Group key={cocoClass.id} wrap="nowrap">
-              <Text size="sm" flex={1} truncate>
-                {cocoClass.name}
-              </Text>
-              <Select
-                flex={1}
-                data={project.labels.map((label) => ({ value: label.id, label: label.name }))}
-                value={labelByClassId.get(cocoClass.id) ?? null}
-                onChange={(value) => {
-                  if (!value) return
-                  setLabelByClassId((current) => new Map(current).set(cocoClass.id, value))
-                }}
-                // This importer lives inside ImportSamplesModal - without an explicit
-                // zIndex above the modal's own, this dropdown renders behind the modal
-                // body and can't be clicked.
-                comboboxProps={{ zIndex: ZIndex.actionModalContent }}
-                disabled={!hasProjectLabels}
-                allowDeselect={false}
-              />
-            </Group>
-          ))}
-        </Stack>
-      </ScrollArea>
+      <LabelMapper
+        items={classes}
+        options={project.labels}
+        mapping={labelByClassId}
+        onChange={(id, value) => setLabelByClassId((current) => new Map(current).set(id, value))}
+        disabled={!hasProjectLabels}
+      />
       <Group justify="flex-end">
         <Button variant="outline" onClick={() => setState({ step: 'select-source' })}>
           Back
         </Button>
         <Button
           onClick={runImport}
-          disabled={!hasProjectLabels || classes.some((c) => !labelByClassId.get(c.id))}
+          disabled={
+            !hasProjectLabels || classes.some((c) => labelByClassId.get(c.id) === undefined)
+          }
         >
           Import
         </Button>

--- a/src/renderer/src/components/sampleIO/importers/coco/__tests__/CocoImporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/importers/coco/__tests__/CocoImporterComponent.test.tsx
@@ -114,6 +114,41 @@ describe('CocoImporterComponent', () => {
     expect(samples[0].annotations[0].labelId).toBe('l2')
   })
 
+  it('excludes a class marked Ignore, without blocking Import, and drops its annotations', async () => {
+    const onComplete = vi.fn()
+    renderWithProviders(
+      <CocoImporterComponent project={project} onComplete={onComplete} onCancel={vi.fn()} />
+    )
+
+    fireEvent.change(screen.getByTestId('coco-folder-input'), {
+      target: {
+        files: [
+          makeFile('img1.jpg', 'x'),
+          makeFile(
+            '_annotations.coco.json',
+            cocoJson(
+              [{ id: 1, file_name: 'img1.jpg' }],
+              [{ image_id: 1, category_id: 1, bbox: [0, 0, 10, 10] }],
+              [{ id: 1, name: 'person' }]
+            )
+          )
+        ]
+      }
+    })
+    await screen.findByText('person')
+
+    fireEvent.click(screen.getByDisplayValue('Person'))
+    fireEvent.click(await screen.findByText('Ignore'))
+    expect(screen.getByRole('button', { name: 'Import' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const samples = onComplete.mock.calls[0][0]
+    expect(samples).toHaveLength(1)
+    expect(samples[0].annotations).toHaveLength(0)
+  })
+
   it('shows an error and stays on the selection step when no images are found', async () => {
     renderWithProviders(
       <CocoImporterComponent project={project} onComplete={vi.fn()} onCancel={vi.fn()} />

--- a/src/renderer/src/components/sampleIO/importers/coco/__tests__/parseCoco.test.ts
+++ b/src/renderer/src/components/sampleIO/importers/coco/__tests__/parseCoco.test.ts
@@ -146,7 +146,7 @@ describe('cocoAnnotationToPoints', () => {
     ])
   })
 
-  it('treats a real (non-rectangular) polygon segmentation as a Mask', () => {
+  it('treats a real (non-rectangular) polygon segmentation as a Polygon', () => {
     const result = cocoAnnotationToPoints({
       image_id: 1,
       category_id: 1,
@@ -154,7 +154,7 @@ describe('cocoAnnotationToPoints', () => {
       segmentation: [[0, 0, 10, 0, 5, 10]]
     })
 
-    expect(result.type).toBe(AnnotationType.Mask)
+    expect(result.type).toBe(AnnotationType.Polygon)
     expect(result.points).toEqual([
       { id: expect.any(String), x: 0, y: 0 },
       { id: expect.any(String), x: 10, y: 0 },

--- a/src/renderer/src/components/sampleIO/importers/coco/parseCoco.ts
+++ b/src/renderer/src/components/sampleIO/importers/coco/parseCoco.ts
@@ -136,7 +136,7 @@ const isBboxRectangle = (
 /** Converts one COCO annotation to the labeler's point representation. A polygon
  *  `segmentation` that isn't just the bbox's own rectangle (i.e. it carries real shape
  *  information, unlike the rectangular segmentation this app's COCO exporter writes for
- *  Box annotations) becomes a Mask; everything else becomes a Box from `bbox`. */
+ *  Box annotations) becomes a Polygon; everything else becomes a Box from `bbox`. */
 export const cocoAnnotationToPoints = (
   annotation: RawCocoAnnotation
 ): { type: AnnotationType; points: IPoint[] } => {
@@ -146,7 +146,7 @@ export const cocoAnnotationToPoints = (
     for (let i = 0; i + 1 < polygon.length; i += 2) {
       points.push({ id: makeUUID(), x: polygon[i], y: polygon[i + 1] })
     }
-    return { type: AnnotationType.Mask, points }
+    return { type: AnnotationType.Polygon, points }
   }
 
   const [x, y, w, h] = annotation.bbox
@@ -161,7 +161,7 @@ export const cocoAnnotationToPoints = (
 
 const buildSampleFromCocoPair = async (
   pair: CocoImagePair,
-  categoryIdToLabelId: Map<number, string>,
+  categoryIdToLabelId: Map<number, string | null>,
   scratchDir: string
 ): Promise<INewSample> => {
   const imagePath = await resolveImagePath(pair.image, scratchDir)
@@ -169,7 +169,7 @@ const buildSampleFromCocoPair = async (
   const annotations: INewAnnotation[] = []
   for (const raw of pair.annotations) {
     const labelId = categoryIdToLabelId.get(raw.category_id)
-    if (labelId === undefined) continue
+    if (labelId === undefined || labelId === null) continue
     const { type, points } = cocoAnnotationToPoints(raw)
     annotations.push({ id: makeUUID(), type, labelId, points })
   }
@@ -188,7 +188,7 @@ const buildSampleFromCocoPair = async (
  *  for why this isn't parallelized. */
 export const cocoDatasetToSamples = async (
   pairs: CocoImagePair[],
-  categoryIdToLabelId: Map<number, string>,
+  categoryIdToLabelId: Map<number, string | null>,
   scratchDir: string,
   onProgress?: (completed: number, total: number) => void
 ): Promise<INewSample[]> => {

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
@@ -1,9 +1,10 @@
-import { useRef, useState, type ChangeEvent, type FC } from 'react'
-import { Button, Group, Loader, Progress, ScrollArea, Select, Stack, Text } from '@mantine/core'
+import { useCallback, useEffect, useRef, useState, type FC } from 'react'
+import { Button, Group, Loader, Progress, Stack, Text } from '@mantine/core'
+import { Dropzone, MIME_TYPES, type FileWithPath } from '@mantine/dropzone'
 import toast from 'react-hot-toast'
 import { FaFileZipper } from 'react-icons/fa6'
 import type { SampleImporterComponentProps } from '../../types'
-import { ZIndex } from '@renderer/zIndex'
+import { LabelMapper } from '../../LabelMapper'
 import { findLabelIdById, findLabelIdByName } from '../matchLabel'
 import { virtualFilesFromExtractedZip } from '../virtualFileSystem'
 import {
@@ -20,14 +21,24 @@ type WizardState =
   | { step: 'mapping'; classes: CvLabelClass[]; pairs: CvLabelPair[] }
   | { step: 'importing'; progress: number }
 
-export const CvLabelImporterComponent: FC<SampleImporterComponentProps> = ({
+type CvLabelImporterComponentProps = SampleImporterComponentProps & {
+  /** Skips the drop/browse step and feeds this file straight into parsing, as if it had
+   *  just been dropped - lets a caller that already has the file in hand (e.g. the Tasks
+   *  page's own full-screen drop target, see CreateTaskButton.tsx) land the user directly
+   *  on the label-mapping step instead of making them drop it again inside this wizard. */
+  initialFile?: FileWithPath
+}
+
+export const CvLabelImporterComponent: FC<CvLabelImporterComponentProps> = ({
   project,
   onComplete,
-  onCancel
+  onCancel,
+  initialFile
 }) => {
-  const [state, setState] = useState<WizardState>({ step: 'select-source' })
-  const [labelByClassId, setLabelByClassId] = useState<Map<string, string>>(new Map())
-  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [state, setState] = useState<WizardState>(
+    initialFile ? { step: 'parsing' } : { step: 'select-source' }
+  )
+  const [labelByClassId, setLabelByClassId] = useState<Map<string, string | null>>(new Map())
   const scratchDirRef = useRef<string | null>(null)
 
   const ensureScratchDir = async (): Promise<string> => {
@@ -37,45 +48,62 @@ export const CvLabelImporterComponent: FC<SampleImporterComponentProps> = ({
     return scratchDirRef.current
   }
 
-  const handleFileSelected = async (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    e.target.value = ''
-    if (!file) return
+  const handleFileSelected = useCallback(
+    async (files: FileWithPath[]) => {
+      const file = files[0]
+      if (!file) return
 
-    setState({ step: 'parsing' })
-    try {
-      const scratchDir = await ensureScratchDir()
-      const files = await virtualFilesFromExtractedZip(file, scratchDir)
-      const found = await findCvLabelManifest(files)
-      if (!found) {
-        toast.error('No manifest.json found - is this a .cvlabel file?')
+      setState({ step: 'parsing' })
+      try {
+        const scratchDir = await ensureScratchDir()
+        const extractedFiles = await virtualFilesFromExtractedZip(file, scratchDir)
+        const found = await findCvLabelManifest(extractedFiles)
+        if (!found) {
+          toast.error('No manifest.json found - is this a .cvlabel file?')
+          setState({ step: 'select-source' })
+          return
+        }
+
+        const pairs = findCvLabelPairs(found.manifest, found.dir, extractedFiles)
+        if (pairs.length === 0) {
+          toast.error('No samples found in this file')
+          setState({ step: 'select-source' })
+          return
+        }
+
+        setLabelByClassId(
+          new Map(
+            found.manifest.labels.map((label) => [
+              label.id,
+              findLabelIdById(project.labels, label.id) ??
+                findLabelIdByName(project.labels, label.name)
+            ]) as [string, string | undefined][]
+          ) as Map<string, string | null>
+        )
+        setState({ step: 'mapping', classes: found.manifest.labels, pairs })
+      } catch (error) {
+        console.error(error)
+        toast.error('Failed to read the file')
         setState({ step: 'select-source' })
-        return
       }
+    },
+    [project]
+  )
 
-      const pairs = findCvLabelPairs(found.manifest, found.dir, files)
-      if (pairs.length === 0) {
-        toast.error('No samples found in this file')
-        setState({ step: 'select-source' })
-        return
-      }
-
-      setLabelByClassId(
-        new Map(
-          found.manifest.labels.map((label) => [
-            label.id,
-            findLabelIdById(project.labels, label.id) ??
-              findLabelIdByName(project.labels, label.name)
-          ]) as [string, string | undefined][]
-        ) as Map<string, string>
-      )
-      setState({ step: 'mapping', classes: found.manifest.labels, pairs })
-    } catch (error) {
-      console.error(error)
-      toast.error('Failed to read the file')
-      setState({ step: 'select-source' })
+  // Mirrors what the Dropzone's own onDrop would do with this same file - runs once per
+  // distinct initialFile (a new drop passes a new File instance, so this naturally re-fires
+  // for each one) rather than on every render, which handleFileSelected alone would cause
+  // if depended on directly given it's recreated whenever `project` changes. Deferred a
+  // microtask out rather than called directly: handleFileSelected's first statement is a
+  // synchronous setState (the same immediate "parsing" flip the Dropzone's own onDrop
+  // relies on), which react-hooks flags as a cascading-render risk when it runs straight
+  // in an effect body - the lazy initial state above already shows "parsing" on the very
+  // first paint, so this deferral costs nothing visible.
+  useEffect(() => {
+    if (initialFile) {
+      void Promise.resolve().then(() => handleFileSelected([initialFile]))
     }
-  }
+  }, [initialFile, handleFileSelected])
 
   const runImport = async () => {
     if (state.step !== 'mapping') return
@@ -102,7 +130,7 @@ export const CvLabelImporterComponent: FC<SampleImporterComponentProps> = ({
     return (
       <Stack gap="lg">
         <Text size="sm" c="dimmed">
-          Select a <code>.cvlabel</code> file exported from this app.
+          Drop a <code>.cvlabel</code> file exported from this app, or click to browse.
         </Text>
         {state.step === 'parsing' ? (
           <Group justify="center" py="xl">
@@ -112,18 +140,24 @@ export const CvLabelImporterComponent: FC<SampleImporterComponentProps> = ({
             </Text>
           </Group>
         ) : (
-          <Button leftSection={<FaFileZipper />} onClick={() => fileInputRef.current?.click()}>
-            Choose File
-          </Button>
+          <Dropzone
+            // .cvlabel has no registered OS mime type, so a dropped file typically
+            // reports an empty File.type - matching it as a zip by extension (the
+            // Accept map's array side) is what actually lets it through, not the mime key.
+            accept={{ [MIME_TYPES.zip]: ['.cvlabel', '.zip'] }}
+            multiple={false}
+            onDrop={(files) => handleFileSelected(files)}
+          >
+            <Group justify="center" gap="xl" mih={160} style={{ pointerEvents: 'none' }}>
+              <Stack align="center" gap={4}>
+                <FaFileZipper size={28} opacity={0.6} />
+                <Text size="sm" c="dimmed">
+                  Drop a .cvlabel file here, or click to browse
+                </Text>
+              </Stack>
+            </Group>
+          </Dropzone>
         )}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".cvlabel,.zip"
-          data-testid="cvlabel-file-input"
-          style={{ display: 'none' }}
-          onChange={handleFileSelected}
-        />
         <Group justify="flex-end">
           <Button variant="subtle" onClick={onCancel}>
             Cancel
@@ -158,39 +192,22 @@ export const CvLabelImporterComponent: FC<SampleImporterComponentProps> = ({
           This project has no labels yet - add one before importing.
         </Text>
       )}
-      <ScrollArea style={{ maxHeight: 260 }} type="always" scrollbars="y">
-        <Stack gap="sm">
-          {classes.map((cvLabelClass) => (
-            <Group key={cvLabelClass.id} wrap="nowrap">
-              <Text size="sm" flex={1} truncate>
-                {cvLabelClass.name}
-              </Text>
-              <Select
-                flex={1}
-                data={project.labels.map((label) => ({ value: label.id, label: label.name }))}
-                value={labelByClassId.get(cvLabelClass.id) ?? null}
-                onChange={(value) => {
-                  if (!value) return
-                  setLabelByClassId((current) => new Map(current).set(cvLabelClass.id, value))
-                }}
-                // This importer lives inside ImportSamplesModal - without an explicit
-                // zIndex above the modal's own, this dropdown renders behind the modal
-                // body and can't be clicked.
-                comboboxProps={{ zIndex: ZIndex.actionModalContent }}
-                disabled={!hasProjectLabels}
-                allowDeselect={false}
-              />
-            </Group>
-          ))}
-        </Stack>
-      </ScrollArea>
+      <LabelMapper
+        items={classes}
+        options={project.labels}
+        mapping={labelByClassId}
+        onChange={(id, value) => setLabelByClassId((current) => new Map(current).set(id, value))}
+        disabled={!hasProjectLabels}
+      />
       <Group justify="flex-end">
         <Button variant="outline" onClick={() => setState({ step: 'select-source' })}>
           Back
         </Button>
         <Button
           onClick={runImport}
-          disabled={!hasProjectLabels || classes.some((c) => !labelByClassId.get(c.id))}
+          disabled={
+            !hasProjectLabels || classes.some((c) => labelByClassId.get(c.id) === undefined)
+          }
         >
           Import
         </Button>

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/__tests__/CvLabelImporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/__tests__/CvLabelImporterComponent.test.tsx
@@ -21,6 +21,11 @@ const project: IProject = {
 
 const manifestJson = (labels: unknown[], samples: unknown[]) => JSON.stringify({ labels, samples })
 
+// Mantine's Dropzone renders a real <input type=file> under the hood and reacts to it the
+// same way it would a drop - same interaction pattern as PlainImagesImporterComponent's
+// own tests, which drive the equivalent Dropzone this way.
+const getFileInput = () => document.querySelector('input[type=file]') as HTMLInputElement
+
 const makeCvLabelFile = async (labels: unknown[], samples: unknown[], images: string[]) => {
   const zip = new JSZip()
   zip.file('manifest.json', manifestJson(labels, samples))
@@ -55,7 +60,7 @@ describe('CvLabelImporterComponent', () => {
       <CvLabelImporterComponent project={project} onComplete={vi.fn()} onCancel={vi.fn()} />
     )
 
-    fireEvent.change(screen.getByTestId('cvlabel-file-input'), { target: { files: [file] } })
+    fireEvent.change(getFileInput(), { target: { files: [file] } })
 
     await screen.findByText('Whatever')
     expect(screen.getByText('car')).toBeInTheDocument()
@@ -83,10 +88,53 @@ describe('CvLabelImporterComponent', () => {
       <CvLabelImporterComponent project={project} onComplete={vi.fn()} onCancel={vi.fn()} />
     )
 
-    fireEvent.change(screen.getByTestId('cvlabel-file-input'), { target: { files: [file] } })
+    fireEvent.change(getFileInput(), { target: { files: [file] } })
 
     await screen.findByText('truck')
     expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled()
+  })
+
+  it('lets the user explicitly Ignore an unmatched label, enabling Import and dropping its annotations', async () => {
+    const file = await makeCvLabelFile(
+      [{ id: 'no-match', name: 'truck' }],
+      [
+        {
+          id: 's1',
+          name: 'photo-one',
+          split: 'train',
+          annotations: [{ id: 'a1', type: 'box', labelId: 'no-match', points: [] }],
+          createdAt: '2026-01-01T00:00:00.000Z',
+          imageFile: 'images/s1.jpg'
+        }
+      ],
+      ['images/s1.jpg']
+    )
+    const onComplete = vi.fn()
+
+    renderWithProviders(
+      <CvLabelImporterComponent project={project} onComplete={onComplete} onCancel={vi.fn()} />
+    )
+
+    fireEvent.change(getFileInput(), { target: { files: [file] } })
+    await screen.findByText('truck')
+
+    // Mantine's Select doesn't re-fire onChange for clicking the already-displayed
+    // option, so go via a real label first to prove a genuine value change, then back
+    // to Ignore - both of which are real transitions and should each fire onChange.
+    fireEvent.click(screen.getByDisplayValue('Ignore'))
+    fireEvent.click(await screen.findByText('Person'))
+    expect(screen.getByRole('button', { name: 'Import' })).toBeEnabled()
+
+    fireEvent.click(screen.getByDisplayValue('Person'))
+    fireEvent.click(await screen.findByText('Ignore'))
+    expect(screen.getByRole('button', { name: 'Import' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const samples = onComplete.mock.calls[0][0]
+    expect(samples).toHaveLength(1)
+    expect(samples[0].annotations).toHaveLength(0)
   })
 
   it('imports with the resolved mapping and calls onComplete', async () => {
@@ -110,7 +158,7 @@ describe('CvLabelImporterComponent', () => {
       <CvLabelImporterComponent project={project} onComplete={onComplete} onCancel={vi.fn()} />
     )
 
-    fireEvent.change(screen.getByTestId('cvlabel-file-input'), { target: { files: [file] } })
+    fireEvent.change(getFileInput(), { target: { files: [file] } })
     await screen.findByText('Human')
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }))
@@ -132,10 +180,10 @@ describe('CvLabelImporterComponent', () => {
       <CvLabelImporterComponent project={project} onComplete={vi.fn()} onCancel={vi.fn()} />
     )
 
-    fireEvent.change(screen.getByTestId('cvlabel-file-input'), { target: { files: [file] } })
+    fireEvent.change(getFileInput(), { target: { files: [file] } })
 
     await waitFor(() => {
-      expect(screen.getByTestId('cvlabel-file-input')).toBeInTheDocument()
+      expect(getFileInput()).toBeInTheDocument()
     })
     expect(screen.queryByRole('button', { name: 'Import' })).not.toBeInTheDocument()
   })

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/parseCvLabel.ts
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/parseCvLabel.ts
@@ -90,7 +90,7 @@ export const findCvLabelPairs = (
  *  source label has no mapping are dropped. */
 export const cvLabelDatasetToSamples = async (
   pairs: CvLabelPair[],
-  labelIdToProjectLabelId: Map<string, string>,
+  labelIdToProjectLabelId: Map<string, string | null>,
   scratchDir: string,
   onProgress?: (completed: number, total: number) => void
 ): Promise<INewSample[]> => {
@@ -104,7 +104,7 @@ export const cvLabelDatasetToSamples = async (
       const annotations: INewAnnotation[] = []
       for (const annotation of pair.sample.annotations) {
         const labelId = labelIdToProjectLabelId.get(annotation.labelId)
-        if (labelId === undefined) continue
+        if (labelId === undefined || labelId === null) continue
         annotations.push({
           id: makeUUID(),
           type: annotation.type,

--- a/src/renderer/src/components/sampleIO/importers/virtualFileSystem.ts
+++ b/src/renderer/src/components/sampleIO/importers/virtualFileSystem.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip'
+import { writeBlobToScratchFile } from './writeToScratch'
 
 /** A file from either a zip archive or a picked folder, addressed by a forward-slash
  *  relative path so the rest of the importers don't need to know which source it
@@ -41,17 +42,26 @@ export const virtualFilesFromZip = async (zipFile: File): Promise<VirtualFile[]>
  *  copying it into scratchDir first - a naive copy (read the File's bytes, ship them
  *  across IPC, write them back out) would hold the entire file in memory twice over for
  *  something that's already sitting on disk, which for a multi-gigabyte dataset export
- *  defeats the point of extracting it in a streaming fashion at all. */
+ *  defeats the point of extracting it in a streaming fashion at all. That resolution only
+ *  works for a File Electron itself handed the renderer (a native file-picker selection or
+ *  a plain OS drag) - a Dropzone drag that goes through directory-aware processing (needed
+ *  elsewhere for folder drops) re-materializes the File via the FileSystemEntry API first,
+ *  which Electron can't map back to a real path. Falls back to the naive copy only in that
+ *  case, so drag-and-drop still works for a zip too, just without the streaming shortcut. */
 export const virtualFilesFromExtractedZip = async (
   zipFile: File,
   scratchDir: string
 ): Promise<VirtualFile[]> => {
-  const zipPath = window.fileUtils.getPathForFile(zipFile)
-  if (!zipPath) {
-    throw new Error('Could not resolve a real path for the selected file')
-  }
+  const resolvedPath = window.fileUtils.getPathForFile(zipFile)
+  const zipPath = resolvedPath || (await writeBlobToScratchFile(scratchDir, zipFile, 'zip'))
 
   await window.zip.extractTo(zipPath, scratchDir)
+  if (!resolvedPath) {
+    // The staged copy lives inside scratchDir itself (nowhere else to put it without a
+    // second temporary-directory round trip) - remove it before listing so it isn't
+    // mistaken for one of the zip's own extracted entries.
+    await window.system.deleteFile(zipPath)
+  }
 
   const relativePaths = await window.system.listFilesRecursive(scratchDir)
 

--- a/src/renderer/src/components/sampleIO/importers/yolo/YoloImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/yolo/YoloImporterComponent.tsx
@@ -1,11 +1,11 @@
 import { useRef, useState, type ChangeEvent, type FC } from 'react'
-import { Button, Group, Loader, Progress, ScrollArea, Select, Stack, Text } from '@mantine/core'
+import { Button, Group, Loader, Progress, Stack, Text } from '@mantine/core'
 import type { SegmentedControlItem } from '@mantine/core'
 import toast from 'react-hot-toast'
 import { FaFileZipper, FaFolderOpen } from 'react-icons/fa6'
 import type { SampleImporterComponentProps } from '../../types'
 import { LabeledSegmentedControl } from '../../LabeledSegmentedControl'
-import { ZIndex } from '@renderer/zIndex'
+import { LabelMapper } from '../../LabelMapper'
 import { findLabelIdByName } from '../matchLabel'
 import {
   virtualFilesFromExtractedZip,
@@ -39,7 +39,7 @@ export const YoloImporterComponent: FC<SampleImporterComponentProps> = ({
   onCancel
 }) => {
   const [state, setState] = useState<WizardState>({ step: 'select-source' })
-  const [labelByClassId, setLabelByClassId] = useState<Map<number, string>>(new Map())
+  const [labelByClassId, setLabelByClassId] = useState<Map<number, string | null>>(new Map())
   const [format, setFormat] = useState<YoloLabelFormat>(YoloLabelFormat.Detection)
   const zipInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
@@ -78,7 +78,7 @@ export const YoloImporterComponent: FC<SampleImporterComponentProps> = ({
             c.id,
             findLabelIdByName(project.labels, c.name) ?? project.labels[0]?.id
           ]) as [number, string | undefined][]
-        ) as Map<number, string>
+        ) as Map<number, string | null>
       )
       setState({ step: 'mapping', classes, pairs })
     } catch (error) {
@@ -220,39 +220,22 @@ export const YoloImporterComponent: FC<SampleImporterComponentProps> = ({
         options={FORMAT_OPTIONS}
         onChange={setFormat}
       />
-      <ScrollArea style={{ maxHeight: 260 }} type="always" scrollbars="y">
-        <Stack gap="sm">
-          {classes.map((yoloClass) => (
-            <Group key={yoloClass.id} wrap="nowrap">
-              <Text size="sm" flex={1} truncate>
-                {yoloClass.name}
-              </Text>
-              <Select
-                flex={1}
-                data={project.labels.map((label) => ({ value: label.id, label: label.name }))}
-                value={labelByClassId.get(yoloClass.id) ?? null}
-                onChange={(value) => {
-                  if (!value) return
-                  setLabelByClassId((current) => new Map(current).set(yoloClass.id, value))
-                }}
-                // This importer lives inside ImportSamplesModal - without an explicit
-                // zIndex above the modal's own, this dropdown renders behind the modal
-                // body and can't be clicked.
-                comboboxProps={{ zIndex: ZIndex.actionModalContent }}
-                disabled={!hasProjectLabels}
-                allowDeselect={false}
-              />
-            </Group>
-          ))}
-        </Stack>
-      </ScrollArea>
+      <LabelMapper
+        items={classes}
+        options={project.labels}
+        mapping={labelByClassId}
+        onChange={(id, value) => setLabelByClassId((current) => new Map(current).set(id, value))}
+        disabled={!hasProjectLabels}
+      />
       <Group justify="flex-end">
         <Button variant="outline" onClick={() => setState({ step: 'select-source' })}>
           Back
         </Button>
         <Button
           onClick={runImport}
-          disabled={!hasProjectLabels || classes.some((c) => !labelByClassId.get(c.id))}
+          disabled={
+            !hasProjectLabels || classes.some((c) => labelByClassId.get(c.id) === undefined)
+          }
         >
           Import
         </Button>

--- a/src/renderer/src/components/sampleIO/importers/yolo/__tests__/YoloImporterComponent.test.tsx
+++ b/src/renderer/src/components/sampleIO/importers/yolo/__tests__/YoloImporterComponent.test.tsx
@@ -93,6 +93,35 @@ describe('YoloImporterComponent', () => {
     expect(samples[0].annotations[0].labelId).toBe('l2')
   })
 
+  it('excludes a class marked Ignore, without blocking Import, and drops its annotations', async () => {
+    const onComplete = vi.fn()
+    renderWithProviders(
+      <YoloImporterComponent project={project} onComplete={onComplete} onCancel={vi.fn()} />
+    )
+
+    fireEvent.change(screen.getByTestId('yolo-folder-input'), {
+      target: {
+        files: [
+          makeFile('img1.jpg', 'x'),
+          makeFile('img1.txt', '0 0.5 0.5 0.2 0.2'),
+          makeFile('classes.txt', 'person\n')
+        ]
+      }
+    })
+    await screen.findByText('person')
+
+    fireEvent.click(screen.getByDisplayValue('Person'))
+    fireEvent.click(await screen.findByText('Ignore'))
+    expect(screen.getByRole('button', { name: 'Import' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    const samples = onComplete.mock.calls[0][0]
+    expect(samples).toHaveLength(1)
+    expect(samples[0].annotations).toHaveLength(0)
+  })
+
   it('shows an error and stays on the selection step when no images are found', async () => {
     renderWithProviders(
       <YoloImporterComponent project={project} onComplete={vi.fn()} onCancel={vi.fn()} />

--- a/src/renderer/src/components/sampleIO/importers/yolo/__tests__/parseYolo.test.ts
+++ b/src/renderer/src/components/sampleIO/importers/yolo/__tests__/parseYolo.test.ts
@@ -250,7 +250,7 @@ describe('yoloDatasetToSamples', () => {
     expect(samples[0].annotations[0].points).toHaveLength(2)
   })
 
-  it('in Segmentation format, builds Mask annotations from polygon lines', async () => {
+  it('in Segmentation format, builds Polygon annotations from polygon lines', async () => {
     const files = [
       makeFile('img1.jpg', 'fake-image-bytes'),
       makeFile('img1.txt', '0 0.1 0.1 0.2 0.1 0.2 0.2')
@@ -266,7 +266,7 @@ describe('yoloDatasetToSamples', () => {
     )
 
     expect(samples[0].annotations).toHaveLength(1)
-    expect(samples[0].annotations[0].type).toBe(AnnotationType.Mask)
+    expect(samples[0].annotations[0].type).toBe(AnnotationType.Polygon)
     expect(samples[0].annotations[0].points).toHaveLength(3)
   })
 

--- a/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
+++ b/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
@@ -222,7 +222,7 @@ const resolveImagePathAndDimensions = async (
 
 const buildSampleFromYoloPair = async (
   pair: YoloImagePair,
-  classIdToLabelId: Map<number, string>,
+  classIdToLabelId: Map<number, string | null>,
   format: YoloLabelFormat,
   scratchDir: string
 ): Promise<INewSample> => {
@@ -234,10 +234,10 @@ const buildSampleFromYoloPair = async (
     if (format === YoloLabelFormat.Segmentation) {
       for (const polygon of parseYoloSegmentationLabelFile(text)) {
         const labelId = classIdToLabelId.get(polygon.classId)
-        if (labelId === undefined) continue
+        if (labelId === undefined || labelId === null) continue
         annotations.push({
           id: makeUUID(),
-          type: AnnotationType.Mask,
+          type: AnnotationType.Polygon,
           labelId,
           points: yoloPolygonToPoints(polygon, width, height)
         })
@@ -245,7 +245,7 @@ const buildSampleFromYoloPair = async (
     } else {
       for (const box of parseYoloLabelFile(text)) {
         const labelId = classIdToLabelId.get(box.classId)
-        if (labelId === undefined) continue
+        if (labelId === undefined || labelId === null) continue
         annotations.push({
           id: makeUUID(),
           type: AnnotationType.Box,
@@ -273,7 +273,7 @@ const buildSampleFromYoloPair = async (
  *  all-segmentation, so it's one choice for the whole import rather than inferred per line. */
 export const yoloDatasetToSamples = async (
   pairs: YoloImagePair[],
-  classIdToLabelId: Map<number, string>,
+  classIdToLabelId: Map<number, string | null>,
   format: YoloLabelFormat,
   scratchDir: string,
   onProgress?: (completed: number, total: number) => void

--- a/src/renderer/src/data/IpcDataStore.ts
+++ b/src/renderer/src/data/IpcDataStore.ts
@@ -2,7 +2,6 @@ import {
   IAnnotation,
   IAnnotationUpdate,
   IDataStore,
-  IAnnotator,
   INewAnnotation,
   ILabel,
   INewSample,
@@ -12,6 +11,8 @@ import {
   IProjectUpdate,
   ISample,
   ISampleUpdate,
+  ITag,
+  ITagUpdate,
   ITask,
   ITaskUpdate
 } from '@shared/types'
@@ -63,6 +64,30 @@ export class IpcDataStore implements IDataStore {
     return window.store.deleteTasks(taskIds)
   }
 
+  getTagsForProject(projectId: string): Promise<ITag[]> {
+    return window.store.getTagsForProject(projectId)
+  }
+
+  createTag(projectId: string, id: string, name: string): Promise<ITag> {
+    return window.store.createTag(projectId, id, name)
+  }
+
+  updateTags(updates: ITagUpdate[]): Promise<ITag[]> {
+    return window.store.updateTags(updates)
+  }
+
+  deleteTags(tagIds: string[]): Promise<boolean[]> {
+    return window.store.deleteTags(tagIds)
+  }
+
+  addTagsToTasks(taskIds: string[], tagIds: string[]): Promise<void> {
+    return window.store.addTagsToTasks(taskIds, tagIds)
+  }
+
+  removeTagsFromTasks(taskIds: string[], tagIds: string[]): Promise<void> {
+    return window.store.removeTagsFromTasks(taskIds, tagIds)
+  }
+
   getSamplesForTask(taskId: string): Promise<ISample[]> {
     return window.store.getSamplesForTask(taskId)
   }
@@ -97,23 +122,6 @@ export class IpcDataStore implements IDataStore {
 
   deleteAnnotations(annotationsIds: string[]): Promise<boolean[]> {
     return window.store.deleteAnnotations(annotationsIds)
-  }
-
-  getAnnotators(projectId: string): Promise<IAnnotator[]> {
-    return window.store.getAnnotators(projectId)
-  }
-
-  createAnnotator(
-    projectId: string,
-    id: string,
-    name: string,
-    url: string,
-    headers: Record<string, string>
-  ): Promise<IAnnotator> {
-    return window.store.createAnnotator(projectId, id, name, url, headers)
-  }
-  deleteAnnotators(externalAnnotatorIds: string[]): Promise<boolean[]> {
-    return window.store.deleteAnnotators(externalAnnotatorIds)
   }
 
   replacePoints(annotationId: string, points: IPointReplacement[]): Promise<IPoint[]> {

--- a/src/renderer/src/hooks/__tests__/useCopyAnnotations.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useCopyAnnotations.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useCopyAnnotations, type CopyAnnotationsPair } from '../useCopyAnnotations'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
+import { AnnotationType, IAnnotation, TrainingSplit } from '@shared/types'
+
+vi.mock('@renderer/hooks/useAppStore', async () => {
+  const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
+  const state = { store: createMockDataStore() }
+  const useAppStore = Object.assign((selector: (s: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+  return { useAppStore }
+})
+
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { createMockDataStore } from '@renderer/__tests__/mockDataStore'
+
+const makeSample = (
+  id: string,
+  opts: { width?: number; height?: number; annotations?: IAnnotation[] } = {}
+) =>
+  toOptimisticSample({
+    id,
+    name: id,
+    split: TrainingSplit.Train,
+    createdAt: new Date().toISOString(),
+    imageUri: `cv-label-image://${id}`,
+    width: opts.width ?? 100,
+    height: opts.height ?? 100,
+    completedAt: null,
+    annotations: opts.annotations ?? []
+  })
+
+const annotationA: IAnnotation = {
+  id: 'a1',
+  type: AnnotationType.Box,
+  labelId: 'l1',
+  points: [
+    { id: 'p1', x: 0, y: 0 },
+    { id: 'p2', x: 10, y: 10 }
+  ]
+}
+
+let queryClient: QueryClient
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeEach(() => {
+  Object.assign(useAppStore.getState().store, createMockDataStore())
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  })
+})
+
+describe('useCopyAnnotations', () => {
+  it("copies a source sample's annotations onto the destination with fresh ids", async () => {
+    const source = makeSample('s1', { annotations: [annotationA] })
+    const destination = makeSample('s2')
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockResolvedValue([])
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([{ source, destination }])
+    })
+
+    expect(dataStore.createAnnotations).toHaveBeenCalledTimes(1)
+    const [sampleId, annotations] = vi.mocked(dataStore.createAnnotations).mock.calls[0]
+    expect(sampleId).toBe('s2')
+    expect(annotations).toHaveLength(1)
+    expect(annotations[0].id).not.toBe(annotationA.id)
+    expect(annotations[0].type).toBe(annotationA.type)
+    expect(annotations[0].labelId).toBe(annotationA.labelId)
+    expect(annotations[0].points.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [10, 10]
+    ])
+    expect(annotations[0].points[0].id).not.toBe(annotationA.points[0].id)
+
+    expect(result.current.progress.copied).toBe(1)
+    expect(result.current.progress.completed).toBe(1)
+  })
+
+  it('skips a destination sample that already has annotations', async () => {
+    const source = makeSample('s1', { annotations: [annotationA] })
+    const destination = makeSample('s2', { annotations: [annotationA] })
+    const dataStore = useAppStore.getState().store
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([{ source, destination }])
+    })
+
+    expect(dataStore.createAnnotations).not.toHaveBeenCalled()
+    expect(result.current.progress.alreadyLabeled).toBe(1)
+    expect(result.current.progress.total).toBe(0)
+  })
+
+  it('skips a pair whose source/destination dimensions differ', async () => {
+    const source = makeSample('s1', { annotations: [annotationA], width: 100, height: 100 })
+    const destination = makeSample('s2', { width: 200, height: 100 })
+    const dataStore = useAppStore.getState().store
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([{ source, destination }])
+    })
+
+    expect(dataStore.createAnnotations).not.toHaveBeenCalled()
+    expect(result.current.progress.dimensionMismatch).toBe(1)
+  })
+
+  it('only copies into a duplicated destination once - first pair wins', async () => {
+    const sourceA = makeSample('s1', { annotations: [annotationA] })
+    const sourceB = makeSample('s2', { annotations: [annotationA] })
+    const destination = makeSample('s3')
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockResolvedValue([])
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([
+        { source: sourceA, destination },
+        { source: sourceB, destination }
+      ])
+    })
+
+    expect(dataStore.createAnnotations).toHaveBeenCalledTimes(1)
+    expect(result.current.progress.duplicateDestination).toBe(1)
+    expect(result.current.progress.total).toBe(1)
+  })
+
+  it('keeps going past a per-pair failure and records it', async () => {
+    const sourceA = makeSample('s1', { annotations: [annotationA] })
+    const destinationA = makeSample('s2')
+    const sourceB = makeSample('s3', { annotations: [annotationA] })
+    const destinationB = makeSample('s4')
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([])
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([
+        { source: sourceA, destination: destinationA },
+        { source: sourceB, destination: destinationB }
+      ])
+    })
+
+    expect(dataStore.createAnnotations).toHaveBeenCalledTimes(2)
+    expect(result.current.progress.completed).toBe(2)
+    expect(result.current.progress.copied).toBe(1)
+    expect(result.current.progress.failures).toEqual([
+      { sampleId: 's2', sampleName: 's2', error: 'boom' }
+    ])
+  })
+
+  it('invalidates the destination task samples query after the run', async () => {
+    const source = makeSample('s1', { annotations: [annotationA] })
+    const destination = makeSample('s2')
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockResolvedValue([])
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      await result.current.run([{ source, destination }])
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['samples', 't-dest', dataStore] })
+  })
+
+  it('does nothing for a sample with no annotations to copy', async () => {
+    const source = makeSample('s1')
+    const destination = makeSample('s2')
+    const dataStore = useAppStore.getState().store
+
+    const { result } = renderHook(() => useCopyAnnotations('t-dest'), { wrapper })
+
+    await act(async () => {
+      const pairs: CopyAnnotationsPair[] = [{ source, destination }]
+      await result.current.run(pairs)
+    })
+
+    expect(dataStore.createAnnotations).not.toHaveBeenCalled()
+    expect(result.current.progress.copied).toBe(0)
+    expect(result.current.progress.completed).toBe(1)
+  })
+})

--- a/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
@@ -1,0 +1,572 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useLabeler,
+  BOX_CORNER_HANDLE_TOP_RIGHT,
+  BOX_CORNER_HANDLE_BOTTOM_LEFT,
+  BOX_EDGE_TOP,
+  BOX_EDGE_RIGHT,
+  BOX_EDGE_BOTTOM,
+  BOX_EDGE_LEFT
+} from '../useLabeler'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
+import { LabelerMode } from '@renderer/types'
+import { AnnotationType, IAnnotation, ILabel, IPoint, TrainingSplit } from '@shared/types'
+
+vi.mock('@renderer/hooks/useAppStore', async () => {
+  const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
+  const state = { store: createMockDataStore() }
+  const useAppStore = Object.assign((selector: (s: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+  return { useAppStore }
+})
+
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { createMockDataStore } from '@renderer/__tests__/mockDataStore'
+
+const labels: ILabel[] = [
+  { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+  { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+]
+
+const makeSample = (annotations: IAnnotation[] = []) =>
+  toOptimisticSample({
+    id: 'sample-1',
+    name: 'sample-1',
+    split: TrainingSplit.Train,
+    createdAt: new Date().toISOString(),
+    imageUri: 'about:blank',
+    width: 100,
+    height: 100,
+    completedAt: null,
+    annotations
+  })
+
+const setup = (annotations: IAnnotation[] = []) => {
+  const { result } = renderHook(() => useLabeler(labels))
+  const { store } = result.current
+  // Bypasses setSample()'s real bitmap-load/hit-id bookkeeping (irrelevant to the
+  // mutation/undo-redo logic under test) - direct state injection is fine except in the
+  // dedicated "setSample clears history" test below, which calls the real action.
+  act(() => store.setState({ sample: makeSample(annotations) }))
+  return store
+}
+
+// Lets any pending .then/.catch/.finally chain (however deep) drain before asserting -
+// a plain `await Promise.resolve()` only advances one microtask tick, which isn't always
+// enough for the 2-3-deep chains in useLabeler's apply* primitives.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const annotationA: IAnnotation = {
+  id: 'a1',
+  type: AnnotationType.Box,
+  labelId: 'l1',
+  points: [
+    { id: 'p1', x: 0, y: 0 },
+    { id: 'p2', x: 10, y: 10 }
+  ]
+}
+
+const annotationB: IAnnotation = {
+  id: 'a2',
+  type: AnnotationType.Box,
+  labelId: 'l1',
+  points: [
+    { id: 'p3', x: 20, y: 20 },
+    { id: 'p4', x: 30, y: 30 }
+  ]
+}
+
+beforeEach(() => {
+  // Fresh vi.fn()s (default resolved values, cleared call history) each test - mutating
+  // the existing store object's properties rather than reassigning it, since useLabeler's
+  // closures hold onto `useAppStore.getState().store` as a stable reference.
+  Object.assign(useAppStore.getState().store, createMockDataStore())
+})
+
+describe('useLabeler undo/redo', () => {
+  it('undoes and redoes a create', async () => {
+    const store = setup([])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+    vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+
+    await act(async () => {
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(10, 10)
+      store.getState().onConfirmPoint(10, 10)
+      await flush()
+    })
+
+    const createdIds = Object.keys(store.getState().sample!.resolve().annotations.resolve())
+    expect(createdIds).toHaveLength(1)
+    const [createdId] = createdIds
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    expect(dataStore.deleteAnnotations).toHaveBeenCalledWith([createdId])
+    expect(store.getState().sample!.resolve().annotations.resolve()[createdId]).toBeUndefined()
+
+    await act(async () => {
+      store.getState().redo()
+      await flush()
+    })
+
+    expect(dataStore.createAnnotations).toHaveBeenCalledTimes(2)
+    expect(store.getState().sample!.resolve().annotations.resolve()[createdId]).toBeDefined()
+  })
+
+  it('undoes a delete, recreating the annotation with its original id', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+
+    await act(async () => {
+      store.getState().deleteAnnotation('a1')
+      await flush()
+    })
+    expect(store.getState().sample!.resolve().annotations.resolve().a1).toBeUndefined()
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    expect(dataStore.createAnnotations).toHaveBeenCalledWith('sample-1', [annotationA])
+    expect(store.getState().sample!.resolve().annotations.resolve().a1).toBeDefined()
+  })
+
+  it('undoes a move, restoring the original points', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.replacePoints).mockImplementation(async (_id, points) =>
+      (points as IPoint[]).map((p) => ({ id: p.id, x: p.x, y: p.y }))
+    )
+
+    act(() => {
+      store.getState().selectAnnotation('a1')
+      store.getState().moveSelectedAnnotationBy(5, 5)
+    })
+    await act(async () => {
+      store.getState().commitAnnotationMove('a1')
+      await flush()
+    })
+
+    const moved = store.getState().sample!.resolve().annotations.resolve().a1.resolve().points
+    expect(moved.map((p) => [p.x, p.y])).toEqual([
+      [5, 5],
+      [15, 15]
+    ])
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    const restored = store.getState().sample!.resolve().annotations.resolve().a1.resolve().points
+    expect(restored.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [10, 10]
+    ])
+  })
+
+  it('undoes a relabel', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.updateAnnotations).mockImplementation(async (updates) =>
+      updates.map((u) => ({ ...annotationA, ...u }))
+    )
+
+    await act(async () => {
+      store.getState().setAnnotationLabelId('a1', 'l2')
+      await flush()
+    })
+    expect(store.getState().sample!.resolve().annotations.resolve().a1.resolve().labelId).toBe('l2')
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    expect(store.getState().sample!.resolve().annotations.resolve().a1.resolve().labelId).toBe('l1')
+    expect(dataStore.updateAnnotations).toHaveBeenLastCalledWith([{ id: 'a1', labelId: 'l1' }])
+  })
+
+  it('clears the redo stack when a new mutation happens', async () => {
+    const store = setup([annotationA, annotationB])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+
+    await act(async () => {
+      store.getState().deleteAnnotation('a1')
+      await flush()
+    })
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+    expect(store.getState().redoStack).toHaveLength(1)
+
+    await act(async () => {
+      store.getState().deleteAnnotation('a2')
+      await flush()
+    })
+
+    expect(store.getState().redoStack).toHaveLength(0)
+  })
+
+  it('clears both stacks when the sample changes', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+
+    await act(async () => {
+      store.getState().deleteAnnotation('a1')
+      await flush()
+    })
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+    expect(store.getState().undoStack.length + store.getState().redoStack.length).toBeGreaterThan(0)
+
+    act(() => {
+      store.getState().setSample(makeSample([]))
+    })
+
+    expect(store.getState().undoStack).toEqual([])
+    expect(store.getState().redoStack).toEqual([])
+  })
+
+  it('undo is a no-op with an empty history', () => {
+    const store = setup([])
+    const dataStore = useAppStore.getState().store
+    const sampleBefore = store.getState().sample
+
+    act(() => store.getState().undo())
+
+    expect(dataStore.deleteAnnotations).not.toHaveBeenCalled()
+    expect(dataStore.createAnnotations).not.toHaveBeenCalled()
+    expect(dataStore.replacePoints).not.toHaveBeenCalled()
+    expect(dataStore.updateAnnotations).not.toHaveBeenCalled()
+    expect(store.getState().sample).toBe(sampleBefore)
+  })
+
+  it('redo is a no-op with an empty history', () => {
+    const store = setup([])
+    const dataStore = useAppStore.getState().store
+
+    act(() => store.getState().redo())
+
+    expect(dataStore.deleteAnnotations).not.toHaveBeenCalled()
+    expect(dataStore.createAnnotations).not.toHaveBeenCalled()
+    expect(dataStore.replacePoints).not.toHaveBeenCalled()
+    expect(dataStore.updateAnnotations).not.toHaveBeenCalled()
+  })
+})
+
+describe('useLabeler duplicateAnnotation', () => {
+  it('creates an offset copy and selects it', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+
+    let newId: string | undefined
+    await act(async () => {
+      newId = store.getState().duplicateAnnotation('a1')
+      await flush()
+    })
+
+    expect(newId).toBeDefined()
+    expect(newId).not.toBe('a1')
+
+    const annotations = store.getState().sample!.resolve().annotations.resolve()
+    expect(Object.keys(annotations)).toHaveLength(2)
+
+    const duplicate = annotations[newId!].resolve()
+    expect(duplicate.labelId).toBe(annotationA.labelId)
+    expect(duplicate.type).toBe(annotationA.type)
+    // Offset the same way on both points - same shape, just translated.
+    expect(duplicate.points[0].x).toBeGreaterThan(annotationA.points[0].x)
+    expect(duplicate.points[0].y).toBeGreaterThan(annotationA.points[0].y)
+    expect(duplicate.points[1].x - duplicate.points[0].x).toBeCloseTo(
+      annotationA.points[1].x - annotationA.points[0].x
+    )
+
+    expect(store.getState().selectedAnnotation?.resolve().id).toBe(newId)
+  })
+
+  it('undoes a duplicate, removing the copy and leaving the original untouched', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+    vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+
+    let newId: string | undefined
+    await act(async () => {
+      newId = store.getState().duplicateAnnotation('a1')
+      await flush()
+    })
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    const annotations = store.getState().sample!.resolve().annotations.resolve()
+    expect(annotations[newId!]).toBeUndefined()
+    expect(annotations.a1).toBeDefined()
+    expect(dataStore.deleteAnnotations).toHaveBeenCalledWith([newId])
+  })
+
+  it('offsets away from the image edge when the default direction has no room', async () => {
+    const nearEdge: IAnnotation = {
+      id: 'a4',
+      type: AnnotationType.Box,
+      labelId: 'l1',
+      points: [
+        { id: 'p1', x: 90, y: 90 },
+        { id: 'p2', x: 100, y: 100 }
+      ]
+    }
+    const store = setup([nearEdge])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+    act(() => store.setState({ bitmap: { width: 100, height: 100 } as ImageBitmap }))
+
+    let newId: string | undefined
+    await act(async () => {
+      newId = store.getState().duplicateAnnotation('a4')
+      await flush()
+    })
+
+    const duplicate = store.getState().sample!.resolve().annotations.resolve()[newId!].resolve()
+    // No room to the right/bottom - the box already touches the 100x100 image's edge -
+    // so it offsets left/up instead, but is still a pure translation (same shape).
+    expect(duplicate.points[0].x).toBeLessThan(nearEdge.points[0].x)
+    expect(duplicate.points[0].y).toBeLessThan(nearEdge.points[0].y)
+    expect(duplicate.points[1].x - duplicate.points[0].x).toBeCloseTo(
+      nearEdge.points[1].x - nearEdge.points[0].x
+    )
+    for (const p of duplicate.points) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(100)
+      expect(p.y).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeLessThanOrEqual(100)
+    }
+  })
+
+  it('shrinks the offset rather than placing the duplicate outside the image when neither side has room', async () => {
+    const fullImage: IAnnotation = {
+      id: 'a5',
+      type: AnnotationType.Box,
+      labelId: 'l1',
+      points: [
+        { id: 'p1', x: 0, y: 0 },
+        { id: 'p2', x: 100, y: 100 }
+      ]
+    }
+    const store = setup([fullImage])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+    act(() => store.setState({ bitmap: { width: 100, height: 100 } as ImageBitmap }))
+
+    let newId: string | undefined
+    await act(async () => {
+      newId = store.getState().duplicateAnnotation('a5')
+      await flush()
+    })
+
+    const duplicate = store.getState().sample!.resolve().annotations.resolve()[newId!].resolve()
+    for (const p of duplicate.points) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(100)
+      expect(p.y).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeLessThanOrEqual(100)
+    }
+  })
+})
+
+describe('useLabeler convertAnnotationType', () => {
+  it('converts a box to a 4-point polygon and back', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.updateAnnotations).mockImplementation(async (updates) =>
+      updates.map((u) => ({ ...annotationA, ...u }))
+    )
+    vi.mocked(dataStore.replacePoints).mockImplementation(async (_id, points) =>
+      (points as IPoint[]).map((p) => ({ id: p.id, x: p.x, y: p.y }))
+    )
+
+    await act(async () => {
+      store.getState().convertAnnotationType('a1')
+      await flush()
+    })
+
+    const converted = store.getState().sample!.resolve().annotations.resolve().a1.resolve()
+    expect(converted.type).toBe(AnnotationType.Polygon)
+    expect(converted.points).toHaveLength(4)
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    const restored = store.getState().sample!.resolve().annotations.resolve().a1.resolve()
+    expect(restored.type).toBe(AnnotationType.Box)
+    expect(restored.points.map((p) => [p.x, p.y])).toEqual(
+      annotationA.points.map((p) => [p.x, p.y])
+    )
+  })
+
+  it('converts a polygon to its bounding box', async () => {
+    const triangle: IAnnotation = {
+      id: 'a3',
+      type: AnnotationType.Polygon,
+      labelId: 'l1',
+      points: [
+        { id: 'p1', x: 0, y: 0 },
+        { id: 'p2', x: 20, y: 0 },
+        { id: 'p3', x: 10, y: 10 }
+      ]
+    }
+    const store = setup([triangle])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.updateAnnotations).mockImplementation(async (updates) =>
+      updates.map((u) => ({ ...triangle, ...u }))
+    )
+    vi.mocked(dataStore.replacePoints).mockImplementation(async (_id, points) =>
+      (points as IPoint[]).map((p) => ({ id: p.id, x: p.x, y: p.y }))
+    )
+
+    await act(async () => {
+      store.getState().convertAnnotationType('a3')
+      await flush()
+    })
+
+    const converted = store.getState().sample!.resolve().annotations.resolve().a3.resolve()
+    expect(converted.type).toBe(AnnotationType.Box)
+    expect(converted.points.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [20, 10]
+    ])
+  })
+})
+
+describe('useLabeler selected annotation hit ids', () => {
+  it("keeps a Box's corner/edge sentinel hit ids selectable after a move", async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.replacePoints).mockImplementation(async (_id, points) =>
+      (points as IPoint[]).map((p) => ({ id: p.id, x: p.x, y: p.y }))
+    )
+
+    act(() => {
+      store.getState().selectAnnotation('a1')
+      store.getState().moveSelectedAnnotationBy(5, 5)
+    })
+    await act(async () => {
+      store.getState().commitAnnotationMove('a1')
+      await flush()
+    })
+
+    expect(
+      store.getState().selectedAnnotationControlHitIds.getByValue(BOX_CORNER_HANDLE_TOP_RIGHT)
+    ).toBeDefined()
+    expect(
+      store.getState().selectedAnnotationControlHitIds.getByValue(BOX_CORNER_HANDLE_BOTTOM_LEFT)
+    ).toBeDefined()
+    expect(store.getState().selectedAnnotationLineHitIds.getByValue(BOX_EDGE_TOP)).toBeDefined()
+    expect(store.getState().selectedAnnotationLineHitIds.getByValue(BOX_EDGE_RIGHT)).toBeDefined()
+    expect(store.getState().selectedAnnotationLineHitIds.getByValue(BOX_EDGE_BOTTOM)).toBeDefined()
+    expect(store.getState().selectedAnnotationLineHitIds.getByValue(BOX_EDGE_LEFT)).toBeDefined()
+  })
+})
+
+describe('useLabeler label picker sync', () => {
+  it('switches selectedLabelId to match the clicked annotation', () => {
+    const store = setup([annotationA])
+    act(() => store.getState().setLabelId('l2'))
+    expect(store.getState().selectedLabelId).toBe('l2')
+
+    act(() => store.getState().selectAnnotation('a1'))
+
+    expect(store.getState().selectedLabelId).toBe('l1')
+  })
+
+  it('leaves selectedLabelId alone when deselecting', () => {
+    const store = setup([annotationA])
+    act(() => {
+      store.getState().setLabelId('l2')
+      store.getState().selectAnnotation('a1')
+    })
+    expect(store.getState().selectedLabelId).toBe('l1')
+
+    act(() => store.getState().selectAnnotation(null))
+
+    expect(store.getState().selectedLabelId).toBe('l1')
+  })
+
+  it('keeps selectedLabelId in sync when the selected annotation is relabeled, including via undo', async () => {
+    const store = setup([annotationA])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.updateAnnotations).mockImplementation(async (updates) =>
+      updates.map((u) => ({ ...annotationA, ...u }))
+    )
+
+    act(() => store.getState().selectAnnotation('a1'))
+    expect(store.getState().selectedLabelId).toBe('l1')
+
+    await act(async () => {
+      store.getState().setAnnotationLabelId('a1', 'l2')
+      await flush()
+    })
+
+    expect(store.getState().selectedLabelId).toBe('l2')
+
+    await act(async () => {
+      store.getState().undo()
+      await flush()
+    })
+
+    expect(store.getState().selectedLabelId).toBe('l1')
+  })
+
+  it('does not change selectedLabelId when relabeling an annotation that is not selected', async () => {
+    const store = setup([annotationA, annotationB])
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.updateAnnotations).mockImplementation(async (updates) =>
+      updates.map((u) => ({ ...annotationB, ...u }))
+    )
+
+    act(() => store.getState().selectAnnotation('a1'))
+    expect(store.getState().selectedLabelId).toBe('l1')
+
+    await act(async () => {
+      store.getState().setAnnotationLabelId('a2', 'l2')
+      await flush()
+    })
+
+    expect(store.getState().selectedLabelId).toBe('l1')
+  })
+})

--- a/src/renderer/src/hooks/useAnnotatorRuntime.ts
+++ b/src/renderer/src/hooks/useAnnotatorRuntime.ts
@@ -1,0 +1,66 @@
+import type { AnnotatorLabel } from '@renderer/types'
+import { create } from 'zustand'
+
+type AnnotatorRuntimeEntry = {
+  labels: AnnotatorLabel[]
+  mappingByProjectId: Record<string, Record<string, string | null>>
+}
+
+type AnnotatorRuntimeState = {
+  entries: Record<string, AnnotatorRuntimeEntry>
+}
+
+type AnnotatorRuntimeActions = {
+  activate: (annotatorId: string, labels: AnnotatorLabel[]) => void
+  setMapping: (
+    annotatorId: string,
+    projectId: string,
+    mapping: Record<string, string | null>
+  ) => void
+  forget: (annotatorId: string) => void
+}
+
+/** Deliberately plain in-memory state, not backed by any store/database - an annotator's
+ *  label vocabulary and its mapping against a project's labels are only ever known once
+ *  the app connects to it (see components/annotators/AnnotatorsModal.tsx), and both are
+ *  discarded on reload rather than persisted anywhere. */
+export const useAnnotatorRuntime = create<AnnotatorRuntimeState & AnnotatorRuntimeActions>(
+  (set) => ({
+    entries: {},
+
+    activate: (annotatorId, labels) =>
+      set((state) => ({
+        entries: {
+          ...state.entries,
+          [annotatorId]: {
+            labels,
+            mappingByProjectId: state.entries[annotatorId]?.mappingByProjectId ?? {}
+          }
+        }
+      })),
+
+    setMapping: (annotatorId, projectId, mapping) =>
+      set((state) => {
+        const existing = state.entries[annotatorId]
+        if (existing === undefined) return state
+
+        return {
+          entries: {
+            ...state.entries,
+            [annotatorId]: {
+              ...existing,
+              mappingByProjectId: { ...existing.mappingByProjectId, [projectId]: mapping }
+            }
+          }
+        }
+      }),
+
+    forget: (annotatorId) =>
+      set((state) => {
+        if (!(annotatorId in state.entries)) return state
+        const entries = { ...state.entries }
+        delete entries[annotatorId]
+        return { entries }
+      })
+  })
+)

--- a/src/renderer/src/hooks/useAnnotators.ts
+++ b/src/renderer/src/hooks/useAnnotators.ts
@@ -1,0 +1,81 @@
+import { useCallback } from 'react'
+import { makeUUID } from '@shared/utils'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+const ANNOTATORS_QUERY_KEY = ['annotators'] as const
+/** Annotators are store-agnostic and project-agnostic app-level data (see
+ *  main/appStore.ts) - fetched straight off window.appStore rather than through
+ *  useAppStore's pluggable IDataStore, the same way window.system/window.exportApi are
+ *  called directly elsewhere without going through a zustand slice. */
+export const useAnnotators = () => {
+  const queryClient = useQueryClient()
+
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ANNOTATORS_QUERY_KEY,
+    queryFn: () => window.appStore.getAnnotators()
+  })
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ANNOTATORS_QUERY_KEY }),
+    [queryClient]
+  )
+
+  const { mutateAsync: createMutateAsync } = useMutation({
+    mutationFn: ({
+      id,
+      name,
+      url,
+      headers
+    }: {
+      id: string
+      name: string
+      url: string
+      headers: Record<string, string>
+    }) => window.appStore.createAnnotator(id, name, url, headers),
+    onSuccess: invalidate
+  })
+
+  const create = useCallback(
+    async (name: string, url: string, headers: Record<string, string>) => {
+      const id = makeUUID()
+      await createMutateAsync({ id, name, url, headers })
+      return id
+    },
+    [createMutateAsync]
+  )
+
+  const { mutateAsync: updateMutateAsync } = useMutation({
+    mutationFn: ({
+      id,
+      name,
+      url,
+      headers
+    }: {
+      id: string
+      name: string
+      url: string
+      headers: Record<string, string>
+    }) => window.appStore.updateAnnotators([{ id, name, url, headers }]),
+    onSuccess: invalidate
+  })
+
+  const update = useCallback(
+    async (id: string, name: string, url: string, headers: Record<string, string>) => {
+      await updateMutateAsync({ id, name, url, headers })
+    },
+    [updateMutateAsync]
+  )
+
+  const { mutateAsync: removeMutateAsync } = useMutation({
+    mutationFn: (ids: string[]) => window.appStore.deleteAnnotators(ids),
+    onSuccess: invalidate
+  })
+
+  const remove = useCallback(
+    async (id: string) => {
+      await removeMutateAsync([id])
+    },
+    [removeMutateAsync]
+  )
+
+  return { items, isLoading, create, update, remove }
+}

--- a/src/renderer/src/hooks/useCopyAnnotations.ts
+++ b/src/renderer/src/hooks/useCopyAnnotations.ts
@@ -1,0 +1,137 @@
+import { errorToString, makeUUID } from '@shared/utils'
+import { INewAnnotation } from '@shared/types'
+import { OptimisticSample } from '@renderer/types'
+import { useAppStore } from './useAppStore'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useState } from 'react'
+
+export type CopyAnnotationsPair = {
+  source: OptimisticSample
+  destination: OptimisticSample
+}
+
+export type CopyAnnotationsFailure = {
+  sampleId: string
+  sampleName: string
+  error: string
+}
+
+export type CopyAnnotationsProgress = {
+  total: number
+  completed: number
+  copied: number
+  alreadyLabeled: number
+  dimensionMismatch: number
+  duplicateDestination: number
+  failures: CopyAnnotationsFailure[]
+}
+
+const INITIAL_PROGRESS: CopyAnnotationsProgress = {
+  total: 0,
+  completed: 0,
+  copied: 0,
+  alreadyLabeled: 0,
+  dimensionMismatch: 0,
+  duplicateDestination: 0,
+  failures: []
+}
+
+/** Copies each pair's source-sample annotations onto its destination sample, skipping a
+ *  pair whose destination already has annotations (never overwrite manual work), whose
+ *  source/destination dimensions differ (points are absolute pixel coordinates, so a
+ *  verbatim copy is only correct when the images are the same size), or whose destination
+ *  was already claimed by an earlier pair in this same run (first pair mapped to a given
+ *  destination wins - prevents double-copying into it). Runs sequentially and keeps going
+ *  past a per-pair failure, same as useRunAnnotator. */
+export const useCopyAnnotations = (destinationTaskId: string) => {
+  const store = useAppStore((s) => s.store)
+  const queryClient = useQueryClient()
+  const [progress, setProgress] = useState<CopyAnnotationsProgress>(INITIAL_PROGRESS)
+  const [isRunning, setIsRunning] = useState(false)
+
+  const run = useCallback(
+    async (pairs: CopyAnnotationsPair[]) => {
+      const seenDestinationIds = new Set<string>()
+      const targets: CopyAnnotationsPair[] = []
+      let alreadyLabeled = 0
+      let dimensionMismatch = 0
+      let duplicateDestination = 0
+
+      for (const pair of pairs) {
+        const destination = pair.destination.resolve()
+        if (seenDestinationIds.has(destination.id)) {
+          duplicateDestination++
+          continue
+        }
+        seenDestinationIds.add(destination.id)
+
+        if (Object.keys(destination.annotations.resolve()).length > 0) {
+          alreadyLabeled++
+          continue
+        }
+
+        const source = pair.source.resolve()
+        if (source.width !== destination.width || source.height !== destination.height) {
+          dimensionMismatch++
+          continue
+        }
+
+        targets.push(pair)
+      }
+
+      setIsRunning(true)
+      setProgress({
+        ...INITIAL_PROGRESS,
+        total: targets.length,
+        alreadyLabeled,
+        dimensionMismatch,
+        duplicateDestination
+      })
+
+      for (const pair of targets) {
+        const source = pair.source.resolve()
+        const destination = pair.destination.resolve()
+        const newAnnotations: INewAnnotation[] = Object.values(source.annotations.resolve())
+          .map((a) => a.resolve())
+          .map((a) => ({
+            id: makeUUID(),
+            type: a.type,
+            labelId: a.labelId,
+            points: a.points.map((p) => ({ id: makeUUID(), x: p.x, y: p.y }))
+          }))
+
+        try {
+          if (newAnnotations.length > 0) {
+            await store.createAnnotations(destination.id, newAnnotations)
+          }
+          setProgress((current) => ({
+            ...current,
+            completed: current.completed + 1,
+            copied: current.copied + newAnnotations.length
+          }))
+        } catch (error) {
+          setProgress((current) => ({
+            ...current,
+            completed: current.completed + 1,
+            failures: [
+              ...current.failures,
+              {
+                sampleId: destination.id,
+                sampleName: destination.name,
+                error: errorToString(error)
+              }
+            ]
+          }))
+        }
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['samples', destinationTaskId, store] })
+      setIsRunning(false)
+    },
+    [store, queryClient, destinationTaskId]
+  )
+
+  const reset = useCallback(() => setProgress(INITIAL_PROGRESS), [])
+
+  return { run, reset, progress, isRunning }
+}

--- a/src/renderer/src/hooks/useLabeler.ts
+++ b/src/renderer/src/hooks/useLabeler.ts
@@ -8,10 +8,34 @@ import { clamp } from '@mantine/hooks'
 import { useAppStore } from '@renderer/hooks/useAppStore'
 import { OptimisticObject } from '@renderer/util/optimistic_object'
 import { ColorGenerator } from '@renderer/util/color_generator'
+import {
+  boundingBoxOf,
+  type BoundingBox
+} from '@renderer/components/sampleIO/exporters/annotationShape'
 
 const ZOOM_STEP_DELTA = 0.15
 const MIN_ZOOM = 0.05
 const MAX_ZOOM = 32
+
+/** A box only ever has 2 real points (opposite corners, normalized to
+ *  [top-left, bottom-right] by normalizeAnnotationPoints), but shows 4 draggable
+ *  handles - these 2 sentinels stand in for the other two (derived) corners in
+ *  selectedAnnotationControlHitIds/moveAnnotationPoint. Dragging one moves one real
+ *  point's x and the other real point's y (see pointIdsBeingMovedAxis) rather than
+ *  corresponding to a single real IPoint. Only ever meaningful while a Box is selected,
+ *  where there's exactly one of each in play at a time, so a fixed literal (rather than
+ *  a per-annotation id) is fine. */
+export const BOX_CORNER_HANDLE_TOP_RIGHT = '__box-corner-top-right__'
+export const BOX_CORNER_HANDLE_BOTTOM_LEFT = '__box-corner-bottom-left__'
+
+/** A box's 4 edges - draggable to resize along a single axis, moving only the real
+ *  point on that edge (see moveAnnotationPoint). Unlike a Polygon's lines, these never go
+ *  through addControlPoint - a Box only ever has 2 real points, so there's nothing to
+ *  insert a new point into. */
+export const BOX_EDGE_TOP = '__box-edge-top__'
+export const BOX_EDGE_RIGHT = '__box-edge-right__'
+export const BOX_EDGE_BOTTOM = '__box-edge-bottom__'
+export const BOX_EDGE_LEFT = '__box-edge-left__'
 
 const createLabelsMap = (labels: ILabel[]) => {
   const labelsMap: Record<string, ILabel> = {}
@@ -47,6 +71,23 @@ export const normalizeAnnotationPoints = <T extends Pick<IAnnotation, 'type' | '
   // }))
 
   return fixedAnnotation
+}
+
+/** How much of moveCurrent applies to a given point mid-drag: the full (dx, dy) if it
+ *  isn't axis-masked (the default for polygon vertices and whole-annotation moves), or just
+ *  one axis for a box's 2 derived corner handles (see BOX_CORNER_HANDLE_TOP_RIGHT).
+ *  Returns [0, 0] for a point that isn't part of the current drag at all. Shared between
+ *  commitAnnotationMove here and the Labeler canvas's live drag preview. */
+export const axisMaskedMoveDelta = (
+  pointId: string,
+  pointIdsBeingMoved: string[] | null,
+  pointIdsBeingMovedAxis: ('x' | 'y' | 'xy')[] | null,
+  moveCurrent: Vector2
+): Vector2 => {
+  const idx = pointIdsBeingMoved?.indexOf(pointId) ?? -1
+  if (idx === -1) return [0, 0]
+  const axis = pointIdsBeingMovedAxis?.[idx] ?? 'xy'
+  return [axis === 'y' ? 0 : moveCurrent[0], axis === 'x' ? 0 : moveCurrent[1]]
 }
 
 const loadBitmap = (uri: string, signal?: AbortSignal) => {
@@ -148,6 +189,12 @@ type LabelerStoreState = {
    */
   moveCurrent: Vector2
   pointIdsBeingMoved: string[] | null
+  /** Parallel array to pointIdsBeingMoved: which axis of moveCurrent each point gets.
+   *  null (or a missing entry) means that point gets the full (dx, dy) - the default for
+   *  polygon vertices and whole-annotation moves. Only a box's 2 derived corner handles
+   *  (top-right/bottom-left) need per-point axis splitting, since dragging one moves one
+   *  real point's x and the other real point's y rather than both axes of a single point. */
+  pointIdsBeingMovedAxis: ('x' | 'y' | 'xy')[] | null
   annotationIdBeingMoved: string | null
   mode: LabelerMode
   showHitTestDebugOverlay: boolean
@@ -168,6 +215,24 @@ type LabelerStoreState = {
   annotationBeingCreated: INewAnnotation | null
   readonly labelsMap: Record<string, ILabel>
   // hitHandlers: Map<string,(e: unknown) => void>
+
+  /** Whether the mouse is anywhere over the AnnotationsDrawer's row list - drives
+   *  whether the canvas is dimmed at all. Deliberately broader than hoveredAnnotationId:
+   *  keying the dim itself off a specific row would flicker off/on every time the mouse
+   *  crosses the gap between two rows (or a group header) on its way from one to
+   *  another - this way the dim stays on continuously across the whole drawer, and only
+   *  the spotlighted shape changes as hoveredAnnotationId changes underneath it. */
+  isAnnotationsDrawerHovered: boolean
+  /** The annotation whose row is currently hovered, if any - drives which shape (if any)
+   *  gets cut out of the dim/gets its outline emphasized. Not the same as
+   *  selectedAnnotation, which persists across mouse movement. */
+  hoveredAnnotationId: string | null
+
+  /** Per-sample undo/redo history - cleared on setSample (see there). Each entry captures
+   *  enough before/after data to replay a single create/delete/points/relabel mutation in
+   *  either direction via the shared apply* primitives (see undo/redo). */
+  readonly undoStack: HistoryEntry[]
+  readonly redoStack: HistoryEntry[]
 }
 
 export type HitTestResult =
@@ -187,11 +252,28 @@ export type HitTestResult =
       lineControlPointId: string
     }
 
+export type HistoryEntry =
+  | { kind: 'create'; annotation: IAnnotation }
+  | { kind: 'delete'; annotation: IAnnotation }
+  | { kind: 'points'; annotationId: string; before: IPoint[]; after: IPoint[] }
+  | { kind: 'relabel'; annotationId: string; beforeLabelId: string; afterLabelId: string }
+  | {
+      kind: 'convert'
+      annotationId: string
+      beforeType: AnnotationType
+      beforePoints: IPoint[]
+      afterType: AnnotationType
+      afterPoints: IPoint[]
+    }
+
 type LabelerStoreActions = {
   markAllDirty: () => void
   preDraw: () => void
   onCanvasResize: (width: number, height: number) => void
   setSample: (sample: OptimisticSample) => void
+  /** Aborts an in-flight bitmap load without starting a new one - for leaving the page
+   *  mid-load, as opposed to setSample's own abort-then-restart when switching samples. */
+  cancelPendingSampleLoad: () => void
   onBitmapLoaded: (bitmap: ImageBitmap) => void
   //onMouseOver: (x: number, y: number) => void
   zoom: (x: number, y: number, delta: number) => void
@@ -213,9 +295,16 @@ type LabelerStoreActions = {
   canvasToBitmapSpace: (x: number, y: number) => [x: number, y: number]
   deleteAnnotation: (annotationId: string) => void
   deleteSelectedAnnotation: () => void
+  duplicateAnnotation: (annotationId: string) => string | undefined
+  duplicateSelectedAnnotation: () => void
+  convertAnnotationType: (annotationId: string) => void
   addControlPoint: (lineId: string, x: number, y: number) => string | undefined
   deleteControlPoint: (controlPointId: string) => void
   hittest: (x: number, y: number) => HitTestResult | null
+  setHoveredAnnotation: (id: string | null) => void
+  setAnnotationsDrawerHovered: (hovered: boolean) => void
+  undo: () => void
+  redo: () => void
 }
 
 export type LabelerStore = LabelerStoreState & LabelerStoreActions
@@ -269,6 +358,35 @@ export const useLabeler = (labels: ILabel[]) => {
 
           selectedAnnotationControlHitIds.clear()
           selectedAnnotationLineHitIds.clear()
+        }
+
+        /** Rebuilds selectedAnnotationControlHitIds/selectedAnnotationLineHitIds from
+         *  scratch for `annotation` - the single source of truth for what a selected
+         *  annotation's hit ids should look like, shared by selectAnnotation and any
+         *  primitive that swaps out a selected annotation's points/type in place
+         *  (replacePoints, type conversion). A Box's derived corner and edge sentinel
+         *  handles only ever get set up here - they're not per-point, so a naive
+         *  "re-add each real point" resync (as addSelectedAnnotationPointId does for
+         *  Polygon) would silently lose them. */
+        const rebuildSelectedAnnotationHitIds = (annotation: IAnnotation) => {
+          clearSelectedAnnotationHitIds()
+
+          for (const point of annotation.points) {
+            selectedAnnotationControlHitIds.set(makeHitId(), point.id)
+          }
+
+          if (annotation.type === AnnotationType.Polygon) {
+            for (const point of annotation.points) {
+              selectedAnnotationLineHitIds.set(makeHitId(), point.id)
+            }
+          } else if (annotation.type === AnnotationType.Box) {
+            selectedAnnotationControlHitIds.set(makeHitId(), BOX_CORNER_HANDLE_TOP_RIGHT)
+            selectedAnnotationControlHitIds.set(makeHitId(), BOX_CORNER_HANDLE_BOTTOM_LEFT)
+            selectedAnnotationLineHitIds.set(makeHitId(), BOX_EDGE_TOP)
+            selectedAnnotationLineHitIds.set(makeHitId(), BOX_EDGE_RIGHT)
+            selectedAnnotationLineHitIds.set(makeHitId(), BOX_EDGE_BOTTOM)
+            selectedAnnotationLineHitIds.set(makeHitId(), BOX_EDGE_LEFT)
+          }
         }
 
         const addSelectedAnnotationPointId = (pointId: string) => {
@@ -401,6 +519,295 @@ export const useLabeler = (labels: ILabel[]) => {
           return getCanvasCenter()
         }
 
+        /** Records an undoable mutation and drops any redo history - matches standard
+         *  editor UX (a new edit invalidates whatever was undone before it). Only called by
+         *  the 4 public mutation actions, never by undo()/redo() themselves (those manage
+         *  the two stacks directly so undoing/redoing doesn't clear the other stack). */
+        const pushHistory = (entry: HistoryEntry) =>
+          set((state) => ({ undoStack: [...state.undoStack, entry], redoStack: [] }))
+
+        /** Optimistically creates `annotation`, then persists it - shared by
+         *  onConfirmAnnotationCreation (a brand new annotation) and undo/redo (replaying a
+         *  previously deleted/created annotation, id and all). */
+        const applyCreateAnnotation = (annotation: IAnnotation) => {
+          const state = get()
+          if (state.sample === null) return
+
+          const dataStore = useAppStore.getState().store
+          const annotations = state.sample.resolve().annotations
+          const newAnnotation = new OptimisticObject(annotation)
+          const { commit, rollback } = annotations.update({
+            [annotation.id]: newAnnotation
+          })
+
+          const sampleId = state.sample.resolve().id
+          set({ annotationDirty: true })
+          dataStore
+            .createAnnotations(sampleId, [annotation])
+            .then((results) => {
+              newAnnotation.updateBase(results[0])
+              commit()
+              if (sampleId === get().sample?.resolve().id) {
+                addAnnotationHitIds(results[0].id)
+                set({ annotationDirty: true, hitTestDirty: true })
+              }
+            })
+            .catch(() => {
+              rollback()
+              if (sampleId === get().sample?.resolve().id) {
+                set({ annotationDirty: true })
+              }
+            })
+        }
+
+        /** Optimistically removes the annotation with id annotationId, then persists the
+         *  delete - shared by deleteAnnotation and undo/redo (undoing a create, or redoing a
+         *  delete). */
+        const applyDeleteAnnotation = (annotationId: string) => {
+          const state = get()
+          const annotations = state.sample?.resolve().annotations
+          if (annotations === undefined) return
+
+          const annotation = annotations.resolve()[annotationId]?.resolve() ?? null
+          if (annotation === null) return
+
+          let selectedAnnotation = state.selectedAnnotation
+          if (state.selectedAnnotation?.resolve().id === annotationId) {
+            selectedAnnotation = null
+          }
+
+          const { commit, rollback } = annotations.update({
+            [annotationId]: undefined
+          })
+          const dataStore = useAppStore.getState().store
+          freeAnnotationHitIds(annotationId)
+          set({
+            selectedAnnotation,
+            hoveredAnnotationId:
+              state.hoveredAnnotationId === annotationId ? null : state.hoveredAnnotationId,
+            annotationDirty: true,
+            hitTestDirty: true
+          })
+          const sampleId = state.sample?.resolve().id
+          dataStore
+            .deleteAnnotations([annotationId])
+            .then((c) => {
+              if (!c[0]) {
+                throw new Error('Failed to delete annotation')
+              }
+              commit()
+            })
+            .catch(() => {
+              rollback()
+              if (sampleId === get().sample?.resolve().id) {
+                addAnnotationHitIds(annotationId)
+              }
+            })
+            .finally(() => {
+              if (sampleId === get().sample?.resolve().id) {
+                set({ annotationDirty: true, hitTestDirty: true })
+              }
+            })
+        }
+
+        /** Optimistically replaces an annotation's full points array, then persists it -
+         *  the shared primitive behind commitAnnotationMove, addControlPoint,
+         *  deleteControlPoint, and undo/redo of any of those (a move only ever changes
+         *  existing points' coordinates, while add/delete-control-point also changes which
+         *  point ids exist - replacePoints' id-diffing on the main-process side handles
+         *  both the same way, so one primitive covers all of them). Always resyncs the
+         *  selected annotation's hit ids afterward, since the point id set may have
+         *  changed. */
+        const applyReplacePoints = (annotationId: string, points: IPoint[]) => {
+          const state = get()
+          const annotation = state.sample?.resolve().annotations.resolve()[annotationId]
+          if (annotation === undefined) return
+
+          const sampleId = state.sample?.resolve().id
+          const dataStore = useAppStore.getState().store
+          const { commit, rollback } = annotation.update({ points })
+          set({ annotationDirty: true, hitTestDirty: true })
+          dataStore
+            .replacePoints(annotationId, points)
+            .then((resultPoints) => {
+              commit({ points: resultPoints })
+            })
+            .catch((e) => {
+              console.error(e)
+              rollback()
+            })
+            .finally(() => {
+              const stillSelected = get().selectedAnnotation
+              if (stillSelected?.resolve().id === annotationId) {
+                rebuildSelectedAnnotationHitIds(stillSelected.resolve())
+              }
+              if (sampleId === get().sample?.resolve().id) {
+                set({ annotationDirty: true, hitTestDirty: true })
+              }
+            })
+        }
+
+        /** Optimistically relabels an annotation, then persists it - shared by
+         *  setAnnotationLabelId and undo/redo. Also keeps the label picker in sync if the
+         *  relabeled annotation is the one currently selected, mirroring selectAnnotation's
+         *  own sync - otherwise relabeling via the context menu (or undoing/redoing one)
+         *  would leave the picker showing a label the selection no longer has. */
+        const applyRelabel = (annotationId: string, labelId: string) => {
+          const state = get()
+          const targetAnnotation =
+            state.sample?.resolve().annotations.resolve()[annotationId] ?? null
+          if (targetAnnotation === null) return
+
+          const { commit, rollback } = targetAnnotation.update({ labelId })
+          const dataStore = useAppStore.getState().store
+          set({
+            annotationDirty: true,
+            ...(state.selectedAnnotation?.resolve().id === annotationId
+              ? { selectedLabelId: labelId }
+              : {})
+          })
+          const sampleId = state.sample?.resolve().id
+          dataStore
+            .updateAnnotations([{ id: annotationId, labelId }])
+            .then((c) => {
+              commit(c[0])
+            })
+            .catch(() => {
+              rollback()
+            })
+            .finally(() => {
+              if (sampleId === get().sample?.resolve().id) {
+                set({ annotationDirty: true })
+              }
+            })
+        }
+
+        /** Optimistically swaps an annotation's type and points together (one atomic
+         *  diff), then persists both - shared by convertAnnotationType and undo/redo of a
+         *  conversion. Persistence is still 2 separate IPC calls (updateAnnotations only
+         *  touches type/labelId, replacePoints only touches points), fired concurrently
+         *  and committed/rolled back together so the optimistic view never shows a
+         *  half-converted annotation (new type, stale points or vice versa). */
+        const applyConvertType = (annotationId: string, type: AnnotationType, points: IPoint[]) => {
+          const state = get()
+          const annotation = state.sample?.resolve().annotations.resolve()[annotationId]
+          if (annotation === undefined) return
+
+          const sampleId = state.sample?.resolve().id
+          const dataStore = useAppStore.getState().store
+          const { commit, rollback } = annotation.update({ type, points })
+          set({ annotationDirty: true, hitTestDirty: true })
+          Promise.all([
+            dataStore.updateAnnotations([{ id: annotationId, type }]),
+            dataStore.replacePoints(annotationId, points)
+          ])
+            .then(([updateResults, pointResults]) => {
+              commit({ type: updateResults[0]?.type, points: pointResults })
+            })
+            .catch((e) => {
+              console.error(e)
+              rollback()
+            })
+            .finally(() => {
+              const stillSelected = get().selectedAnnotation
+              if (stillSelected?.resolve().id === annotationId) {
+                rebuildSelectedAnnotationHitIds(stillSelected.resolve())
+              }
+              if (sampleId === get().sample?.resolve().id) {
+                set({ annotationDirty: true, hitTestDirty: true })
+              }
+            })
+        }
+
+        /** A Box's own 2 real points (top-left/bottom-right, per normalizeAnnotationPoints)
+         *  become a Polygon's 4 corner points - fresh point ids throughout, since a
+         *  Polygon needs more points than a Box ever has. */
+        const boxPointsToPolygonPoints = (points: IPoint[]): IPoint[] => {
+          const [topLeft, bottomRight] = points
+          return [
+            { id: makeUUID(), x: topLeft.x, y: topLeft.y },
+            { id: makeUUID(), x: bottomRight.x, y: topLeft.y },
+            { id: makeUUID(), x: bottomRight.x, y: bottomRight.y },
+            { id: makeUUID(), x: topLeft.x, y: bottomRight.y }
+          ]
+        }
+
+        /** A Polygon's outline is reduced to its axis-aligned bounding box - necessarily
+         *  lossy (a non-rectangular outline can't survive becoming a Box), reusing the
+         *  same boundingBoxOf the exporters already rely on for the same "give every
+         *  annotation a rectangle" reduction. */
+        const polygonPointsToBoxPoints = (points: IPoint[]): IPoint[] => {
+          const box = boundingBoxOf(points)
+          return [
+            { id: makeUUID(), x: box.minX, y: box.minY },
+            { id: makeUUID(), x: box.minX + box.width, y: box.minY + box.height }
+          ]
+        }
+
+        const DUPLICATE_OFFSET_RATIO = 0.08
+        const DUPLICATE_OFFSET_MIN = 12
+
+        /** How far a duplicate is nudged from its original, scaled to the source
+         *  annotation's own size (not the image's) so a tiny annotation still gets a
+         *  clearly visible offset and a huge one doesn't jump by an absurd amount -
+         *  floored so a degenerate (near-zero-area) annotation still visibly offsets. */
+        const duplicateOffsetFor = (box: BoundingBox): number =>
+          Math.max(DUPLICATE_OFFSET_MIN, Math.max(box.width, box.height) * DUPLICATE_OFFSET_RATIO)
+
+        /** Picks how far to nudge one axis of a duplicate so its whole bounding box stays
+         *  inside [0, extent] - prefers the default positive (down/right) direction, falls
+         *  back to negative (up/left) when that side is the one with room, and only falls
+         *  short of `desired` when the source annotation is close enough to the image's
+         *  full size that neither side has room for it. Always a single scalar applied
+         *  uniformly to every point (see duplicateAnnotation), never a per-point clamp, so
+         *  the duplicate is nudged less far (or the other way) rather than distorted. */
+        const clampedDuplicateAxisOffset = (
+          min: number,
+          size: number,
+          extent: number,
+          desired: number
+        ) => {
+          const spaceAfter = extent - (min + size)
+          const spaceBefore = min
+          if (spaceAfter >= desired) return desired
+          if (spaceBefore >= desired) return -desired
+          return spaceAfter >= spaceBefore ? spaceAfter : -spaceBefore
+        }
+
+        /** Undoing a just-created annotation before its createAnnotations call has
+         *  resolved races the resulting deleteAnnotations call server-side - a pre-existing
+         *  class of risk (the same as a fast create-then-delete via the UI today), not
+         *  introduced or fixed by undo/redo. */
+        const applyHistoryInverse = (entry: HistoryEntry) => {
+          switch (entry.kind) {
+            case 'create':
+              return applyDeleteAnnotation(entry.annotation.id)
+            case 'delete':
+              return applyCreateAnnotation(entry.annotation)
+            case 'points':
+              return applyReplacePoints(entry.annotationId, entry.before)
+            case 'relabel':
+              return applyRelabel(entry.annotationId, entry.beforeLabelId)
+            case 'convert':
+              return applyConvertType(entry.annotationId, entry.beforeType, entry.beforePoints)
+          }
+        }
+
+        const applyHistoryForward = (entry: HistoryEntry) => {
+          switch (entry.kind) {
+            case 'create':
+              return applyCreateAnnotation(entry.annotation)
+            case 'delete':
+              return applyDeleteAnnotation(entry.annotation.id)
+            case 'points':
+              return applyReplacePoints(entry.annotationId, entry.after)
+            case 'relabel':
+              return applyRelabel(entry.annotationId, entry.afterLabelId)
+            case 'convert':
+              return applyConvertType(entry.annotationId, entry.afterType, entry.afterPoints)
+          }
+        }
+
         const initialState: LabelerStoreState = {
           imageHitId: imageHitId,
           sizeDirty: false,
@@ -431,7 +838,12 @@ export const useLabeler = (labels: ILabel[]) => {
           sample: null,
           moveCurrent: [0, 0],
           pointIdsBeingMoved: null,
-          annotationIdBeingMoved: null
+          pointIdsBeingMovedAxis: null,
+          annotationIdBeingMoved: null,
+          isAnnotationsDrawerHovered: false,
+          hoveredAnnotationId: null,
+          undoStack: [],
+          redoStack: []
         }
 
         return {
@@ -477,11 +889,17 @@ export const useLabeler = (labels: ILabel[]) => {
             }
 
             const inCreateMode =
-              state.mode === LabelerMode.CreateBox || state.mode === LabelerMode.CreateMask
+              state.mode === LabelerMode.CreateBox || state.mode === LabelerMode.CreatePolygon
             set({
               mousePos: [x, y],
               annotationBeingCreated: annotationBeingCreated,
-              annotationDirty: changed || inCreateMode
+              // OR'd with the current flag, never overwritten to false here - clearing
+              // dirty flags is preDraw()'s job exclusively. This listens globally (see
+              // usePointerMove), so it fires on every mouse move across the whole app;
+              // unconditionally overwriting annotationDirty raced with (and could
+              // silently clobber) a `true` some other action - e.g. the AnnotationsDrawer's
+              // hover spotlight - had just set moments earlier but hadn't been painted yet.
+              annotationDirty: state.annotationDirty || changed || inCreateMode
             })
           },
           zoom: (x: number, y: number, delta: number) => {
@@ -544,7 +962,8 @@ export const useLabeler = (labels: ILabel[]) => {
               return
             }
 
-            const type = mode === LabelerMode.CreateBox ? AnnotationType.Box : AnnotationType.Mask
+            const type =
+              mode === LabelerMode.CreateBox ? AnnotationType.Box : AnnotationType.Polygon
 
             set({
               mode,
@@ -568,24 +987,26 @@ export const useLabeler = (labels: ILabel[]) => {
           selectAnnotation: (id: string | null) => {
             if ((get().selectedAnnotation?.resolve().id ?? null) === id) return
 
-            clearSelectedAnnotationHitIds()
             let annotation: OptimisticObject<IAnnotation> | null = null
             if (id !== null) {
               annotation = get().sample?.resolve().annotations.resolve()[id] ?? null
-              if (annotation !== null) {
-                for (const point of annotation.resolve().points) {
-                  selectedAnnotationControlHitIds.set(makeHitId(), point.id)
-                }
-
-                if (annotation.resolve().type === AnnotationType.Mask) {
-                  for (const point of annotation.resolve().points) {
-                    selectedAnnotationLineHitIds.set(makeHitId(), point.id)
-                  }
-                }
-              }
             }
 
-            set({ selectedAnnotation: annotation, annotationDirty: true, hitTestDirty: true })
+            if (annotation !== null) {
+              rebuildSelectedAnnotationHitIds(annotation.resolve())
+            } else {
+              clearSelectedAnnotationHitIds()
+            }
+
+            set({
+              selectedAnnotation: annotation,
+              annotationDirty: true,
+              hitTestDirty: true,
+              // Selecting an existing annotation switches the label picker to match it -
+              // deselecting (annotation === null) leaves it alone rather than resetting to
+              // some default, since there's nothing meaningful to switch it to.
+              ...(annotation !== null ? { selectedLabelId: annotation.resolve().labelId } : {})
+            })
           },
           onConfirmPoint: (x: number, y: number) => {
             const state = get()
@@ -608,10 +1029,9 @@ export const useLabeler = (labels: ILabel[]) => {
           onConfirmAnnotationCreation: (discardLivePoint = false) => {
             const state = get()
             if (state.annotationBeingCreated !== null && state.sample !== null) {
-              const dataStore = useAppStore.getState().store
               let annotation: INewAnnotation = state.annotationBeingCreated
 
-              if (annotation.type === AnnotationType.Mask && discardLivePoint) {
+              if (annotation.type === AnnotationType.Polygon && discardLivePoint) {
                 const committedPoints = annotation.points.slice(0, -1)
                 if (committedPoints.length < 3) {
                   return
@@ -634,29 +1054,8 @@ export const useLabeler = (labels: ILabel[]) => {
                 annotationDirty: true
               })
 
-              const annotations = state.sample.resolve().annotations
-              const newAnnotation = new OptimisticObject(annotation)
-              const { commit, rollback } = annotations.update({
-                [annotation.id]: newAnnotation
-              })
-
-              const sampleId = state.sample.resolve().id
-              dataStore
-                .createAnnotations(sampleId, [annotation])
-                .then((results) => {
-                  newAnnotation.updateBase(results[0])
-                  commit()
-                  if (sampleId === get().sample?.resolve().id) {
-                    addAnnotationHitIds(results[0].id)
-                    set({ annotationDirty: true, hitTestDirty: true })
-                  }
-                })
-                .catch(() => {
-                  rollback()
-                  if (sampleId === get().sample?.resolve().id) {
-                    set({ annotationDirty: true })
-                  }
-                })
+              applyCreateAnnotation(annotation)
+              pushHistory({ kind: 'create', annotation })
             }
           },
           setSample: (sample) => {
@@ -682,8 +1081,11 @@ export const useLabeler = (labels: ILabel[]) => {
             set({
               sample,
               selectedAnnotation: null,
+              hoveredAnnotationId: null,
               hitTestDirty: get().mode === LabelerMode.Select,
-              annotationDirty: true
+              annotationDirty: true,
+              undoStack: [],
+              redoStack: []
             })
 
             const sampleId = sample.resolve().id
@@ -705,6 +1107,9 @@ export const useLabeler = (labels: ILabel[]) => {
                 }
               })
           },
+          cancelPendingSampleLoad: () => {
+            activeSampleAbort?.abort()
+          },
           setAnnotationLabelId: (annotationId, labelId) => {
             const state = get()
             const targetAnnotation =
@@ -713,28 +1118,11 @@ export const useLabeler = (labels: ILabel[]) => {
               return
             }
 
-            const { commit, rollback } = targetAnnotation.update({ labelId: labelId })
-            const dataStore = useAppStore.getState().store
-            set({ annotationDirty: true })
-            const sampleId = state.sample?.resolve().id
-            dataStore
-              .updateAnnotations([
-                {
-                  id: targetAnnotation.resolve().id,
-                  labelId: labelId
-                }
-              ])
-              .then((c) => {
-                commit(c[0])
-              })
-              .catch(() => {
-                rollback()
-              })
-              .finally(() => {
-                if (sampleId === get().sample?.resolve().id) {
-                  set({ annotationDirty: true })
-                }
-              })
+            const beforeLabelId = targetAnnotation.resolve().labelId
+            if (beforeLabelId === labelId) return
+
+            applyRelabel(annotationId, labelId)
+            pushHistory({ kind: 'relabel', annotationId, beforeLabelId, afterLabelId: labelId })
           },
           moveSelectedAnnotationBy: (dx, dy) => {
             const state = get()
@@ -745,6 +1133,7 @@ export const useLabeler = (labels: ILabel[]) => {
             set({
               moveCurrent: [dx, dy],
               pointIdsBeingMoved: state.selectedAnnotation.resolve().points.map((c) => c.id),
+              pointIdsBeingMovedAxis: null,
               annotationIdBeingMoved: state.selectedAnnotation.resolve().id,
               annotationDirty: true,
               hitTestDirty: true
@@ -753,14 +1142,69 @@ export const useLabeler = (labels: ILabel[]) => {
           moveAnnotationPoint: (pointId, x, y) => {
             const state = get()
             if (state.selectedAnnotation === null) return
-            const point = state.selectedAnnotation.resolve().points.find((c) => c.id === pointId)
-            if (point === undefined) return
 
             const localPos = canvasToBitmapSpace(x, y)
+
+            if (
+              pointId === BOX_CORNER_HANDLE_TOP_RIGHT ||
+              pointId === BOX_CORNER_HANDLE_BOTTOM_LEFT
+            ) {
+              const boxPoints = state.selectedAnnotation.resolve().points
+              if (boxPoints.length !== 2) return
+              // Normalized by normalizeAnnotationPoints, so points[0] is always
+              // top-left and points[1] is always bottom-right.
+              const [topLeft, bottomRight] = boxPoints
+              const isTopRight = pointId === BOX_CORNER_HANDLE_TOP_RIGHT
+              // Top-right's x is the right edge (bottomRight.x); its y is the top edge
+              // (topLeft.y). Bottom-left is the mirror: left edge's x, bottom edge's y.
+              const xSource = isTopRight ? bottomRight : topLeft
+              const ySource = isTopRight ? topLeft : bottomRight
+
+              set({
+                moveCurrent: [localPos[0] - xSource.x, localPos[1] - ySource.y],
+                pointIdsBeingMoved: [xSource.id, ySource.id],
+                pointIdsBeingMovedAxis: ['x', 'y'],
+                annotationIdBeingMoved: state.selectedAnnotation.resolve().id,
+                annotationDirty: true,
+                hitTestDirty: true
+              })
+              return
+            }
+
+            if (
+              pointId === BOX_EDGE_TOP ||
+              pointId === BOX_EDGE_RIGHT ||
+              pointId === BOX_EDGE_BOTTOM ||
+              pointId === BOX_EDGE_LEFT
+            ) {
+              const boxPoints = state.selectedAnnotation.resolve().points
+              if (boxPoints.length !== 2) return
+              // Normalized by normalizeAnnotationPoints, so points[0] is always
+              // top-left and points[1] is always bottom-right.
+              const [topLeft, bottomRight] = boxPoints
+              const isTopOrLeft = pointId === BOX_EDGE_TOP || pointId === BOX_EDGE_LEFT
+              const source = isTopOrLeft ? topLeft : bottomRight
+              const axis: 'x' | 'y' =
+                pointId === BOX_EDGE_TOP || pointId === BOX_EDGE_BOTTOM ? 'y' : 'x'
+
+              set({
+                moveCurrent: [localPos[0] - source.x, localPos[1] - source.y],
+                pointIdsBeingMoved: [source.id],
+                pointIdsBeingMovedAxis: [axis],
+                annotationIdBeingMoved: state.selectedAnnotation.resolve().id,
+                annotationDirty: true,
+                hitTestDirty: true
+              })
+              return
+            }
+
+            const point = state.selectedAnnotation.resolve().points.find((c) => c.id === pointId)
+            if (point === undefined) return
 
             set({
               moveCurrent: [localPos[0] - point.x, localPos[1] - point.y],
               pointIdsBeingMoved: [pointId],
+              pointIdsBeingMovedAxis: null,
               annotationIdBeingMoved: state.selectedAnnotation.resolve().id,
               annotationDirty: true,
               hitTestDirty: true
@@ -781,8 +1225,8 @@ export const useLabeler = (labels: ILabel[]) => {
               return
             }
 
-            const dataStore = useAppStore.getState().store
             const resolvedAnnotation = annotation.resolve()
+            const before = structuredClone(resolvedAnnotation.points)
             const pointsBeingMoved = new Set(state.pointIdsBeingMoved)
             const annotationPointIds = new Set(resolvedAnnotation.points.map((c) => c.id))
             const pointsToMove = pointsBeingMoved.intersection(annotationPointIds)
@@ -792,88 +1236,39 @@ export const useLabeler = (labels: ILabel[]) => {
             const payload = normalizeAnnotationPoints({
               type: resolvedAnnotation.type,
               points: resolvedAnnotation.points.map((point) => {
-                const diff = pointsToMove.has(point.id) ? state.moveCurrent : [0, 0]
+                const [dx, dy] = axisMaskedMoveDelta(
+                  point.id,
+                  state.pointIdsBeingMoved,
+                  state.pointIdsBeingMovedAxis,
+                  state.moveCurrent
+                )
                 return {
                   id: point.id,
-                  x: point.x + diff[0],
-                  y: point.y + diff[1]
+                  x: point.x + dx,
+                  y: point.y + dy
                 }
               })
             }).points
-
-            const { commit, rollback } = annotation.update({
-              points: payload
-            })
 
             set({
               annotationDirty: true,
               hitTestDirty: true,
               annotationIdBeingMoved: null,
-              pointIdsBeingMoved: null
+              pointIdsBeingMoved: null,
+              pointIdsBeingMovedAxis: null
             })
 
-            dataStore
-              .replacePoints(annotationId, payload)
-              .then((resultPoints) => {
-                commit({
-                  points: resultPoints
-                })
-              })
-              .catch(() => {
-                rollback()
-              })
-              .finally(() => {
-                if (sampleId === get().sample?.resolve().id) {
-                  set({ annotationDirty: true, hitTestDirty: true })
-                }
-              })
+            applyReplacePoints(annotationId, payload)
+            pushHistory({ kind: 'points', annotationId, before, after: payload })
           },
           deleteAnnotation: (annotationId: string) => {
             const state = get()
-            const annotations = state.sample?.resolve().annotations
+            const annotation =
+              state.sample?.resolve().annotations.resolve()[annotationId]?.resolve() ?? null
+            if (annotation === null) return
 
-            if (annotations === undefined) return
-
-            const annotation = annotations.resolve()[annotationId]?.resolve() ?? null
-
-            let selectedAnnotation = state.selectedAnnotation
-
-            if (state.selectedAnnotation?.resolve().id === annotationId) {
-              selectedAnnotation = null
-            }
-
-            if (annotation !== null) {
-              const { commit, rollback } = annotations.update({
-                [annotation.id]: undefined
-              })
-              const store = useAppStore.getState().store
-              freeAnnotationHitIds(annotationId)
-              set({
-                selectedAnnotation: selectedAnnotation,
-                annotationDirty: true,
-                hitTestDirty: true
-              })
-              const sampleId = state.sample?.resolve().id
-              store
-                .deleteAnnotations([annotation.id])
-                .then((c) => {
-                  if (!c[0]) {
-                    throw new Error('Failed to delete annotation')
-                  }
-                  commit()
-                })
-                .catch(() => {
-                  rollback()
-                  if (sampleId === get().sample?.resolve().id) {
-                    addAnnotationHitIds(annotationId)
-                  }
-                })
-                .finally(() => {
-                  if (sampleId === get().sample?.resolve().id) {
-                    set({ annotationDirty: true, hitTestDirty: true })
-                  }
-                })
-            }
+            applyDeleteAnnotation(annotationId)
+            pushHistory({ kind: 'delete', annotation })
           },
           deleteSelectedAnnotation: () => {
             const state = get()
@@ -881,6 +1276,69 @@ export const useLabeler = (labels: ILabel[]) => {
               const annotation = state.selectedAnnotation
               state.deleteAnnotation(annotation.resolve().id)
             }
+          },
+          duplicateAnnotation: (annotationId: string) => {
+            const state = get()
+            const annotation =
+              state.sample?.resolve().annotations.resolve()[annotationId]?.resolve() ?? null
+            if (annotation === null) return undefined
+
+            const box = boundingBoxOf(annotation.points)
+            const desired = duplicateOffsetFor(box)
+            const bitmap = state.bitmap
+            const dx =
+              bitmap !== null
+                ? clampedDuplicateAxisOffset(box.minX, box.width, bitmap.width, desired)
+                : desired
+            const dy =
+              bitmap !== null
+                ? clampedDuplicateAxisOffset(box.minY, box.height, bitmap.height, desired)
+                : desired
+
+            const duplicate: IAnnotation = {
+              id: makeUUID(),
+              type: annotation.type,
+              labelId: annotation.labelId,
+              points: annotation.points.map((p) => ({
+                id: makeUUID(),
+                x: p.x + dx,
+                y: p.y + dy
+              }))
+            }
+
+            applyCreateAnnotation(duplicate)
+            pushHistory({ kind: 'create', annotation: duplicate })
+            get().selectAnnotation(duplicate.id)
+            return duplicate.id
+          },
+          duplicateSelectedAnnotation: () => {
+            const state = get()
+            if (state.selectedAnnotation !== null) {
+              state.duplicateAnnotation(state.selectedAnnotation.resolve().id)
+            }
+          },
+          convertAnnotationType: (annotationId: string) => {
+            const state = get()
+            const annotation =
+              state.sample?.resolve().annotations.resolve()[annotationId]?.resolve() ?? null
+            if (annotation === null) return
+
+            const afterType =
+              annotation.type === AnnotationType.Box ? AnnotationType.Polygon : AnnotationType.Box
+            const afterPoints =
+              afterType === AnnotationType.Polygon
+                ? boxPointsToPolygonPoints(annotation.points)
+                : polygonPointsToBoxPoints(annotation.points)
+
+            applyConvertType(annotationId, afterType, afterPoints)
+            pushHistory({
+              kind: 'convert',
+              annotationId,
+              beforeType: annotation.type,
+              beforePoints: structuredClone(annotation.points),
+              afterType,
+              afterPoints
+            })
           },
           addControlPoint: (controlPointId: string, x: number, y: number) => {
             const state = get()
@@ -897,34 +1355,18 @@ export const useLabeler = (labels: ILabel[]) => {
               y: bitmapY
             }
             const resolvedAnnotation = structuredClone(annotation.resolve())
+            const before = structuredClone(resolvedAnnotation.points)
             const points = resolvedAnnotation.points
             points.splice(pointIndex + 1, 0, newPoint)
-            const store = useAppStore.getState().store
-            const { commit, rollback } = annotation.update({
-              points: points
-            })
             addSelectedAnnotationPointId(newPoint.id)
             set({ annotationDirty: true, hitTestDirty: true })
-            store
-              .replacePoints(resolvedAnnotation.id, points)
-              .then((c) => {
-                commit({
-                  points: c
-                })
-              })
-              .catch((e) => {
-                console.error(e)
-                rollback()
-              })
-              .finally(() => {
-                if (get().selectedAnnotation?.resolve().id === resolvedAnnotation.id) {
-                  clearSelectedAnnotationHitIds()
-                  for (const point of annotation.resolve().points) {
-                    addSelectedAnnotationPointId(point.id)
-                  }
-                }
-                set({ annotationDirty: true, hitTestDirty: true })
-              })
+            applyReplacePoints(resolvedAnnotation.id, points)
+            pushHistory({
+              kind: 'points',
+              annotationId: resolvedAnnotation.id,
+              before,
+              after: points
+            })
             return newPoint.id
           },
           deleteControlPoint: (controlPointId: string) => {
@@ -934,35 +1376,19 @@ export const useLabeler = (labels: ILabel[]) => {
             const resolvedAnnotation = structuredClone(annotation.resolve())
             const pointIndex = resolvedAnnotation.points.findIndex((c) => c.id === controlPointId)
             if (pointIndex === -1 || resolvedAnnotation.points.length <= 3) return
+            const before = structuredClone(resolvedAnnotation.points)
             const points = resolvedAnnotation.points
             const pointToRemove = points[pointIndex]
             points.splice(pointIndex, 1)
-            const store = useAppStore.getState().store
-            const { commit, rollback } = annotation.update({
-              points: points
-            })
             clearSelectedAnnotationPointId(pointToRemove.id)
             set({ annotationDirty: true, hitTestDirty: true })
-            store
-              .replacePoints(resolvedAnnotation.id, points)
-              .then((c) => {
-                commit({
-                  points: c
-                })
-              })
-              .catch((e) => {
-                console.error(e)
-                rollback()
-              })
-              .finally(() => {
-                if (get().selectedAnnotation?.resolve().id === resolvedAnnotation.id) {
-                  clearSelectedAnnotationHitIds()
-                  for (const point of annotation.resolve().points) {
-                    addSelectedAnnotationPointId(point.id)
-                  }
-                }
-                set({ annotationDirty: true, hitTestDirty: true })
-              })
+            applyReplacePoints(resolvedAnnotation.id, points)
+            pushHistory({
+              kind: 'points',
+              annotationId: resolvedAnnotation.id,
+              before,
+              after: points
+            })
           },
           hittest: (x, y): HitTestResult | null => {
             const state = get()
@@ -1005,6 +1431,39 @@ export const useLabeler = (labels: ILabel[]) => {
             }
 
             return null
+          },
+          setHoveredAnnotation: (id) => {
+            if (get().hoveredAnnotationId === id) return
+            set({ hoveredAnnotationId: id, annotationDirty: true })
+          },
+          setAnnotationsDrawerHovered: (hovered) => {
+            const state = get()
+            if (state.isAnnotationsDrawerHovered === hovered) return
+            set({
+              isAnnotationsDrawerHovered: hovered,
+              // Leaving the drawer entirely always clears whichever row was hovered too -
+              // belt-and-suspenders alongside each row's own onMouseLeave.
+              hoveredAnnotationId: hovered ? state.hoveredAnnotationId : null,
+              annotationDirty: true
+            })
+          },
+          undo: () => {
+            const { undoStack } = get()
+            const entry = undoStack[undoStack.length - 1]
+            if (entry === undefined) return
+
+            set({ undoStack: undoStack.slice(0, -1) })
+            applyHistoryInverse(entry)
+            set((s) => ({ redoStack: [...s.redoStack, entry] }))
+          },
+          redo: () => {
+            const { redoStack } = get()
+            const entry = redoStack[redoStack.length - 1]
+            if (entry === undefined) return
+
+            set({ redoStack: redoStack.slice(0, -1) })
+            applyHistoryForward(entry)
+            set((s) => ({ undoStack: [...s.undoStack, entry] }))
           }
         }
       }),

--- a/src/renderer/src/hooks/useProjects.ts
+++ b/src/renderer/src/hooks/useProjects.ts
@@ -62,13 +62,21 @@ export const useProjects = () => {
       queryClient.setQueryData<IProject[]>(projectsQueryKey, (current = []) =>
         current.map((project) => {
           if (project.id !== update.id) return project
+          const existingIds = new Set(project.labels.map((l) => l.id))
+          // A label id the project doesn't have yet is a new one being added (see
+          // IProjectUpdate), not a rename - append it rather than dropping it on the
+          // floor until the post-mutation refetch catches up.
+          const newLabels = (update.labels ?? []).filter((l) => !existingIds.has(l.id))
           return {
             ...project,
             name: update.name ?? project.name,
-            labels: project.labels.map((label) => {
-              const renamed = update.labels?.find((l) => l.id === label.id)
-              return renamed ? { ...label, name: renamed.name } : label
-            })
+            labels: [
+              ...project.labels.map((label) => {
+                const updated = update.labels?.find((l) => l.id === label.id)
+                return updated ? { ...label, name: updated.name, color: updated.color } : label
+              }),
+              ...newLabels
+            ]
           }
         })
       )
@@ -84,7 +92,7 @@ export const useProjects = () => {
   })
 
   const update = useCallback(
-    async (id: string, name: string, labels: Pick<ILabel, 'id' | 'name'>[]) => {
+    async (id: string, name: string, labels: Pick<ILabel, 'id' | 'name' | 'color'>[]) => {
       await updateMutateAsync({ id, name, labels })
     },
     [updateMutateAsync]

--- a/src/renderer/src/hooks/useRunAnnotator.ts
+++ b/src/renderer/src/hooks/useRunAnnotator.ts
@@ -1,0 +1,113 @@
+import { errorToString } from '@shared/utils'
+import { IAnnotator } from '@shared/types'
+import { OptimisticSample } from '@renderer/types'
+import { runAnnotatorOnSample } from '@renderer/api/ExternalAnnotator'
+import { useAppStore } from './useAppStore'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useState } from 'react'
+
+export type RunAnnotatorFailure = {
+  sampleId: string
+  sampleName: string
+  error: string
+}
+
+export type RunAnnotatorProgress = {
+  total: number
+  completed: number
+  created: number
+  skipped: number
+  alreadyLabeled: number
+  failures: RunAnnotatorFailure[]
+}
+
+const INITIAL_PROGRESS: RunAnnotatorProgress = {
+  total: 0,
+  completed: 0,
+  created: 0,
+  skipped: 0,
+  alreadyLabeled: 0,
+  failures: []
+}
+
+/** Runs an annotator over a set of samples, skipping any sample that already has at
+ *  least one annotation - auto-labeling only ever targets unlabeled samples. Runs
+ *  sequentially and keeps going past a per-sample failure so one bad image doesn't stop
+ *  the rest of the batch. `taskIds` covers every task the passed-in samples were drawn
+ *  from (usually one, but a batch run from the Tasks page can span several), so each of
+ *  their sample caches gets invalidated once the run finishes. */
+export const useRunAnnotator = (taskIds: string[]) => {
+  const store = useAppStore((s) => s.store)
+  const queryClient = useQueryClient()
+  const [progress, setProgress] = useState<RunAnnotatorProgress>(INITIAL_PROGRESS)
+  const [isRunning, setIsRunning] = useState(false)
+  // Distinct from isRunning (which flips back to false once the run finishes) and from
+  // progress.total (which is legitimately 0 when every sample was already labeled) - the
+  // only reliable way to tell "a run happened" from "nothing has run yet" is a flag that
+  // run() itself sets and only reset() clears.
+  const [hasRun, setHasRun] = useState(false)
+
+  const run = useCallback(
+    async (
+      annotator: IAnnotator,
+      labelMapping: Record<string, string | null>,
+      samples: OptimisticSample[]
+    ) => {
+      const targets = samples.filter(
+        (sample) => Object.keys(sample.resolve().annotations.resolve()).length === 0
+      )
+      const alreadyLabeled = samples.length - targets.length
+
+      setHasRun(true)
+      setIsRunning(true)
+      setProgress({ ...INITIAL_PROGRESS, total: targets.length, alreadyLabeled })
+
+      for (const sample of targets) {
+        const resolved = sample.resolve()
+        try {
+          const { annotations, skipped } = await runAnnotatorOnSample(
+            annotator,
+            labelMapping,
+            resolved
+          )
+          if (annotations.length > 0) {
+            await store.createAnnotations(resolved.id, annotations)
+          }
+          setProgress((current) => ({
+            ...current,
+            completed: current.completed + 1,
+            created: current.created + annotations.length,
+            skipped: current.skipped + skipped
+          }))
+        } catch (error) {
+          setProgress((current) => ({
+            ...current,
+            completed: current.completed + 1,
+            failures: [
+              ...current.failures,
+              { sampleId: resolved.id, sampleName: resolved.name, error: errorToString(error) }
+            ]
+          }))
+        }
+      }
+
+      // Awaited before clearing isRunning (which enables "Done") - the caller can stay on
+      // this same modal and immediately Run again, so the sample list backing that next
+      // run must already reflect the annotations just created, not a stale pre-run snapshot.
+      await Promise.all(
+        taskIds.map((taskId) =>
+          queryClient.invalidateQueries({ queryKey: ['samples', taskId, store] })
+        )
+      )
+      setIsRunning(false)
+    },
+    [store, queryClient, taskIds]
+  )
+
+  const reset = useCallback(() => {
+    setProgress(INITIAL_PROGRESS)
+    setHasRun(false)
+  }, [])
+
+  return { run, reset, progress, isRunning, hasRun }
+}

--- a/src/renderer/src/hooks/useSamples.ts
+++ b/src/renderer/src/hooks/useSamples.ts
@@ -2,8 +2,8 @@ import { navigate } from '@renderer/router/appRouter'
 import { useCallback } from 'react'
 import { useAppStore } from './useAppStore'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { OptimisticObject } from '@renderer/util/optimistic_object'
-import { IAnnotation, INewSample, IProject, ITask } from '@shared/types'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
+import { INewSample, IProject, ITask } from '@shared/types'
 import { OptimisticSample } from '@renderer/types'
 
 export const useSamples = (project: IProject, task: ITask) => {
@@ -19,20 +19,7 @@ export const useSamples = (project: IProject, task: ITask) => {
   } = useQuery({
     queryKey: samplesQueryKey,
     queryFn: () =>
-      store.getSamplesForTask(task.id).then((a) =>
-        a.map((c) => {
-          const annotationsObj = c.annotations.reduce<{
-            [key: string]: OptimisticObject<IAnnotation>
-          }>((t, c) => {
-            return { ...t, [c.id]: new OptimisticObject(c) }
-          }, {})
-
-          return new OptimisticObject({
-            ...c,
-            annotations: new OptimisticObject(annotationsObj, true)
-          })
-        })
-      )
+      store.getSamplesForTask(task.id).then((samples) => samples.map(toOptimisticSample))
   })
 
   const loading = isLoading || isFetching

--- a/src/renderer/src/hooks/useTags.ts
+++ b/src/renderer/src/hooks/useTags.ts
@@ -1,0 +1,71 @@
+import { IProject } from '@shared/types'
+import { makeUUID } from '@shared/utils'
+import { useCallback } from 'react'
+import { useAppStore } from './useAppStore'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+/** A project's tag vocabulary - managed from one place (ManageTagsModal). Typing only
+ *  ever happens here (create/rename); everywhere else a tag is attached to a task, it's
+ *  picked from `items` by id. */
+export const useTags = (project: IProject) => {
+  const store = useAppStore((s) => s.store)
+  const queryClient = useQueryClient()
+  const tagsQueryKey = ['tags', project.id, store] as const
+  const tasksQueryKey = ['tasks', project.id, store] as const
+
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: tagsQueryKey,
+    queryFn: () => store.getTagsForProject(project.id)
+  })
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: tagsQueryKey }),
+    [queryClient, tagsQueryKey]
+  )
+
+  // A rename/delete changes what's embedded in each task's own `tags` field too - not
+  // needed for create, which can't affect any task's existing tags.
+  const invalidateTasksToo = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: tasksQueryKey }),
+    [queryClient, tasksQueryKey]
+  )
+
+  const { mutateAsync: createMutateAsync } = useMutation({
+    mutationFn: (name: string) => store.createTag(project.id, makeUUID(), name),
+    onSuccess: invalidate
+  })
+
+  const create = useCallback(async (name: string) => createMutateAsync(name), [createMutateAsync])
+
+  const { mutateAsync: renameMutateAsync } = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => store.updateTags([{ id, name }]),
+    onSuccess: () => {
+      invalidate()
+      invalidateTasksToo()
+    }
+  })
+
+  const rename = useCallback(
+    async (id: string, name: string) => {
+      await renameMutateAsync({ id, name })
+    },
+    [renameMutateAsync]
+  )
+
+  const { mutateAsync: removeMutateAsync } = useMutation({
+    mutationFn: (id: string) => store.deleteTags([id]),
+    onSuccess: () => {
+      invalidate()
+      invalidateTasksToo()
+    }
+  })
+
+  const remove = useCallback(
+    async (id: string) => {
+      await removeMutateAsync(id)
+    },
+    [removeMutateAsync]
+  )
+
+  return { items, isLoading, create, rename, remove }
+}

--- a/src/renderer/src/hooks/useTasks.ts
+++ b/src/renderer/src/hooks/useTasks.ts
@@ -21,11 +21,14 @@ export const useTasks = (project: IProject) => {
   const { mutateAsync } = useMutation({
     mutationFn: ({ id, name, samples }: { id: string; name: string; samples: INewSample[] }) =>
       store.createTask(project.id, id, name, samples),
-    onMutate: async ({ id, name }) => {
+    onMutate: async ({ id, name, samples }) => {
       await queryClient.cancelQueries({ queryKey: tasksQueryKey })
       const previousTasks = queryClient.getQueryData<ITask[]>(tasksQueryKey) ?? []
 
-      queryClient.setQueryData<ITask[]>(tasksQueryKey, (current = []) => [...current, { id, name }])
+      queryClient.setQueryData<ITask[]>(tasksQueryKey, (current = []) => [
+        ...current,
+        { id, name, sampleCount: samples.length, completedSampleCount: 0 }
+      ])
 
       return { previousTasks, optimisticId: id }
     },
@@ -122,5 +125,38 @@ export const useTasks = (project: IProject) => {
     [removeMutateAsync]
   )
 
-  return { items, create, open, update, remove, removeMany, isLoading }
+  // Tags are picked by id (see hooks/useTags.ts for the project's vocabulary) and
+  // attached/detached across a whole batch of task ids in one call (see
+  // IDataStore.addTagsToTasks) - simple invalidate-on-success here rather than granular
+  // optimistic patching, since tagging isn't perf-sensitive and the resulting per-task
+  // tag lists are easiest to just re-fetch.
+  const { mutateAsync: addTagsMutateAsync } = useMutation({
+    mutationFn: ({ taskIds, tagIds }: { taskIds: string[]; tagIds: string[] }) =>
+      store.addTagsToTasks(taskIds, tagIds),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: tasksQueryKey })
+  })
+
+  const addTags = useCallback(
+    async (taskIds: string[], tagIds: string[]) => {
+      if (taskIds.length === 0 || tagIds.length === 0) return
+      await addTagsMutateAsync({ taskIds, tagIds })
+    },
+    [addTagsMutateAsync]
+  )
+
+  const { mutateAsync: removeTagsMutateAsync } = useMutation({
+    mutationFn: ({ taskIds, tagIds }: { taskIds: string[]; tagIds: string[] }) =>
+      store.removeTagsFromTasks(taskIds, tagIds),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: tasksQueryKey })
+  })
+
+  const removeTags = useCallback(
+    async (taskIds: string[], tagIds: string[]) => {
+      if (taskIds.length === 0 || tagIds.length === 0) return
+      await removeTagsMutateAsync({ taskIds, tagIds })
+    },
+    [removeTagsMutateAsync]
+  )
+
+  return { items, create, open, update, remove, removeMany, addTags, removeTags, isLoading }
 }

--- a/src/renderer/src/router/RouterOutlet.tsx
+++ b/src/renderer/src/router/RouterOutlet.tsx
@@ -3,12 +3,12 @@ import { TasksPage } from '@renderer/routes/tasks/TasksPage'
 import { SamplesPage } from '@renderer/routes/samples/SamplesPage'
 import { LabelPage } from '@renderer/routes/label/LabelPage'
 import { makeRouterOutlet } from './makeRouter'
-import { useRouterStore, type AppRoutes } from './appRouter'
+import { appRouter, type AppRoutes } from './appRouter'
 
 // Only App.tsx should import this module: it pulls in every page component to build the
 // stack, and those pages' hooks import navigate/back from appRouter.tsx - importing this
 // file from anywhere reachable by a page would recreate that cycle.
-export const RouterOutlet = makeRouterOutlet<AppRoutes>(useRouterStore, {
+export const RouterOutlet = makeRouterOutlet<AppRoutes>(appRouter, {
   projects: ProjectsPage,
   tasks: TasksPage,
   samples: SamplesPage,

--- a/src/renderer/src/router/RouterOutlet.tsx
+++ b/src/renderer/src/router/RouterOutlet.tsx
@@ -1,5 +1,6 @@
 import { ProjectsPage } from '@renderer/routes/projects/ProjectsPage'
 import { TasksPage } from '@renderer/routes/tasks/TasksPage'
+import { CopyAnnotationsPage } from '@renderer/routes/tasks/CopyAnnotationsPage'
 import { SamplesPage } from '@renderer/routes/samples/SamplesPage'
 import { LabelPage } from '@renderer/routes/label/LabelPage'
 import { makeRouterOutlet } from './makeRouter'
@@ -11,6 +12,7 @@ import { appRouter, type AppRoutes } from './appRouter'
 export const RouterOutlet = makeRouterOutlet<AppRoutes>(appRouter, {
   projects: ProjectsPage,
   tasks: TasksPage,
+  'copy-annotations': CopyAnnotationsPage,
   samples: SamplesPage,
   label: LabelPage
 })

--- a/src/renderer/src/router/__tests__/makeRouter.test.tsx
+++ b/src/renderer/src/router/__tests__/makeRouter.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { act, render, fireEvent, screen } from '@testing-library/react'
 import { useState, type FC } from 'react'
 import { makeRouter, makeRouterOutlet } from '../makeRouter'
 
@@ -8,23 +8,30 @@ type Routes = {
   detail: { id: string }
 }
 
-const Home: FC = () => {
-  const [count, setCount] = useState(0)
-  return (
-    <div>
-      <p>Home screen</p>
-      <p data-testid="home-count">{count}</p>
-      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
-    </div>
-  )
-}
-
-const Detail: FC<{ id: string }> = ({ id }) => <p>Detail screen: {id}</p>
-
 const setup = () => {
   const router = makeRouter<Routes>('home')
-  const RouterOutlet = makeRouterOutlet(router.useRouterStore, { home: Home, detail: Detail })
-  return { ...router, RouterOutlet }
+  const onHomeEnter = vi.fn()
+  const onHomeLeave = vi.fn()
+
+  const Home: FC = () => {
+    const [count, setCount] = useState(0)
+    const visible = router.useIsRouteVisible()
+    router.useOnRouteEnter(onHomeEnter)
+    router.useOnRouteLeave(onHomeLeave)
+    return (
+      <div>
+        <p>Home screen</p>
+        <p data-testid="home-count">{count}</p>
+        <p data-testid="home-visible">{String(visible)}</p>
+        <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+      </div>
+    )
+  }
+
+  const Detail: FC<{ id: string }> = ({ id }) => <p>Detail screen: {id}</p>
+
+  const RouterOutlet = makeRouterOutlet(router, { home: Home, detail: Detail })
+  return { ...router, RouterOutlet, onHomeEnter, onHomeLeave }
 }
 
 describe('makeRouter', () => {
@@ -101,5 +108,65 @@ describe('makeRouter', () => {
 
     expect(screen.getByText('Detail screen: second')).toBeInTheDocument()
     expect(screen.queryByText('Detail screen: first')).not.toBeInTheDocument()
+  })
+
+  it('useIsRouteVisible reflects whether this screen is the top of the stack', () => {
+    const { navigate, back, RouterOutlet } = setup()
+    render(<RouterOutlet />)
+
+    expect(screen.getByTestId('home-visible')).toHaveTextContent('true')
+
+    act(() => navigate('detail', { id: 'abc' }))
+    expect(screen.getByTestId('home-visible')).toHaveTextContent('false')
+
+    act(() => back())
+    expect(screen.getByTestId('home-visible')).toHaveTextContent('true')
+  })
+
+  it('useOnRouteEnter fires on mount and again when the screen becomes visible again', () => {
+    const { navigate, back, RouterOutlet, onHomeEnter } = setup()
+    render(<RouterOutlet />)
+    expect(onHomeEnter).toHaveBeenCalledTimes(1)
+
+    act(() => navigate('detail', { id: 'abc' }))
+    expect(onHomeEnter).toHaveBeenCalledTimes(1)
+
+    act(() => back())
+    expect(onHomeEnter).toHaveBeenCalledTimes(2)
+  })
+
+  it('useOnRouteLeave fires whenever the screen stops being visible, whether hidden or fully removed', () => {
+    const { navigate, back, RouterOutlet, onHomeLeave } = setup()
+    render(<RouterOutlet />)
+    expect(onHomeLeave).not.toHaveBeenCalled()
+
+    // Hidden by a screen pushed on top - still mounted, just not visible.
+    act(() => navigate('detail', { id: 'a' }))
+    expect(onHomeLeave).toHaveBeenCalledTimes(1)
+
+    // Becoming visible again shouldn't fire another leave.
+    act(() => back())
+    expect(onHomeLeave).toHaveBeenCalledTimes(1)
+
+    // Hidden again by a fresh "home" instance pushed on top.
+    act(() => navigate('home'))
+    expect(onHomeLeave).toHaveBeenCalledTimes(2)
+
+    // That fresh instance is fully removed by back() - also fires leave.
+    act(() => back())
+    expect(onHomeLeave).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when a lifecycle hook is used outside a routed screen', () => {
+    const router = makeRouter<Routes>('home')
+    const Rogue: FC = () => {
+      router.useIsRouteVisible()
+      return null
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => render(<Rogue />)).toThrow(/must be used within a screen/)
+
+    consoleError.mockRestore()
   })
 })

--- a/src/renderer/src/router/appRouter.tsx
+++ b/src/renderer/src/router/appRouter.tsx
@@ -12,4 +12,12 @@ export type AppRoutes = {
 // No page components imported here on purpose - pages' hooks import navigate/back from
 // this module, so pulling in the page components here (which the RouterOutlet needs) would
 // create a cycle. See router/RouterOutlet.tsx for that half.
-export const { navigate, back, useRouterStore } = makeRouter<AppRoutes>('projects')
+export const appRouter = makeRouter<AppRoutes>('projects')
+export const {
+  navigate,
+  back,
+  useRouterStore,
+  useIsRouteVisible,
+  useOnRouteEnter,
+  useOnRouteLeave
+} = appRouter

--- a/src/renderer/src/router/appRouter.tsx
+++ b/src/renderer/src/router/appRouter.tsx
@@ -7,6 +7,7 @@ export type AppRoutes = {
   tasks: { project: IProject }
   samples: { project: IProject; task: ITask }
   label: { project: IProject; task: ITask; samples: OptimisticSample[]; initial: number }
+  'copy-annotations': { project: IProject; sourceTask: ITask }
 }
 
 // No page components imported here on purpose - pages' hooks import navigate/back from

--- a/src/renderer/src/router/makeRouter.tsx
+++ b/src/renderer/src/router/makeRouter.tsx
@@ -1,4 +1,12 @@
-import { Activity, type FC, type ReactNode } from 'react'
+import {
+  Activity,
+  createContext,
+  useContext,
+  useEffect,
+  useEffectEvent,
+  type FC,
+  type ReactNode
+} from 'react'
 import { create, type UseBoundStore, type StoreApi } from 'zustand'
 import { makeUUID } from '@shared/utils'
 
@@ -31,6 +39,28 @@ export type RouterScreens<Routes extends RouteParamsMap> = {
   [K in keyof Routes]: FC<Routes[K] extends undefined ? Record<string, never> : Routes[K]>
 }
 
+/** Identifies which stack entry a screen (and anything it renders) belongs to, so the
+ *  lifecycle hooks below can look up their own entry's visibility. Provided by
+ *  `makeRouterOutlet` around each `<Activity>`'s children. */
+type RouteContextValue = { key: string }
+
+export type RouterHandle<Routes extends RouteParamsMap> = {
+  navigate: <K extends keyof Routes>(...args: NavigateArgs<Routes, K>) => void
+  back: () => void
+  useRouterStore: RouterStore<Routes>
+  /** True iff this screen's stack entry is currently the top (visible) one. */
+  useIsRouteVisible: () => boolean
+  /** Runs `callback` when this screen becomes visible: on first mount, and again every
+   *  time its `<Activity>` subtree goes from hidden back to visible (Activity remounts
+   *  effects on that transition, so a plain mount effect already doubles as this). */
+  useOnRouteEnter: (callback: () => void) => void
+  /** Runs `callback` when this screen stops being visible: hidden by a `navigate()` past
+   *  it, or fully removed by `back()` (Activity tears down effects in both cases, so a
+   *  plain effect cleanup already doubles as this). */
+  useOnRouteLeave: (callback: () => void) => void
+  RouteContext: React.Context<RouteContextValue | null>
+}
+
 /**
  * Builds a stack-based navigator's data/actions: screens are pushed on top of each other
  * and stay mounted (see `makeRouterOutlet`) so state like scroll position survives going
@@ -41,7 +71,9 @@ export type RouterScreens<Routes extends RouteParamsMap> = {
  * other page's component to get them, which would create a circular dependency between
  * this module and the pages themselves. Pair with `makeRouterOutlet` to render the stack.
  */
-export const makeRouter = <Routes extends RouteParamsMap>(...initial: AnyNavigateArgs<Routes>) => {
+export const makeRouter = <Routes extends RouteParamsMap>(
+  ...initial: AnyNavigateArgs<Routes>
+): RouterHandle<Routes> => {
   const toEntry = (args: AnyNavigateArgs<Routes>): StackEntry<Routes> => {
     const [screen, params] = args
     return { key: makeUUID(), screen, params: params as Routes[keyof Routes] }
@@ -61,7 +93,49 @@ export const makeRouter = <Routes extends RouteParamsMap>(...initial: AnyNavigat
     useRouterStore.setState((s) => (s.stack.length <= 1 ? s : { stack: s.stack.slice(0, -1) }))
   }
 
-  return { navigate, back, useRouterStore }
+  const RouteContext = createContext<RouteContextValue | null>(null)
+
+  const useOwnRouteKey = (): string => {
+    const ctx = useContext(RouteContext)
+    if (ctx === null) {
+      throw new Error(
+        'Router lifecycle hooks (useIsRouteVisible/useOnRouteEnter/useOnRouteLeave) must be ' +
+          "used within a screen rendered by this router's RouterOutlet."
+      )
+    }
+    return ctx.key
+  }
+
+  const useIsRouteVisible = (): boolean => {
+    const key = useOwnRouteKey()
+    return useRouterStore((s) => s.stack[s.stack.length - 1]?.key === key)
+  }
+
+  const useOnRouteEnter = (callback: () => void): void => {
+    useOwnRouteKey()
+    const onEnter = useEffectEvent(callback)
+    useEffect(() => {
+      onEnter()
+    }, [])
+  }
+
+  const useOnRouteLeave = (callback: () => void): void => {
+    useOwnRouteKey()
+    const onLeave = useEffectEvent(callback)
+    useEffect(() => {
+      return () => onLeave()
+    }, [])
+  }
+
+  return {
+    navigate,
+    back,
+    useRouterStore,
+    useIsRouteVisible,
+    useOnRouteEnter,
+    useOnRouteLeave,
+    RouteContext
+  }
 }
 
 /**
@@ -72,9 +146,11 @@ export const makeRouter = <Routes extends RouteParamsMap>(...initial: AnyNavigat
  * assembles them (e.g. `App.tsx`), rather than being reachable from the pages themselves.
  */
 export const makeRouterOutlet = <Routes extends RouteParamsMap>(
-  useRouterStore: RouterStore<Routes>,
+  router: RouterHandle<Routes>,
   screens: RouterScreens<Routes>
 ) => {
+  const { useRouterStore, RouteContext } = router
+
   return function RouterOutlet(): ReactNode {
     const stack = useRouterStore((s) => s.stack)
     const topKey = stack[stack.length - 1]?.key
@@ -87,7 +163,9 @@ export const makeRouterOutlet = <Routes extends RouteParamsMap>(
           name={String(entry.screen)}
           mode={entry.key === topKey ? 'visible' : 'hidden'}
         >
-          <Screen {...(entry.params ?? {})} />
+          <RouteContext.Provider value={{ key: entry.key }}>
+            <Screen {...(entry.params ?? {})} />
+          </RouteContext.Provider>
         </Activity>
       )
     })

--- a/src/renderer/src/routes/label/AnnotationsDrawer.tsx
+++ b/src/renderer/src/routes/label/AnnotationsDrawer.tsx
@@ -1,14 +1,46 @@
-import { ActionIcon, Badge, Drawer, Group, Stack, Text } from '@mantine/core'
+import {
+  ActionIcon,
+  Badge,
+  Collapse,
+  Drawer,
+  Group,
+  Stack,
+  Text,
+  UnstyledButton
+} from '@mantine/core'
+import { styled } from '@linaria/react'
 import { LabelerStore } from '@renderer/hooks/useLabeler'
+import { useOnRouteLeave } from '@renderer/router/appRouter'
 import { LabelerMode } from '@renderer/types'
-import { AnnotationType } from '@shared/types'
-import type { FC } from 'react'
-import { MdDeleteOutline } from 'react-icons/md'
+import { AnnotationType, IAnnotation } from '@shared/types'
+import { useEffect, useState, type FC } from 'react'
+import { MdChevronRight, MdDeleteOutline } from 'react-icons/md'
 import { BsBoundingBoxCircles } from 'react-icons/bs'
 import { PiPolygonLight } from 'react-icons/pi'
 import tinycolor from 'tinycolor2'
 import { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
+
+// Same hover-affordance convention as BasicListPageItem's Row: a plain background swap
+// on hover, layered with a stronger one for the selected row so hovering an
+// already-selected row still visibly reacts instead of looking inert.
+const AnnotationRow = styled(Group)`
+  cursor: pointer;
+  border-radius: var(--mantine-radius-sm);
+  transition: background-color 0.1s ease;
+
+  &:hover {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+  }
+
+  &[data-selected='true'] {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+  }
+
+  &[data-selected='true']:hover {
+    background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  }
+`
 
 export type AnnotationsDrawerProps = {
   store: UseBoundStore<StoreApi<LabelerStore>>
@@ -19,6 +51,26 @@ export type AnnotationsDrawerProps = {
 const AnnotationTypeIcon = ({ type }: { type: AnnotationType }) =>
   type === AnnotationType.Box ? <BsBoundingBoxCircles size={14} /> : <PiPolygonLight size={14} />
 
+/** Groups annotations that don't resolve to a project label (e.g. the label was since
+ *  deleted) - kept visible under their own group rather than dropped. */
+const UNKNOWN_LABEL_GROUP = '__unknown__'
+
+/** Buckets annotations by label id, preserving each group's first-occurrence order in
+ *  the underlying annotation list. */
+const groupByLabel = (annotations: IAnnotation[]): Map<string, IAnnotation[]> => {
+  const groups = new Map<string, IAnnotation[]>()
+  for (const annotation of annotations) {
+    const key = annotation.labelId || UNKNOWN_LABEL_GROUP
+    const bucket = groups.get(key)
+    if (bucket) {
+      bucket.push(annotation)
+    } else {
+      groups.set(key, [annotation])
+    }
+  }
+  return groups
+}
+
 export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, onClose }) => {
   const annotations = store(
     useShallow((s) =>
@@ -27,6 +79,31 @@ export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, o
   )
   const selectedAnnotationId = store((s) => s.selectedAnnotation?.resolve().id ?? null)
   const labelsMap = store((s) => s.labelsMap)
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+
+  // Closing the drawer doesn't naturally fire a mouseleave on whatever was hovered when
+  // it closed - clear the canvas dim/spotlight explicitly so it doesn't linger.
+  useEffect(() => {
+    if (!opened) {
+      store.getState().setAnnotationsDrawerHovered(false)
+    }
+  }, [opened, store])
+
+  // Same idea for leaving the Labeler page entirely while the drawer happened to be open -
+  // that also doesn't fire a mouseleave, and Activity would otherwise preserve the dim
+  // state until the user's mouse re-triggers it on return.
+  useOnRouteLeave(() => store.getState().setAnnotationsDrawerHovered(false))
+
+  const toggleGroup = (key: string) =>
+    setCollapsedGroups((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
 
   return (
     <Drawer
@@ -38,38 +115,37 @@ export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, o
       closeOnClickOutside={false}
       title="Annotations"
     >
-      <Stack gap="xs">
+      <Stack
+        gap="xs"
+        data-testid="annotations-drawer-content"
+        onMouseEnter={() => store.getState().setAnnotationsDrawerHovered(true)}
+        onMouseLeave={() => store.getState().setAnnotationsDrawerHovered(false)}
+      >
         {annotations.length === 0 && (
           <Text c="dimmed" size="sm">
             No annotations yet
           </Text>
         )}
-        {annotations.map((annotation) => {
-          const label = labelsMap[annotation.labelId]
-          const selected = annotation.id === selectedAnnotationId
+        {Array.from(groupByLabel(annotations)).map(([groupKey, groupAnnotations]) => {
+          const label = groupKey === UNKNOWN_LABEL_GROUP ? undefined : labelsMap[groupKey]
+          const isOpen = !collapsedGroups.has(groupKey)
+          const groupName = label?.name ?? 'Unknown label'
 
           return (
-            <Group
-              key={annotation.id}
-              justify="space-between"
-              wrap="nowrap"
-              p="xs"
-              style={{
-                cursor: 'pointer',
-                borderRadius: 'var(--mantine-radius-sm)',
-                backgroundColor: selected
-                  ? 'light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5))'
-                  : undefined
-              }}
-              onClick={() => {
-                const state = store.getState()
-                if (state.mode !== LabelerMode.Select) {
-                  state.setMode(LabelerMode.Select)
-                }
-                state.selectAnnotation(annotation.id)
-              }}
-            >
-              <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+            <Stack key={groupKey} gap={4}>
+              <UnstyledButton
+                onClick={() => toggleGroup(groupKey)}
+                aria-expanded={isOpen}
+                style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                <MdChevronRight
+                  size={16}
+                  style={{
+                    flexShrink: 0,
+                    transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                    transition: 'transform 0.1s ease'
+                  }}
+                />
                 {label && (
                   <Badge
                     size="xs"
@@ -81,23 +157,58 @@ export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, o
                     }}
                   />
                 )}
-                <AnnotationTypeIcon type={annotation.type} />
-                <Text size="sm" truncate>
-                  {label?.name ?? 'Unknown label'}
+                <Text size="sm" fw={500} truncate style={{ flex: 1, textAlign: 'left' }}>
+                  {groupName}
                 </Text>
-              </Group>
-              <ActionIcon
-                aria-label="Delete annotation"
-                variant="subtle"
-                color="red"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  store.getState().deleteAnnotation(annotation.id)
-                }}
-              >
-                <MdDeleteOutline size={16} />
-              </ActionIcon>
-            </Group>
+                <Text size="xs" c="dimmed">
+                  {groupAnnotations.length}
+                </Text>
+              </UnstyledButton>
+              <Collapse in={isOpen}>
+                <Stack gap="xs" pl="lg">
+                  {groupAnnotations.map((annotation, index) => {
+                    const selected = annotation.id === selectedAnnotationId
+
+                    return (
+                      <AnnotationRow
+                        key={annotation.id}
+                        justify="space-between"
+                        wrap="nowrap"
+                        p="xs"
+                        data-selected={selected}
+                        onClick={() => {
+                          const state = store.getState()
+                          if (state.mode !== LabelerMode.Select) {
+                            state.setMode(LabelerMode.Select)
+                          }
+                          state.selectAnnotation(annotation.id)
+                        }}
+                        onMouseEnter={() => store.getState().setHoveredAnnotation(annotation.id)}
+                        onMouseLeave={() => store.getState().setHoveredAnnotation(null)}
+                      >
+                        <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                          <AnnotationTypeIcon type={annotation.type} />
+                          <Text size="sm" truncate>
+                            {annotation.type === AnnotationType.Box ? 'Box' : 'Polygon'} {index + 1}
+                          </Text>
+                        </Group>
+                        <ActionIcon
+                          aria-label="Delete annotation"
+                          variant="subtle"
+                          color="red"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            store.getState().deleteAnnotation(annotation.id)
+                          }}
+                        >
+                          <MdDeleteOutline size={16} />
+                        </ActionIcon>
+                      </AnnotationRow>
+                    )
+                  })}
+                </Stack>
+              </Collapse>
+            </Stack>
           )
         })}
       </Stack>

--- a/src/renderer/src/routes/label/LabelPage.tsx
+++ b/src/renderer/src/routes/label/LabelPage.tsx
@@ -10,6 +10,8 @@ import {
   Tooltip,
   VisuallyHidden
 } from '@mantine/core'
+import { useHotkeys } from '@mantine/hooks'
+import { AsyncButton } from '@renderer/components/AsyncButton'
 import { Labeler } from '@renderer/components/Labeler'
 import { useLabeler } from '@renderer/hooks/useLabeler'
 import { LabelerMode, OptimisticSample } from '@renderer/types'
@@ -21,7 +23,7 @@ import { MdFormatListBulleted } from 'react-icons/md'
 import { ILabel, IProject, ITask, OmitV2 } from '@shared/types'
 import { mod } from '@shared/utils'
 import { useAppStore } from '@renderer/hooks/useAppStore'
-import { back } from '@renderer/router/appRouter'
+import { back, useOnRouteEnter, useOnRouteLeave } from '@renderer/router/appRouter'
 import { AnnotationsDrawer } from './AnnotationsDrawer'
 
 const Container = styled.div`
@@ -95,12 +97,12 @@ const LabelerModeControl = ({ value, onChange, size = 'md' }: LabelerModeControl
         )
       },
       {
-        value: LabelerMode.CreateMask,
+        value: LabelerMode.CreatePolygon,
         label: (
-          <Tooltip label="Create Segments">
+          <Tooltip label="Create Polygon">
             <span>
               <PiPolygonLight size={ICON_SIZE} style={ICON_STYLE} />
-              <VisuallyHidden>Create Segments</VisuallyHidden>
+              <VisuallyHidden>Create Polygon</VisuallyHidden>
             </span>
           </Tooltip>
         )
@@ -176,39 +178,20 @@ const SelectedLabelControl = ({ labels, selectedLabelId, onChange }: SelectedLab
 
 type LabelingCompletedControlProps = {
   value: string | null
-  onChange: (newValue: string | null) => void
+  onChange: (newValue: string | null) => Promise<unknown>
 }
 
-const SAMPLE_COMPLETED_CONTROL_IN_PROGRESS = 'in-progress'
-const SAMPLE_COMPLETED_CONTROL_COMPLETED = 'completed'
-
-const SampleCompletedControl = ({ value, onChange }: LabelingCompletedControlProps) => (
-  <TextSegmentedControl
-    value={
-      value === null ? SAMPLE_COMPLETED_CONTROL_IN_PROGRESS : SAMPLE_COMPLETED_CONTROL_COMPLETED
-    }
-    onChange={(e) => {
-      switch (e) {
-        case SAMPLE_COMPLETED_CONTROL_COMPLETED:
-          onChange(new Date().toISOString())
-          break
-        case SAMPLE_COMPLETED_CONTROL_IN_PROGRESS:
-          onChange(null)
-          break
-      }
-    }}
-    data={[
-      {
-        value: SAMPLE_COMPLETED_CONTROL_IN_PROGRESS,
-        label: 'In Progress'
-      },
-      {
-        value: SAMPLE_COMPLETED_CONTROL_COMPLETED,
-        label: 'Completed'
-      }
-    ]}
-  />
-)
+const SampleCompletedControl = ({ value, onChange }: LabelingCompletedControlProps) => {
+  const isCompleted = value !== null
+  return (
+    <AsyncButton
+      variant="outline"
+      onClick={() => onChange(isCompleted ? null : new Date().toISOString())}
+    >
+      {isCompleted ? 'Mark In Progress' : 'Mark Complete'}
+    </AsyncButton>
+  )
+}
 
 type SampleSelectProps = {
   value: number
@@ -258,7 +241,7 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
   const onSampleCompletedChanged = useCallback(
     (sampleId: string, newValue: string | null) => {
       const sample = samples.find((c) => c.resolve().id === sampleId)
-      if (sample === undefined) return
+      if (sample === undefined) return Promise.resolve()
       const { commit, rollback } = sample.update({
         completedAt: newValue
       })
@@ -267,7 +250,7 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
       // Force a notify so selectors reading sample.resolve() (currentSampleId,
       // sampleCompletedAt) actually re-render.
       store.setState((s) => ({ ...s }))
-      useAppStore
+      return useAppStore
         .getState()
         .store.updateSamples([
           {
@@ -290,6 +273,22 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
   useLayoutEffect(() => {
     store.getState().setSample(samples[index])
   }, [index, samples, store])
+
+  // Force a full repaint on return: the canvas's own resize-detection normally covers
+  // becoming visible again, but that depends on measuring a bounding rect that Activity
+  // may not have finished restoring yet - an explicit markAllDirty() here is reliable.
+  useOnRouteEnter(() => store.getState().markAllDirty())
+  // Don't let a bitmap load started for this page keep running (and settling into a
+  // hidden store) after the user has already left it.
+  useOnRouteLeave(() => store.getState().cancelPendingSampleLoad())
+
+  // useHotkeys ignores INPUT/TEXTAREA/SELECT targets by default, so this doesn't fire
+  // while e.g. the sample index NumberInput below is focused.
+  useHotkeys([
+    ['mod+z', () => store.getState().undo()],
+    ['mod+shift+z', () => store.getState().redo()],
+    ['mod+d', () => store.getState().duplicateSelectedAnnotation()]
+  ])
 
   return (
     <Container>

--- a/src/renderer/src/routes/label/__tests__/AnnotationsDrawer.test.tsx
+++ b/src/renderer/src/routes/label/__tests__/AnnotationsDrawer.test.tsx
@@ -1,11 +1,24 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { act, screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
 import { LabelerStore } from '@renderer/hooks/useLabeler'
 import { LabelerMode } from '@renderer/types'
 import { AnnotationType, IAnnotation, ILabel } from '@shared/types'
 import { create } from 'zustand'
 import type { StoreApi, UseBoundStore } from 'zustand'
+
+const { onRouteLeave } = vi.hoisted(() => ({
+  onRouteLeave: { current: null as (() => void) | null }
+}))
+
+vi.mock('@renderer/router/appRouter', () => ({
+  navigate: vi.fn(),
+  back: vi.fn(),
+  useOnRouteLeave: (callback: () => void) => {
+    onRouteLeave.current = callback
+  }
+}))
+
 import { AnnotationsDrawer } from '../AnnotationsDrawer'
 
 const labels: ILabel[] = [
@@ -23,9 +36,19 @@ const boxAnnotation: IAnnotation = {
   ]
 }
 
-const maskAnnotation: IAnnotation = {
+const secondBoxAnnotation: IAnnotation = {
+  id: 'a3',
+  type: AnnotationType.Box,
+  labelId: 'l1',
+  points: [
+    { id: 'p4', x: 20, y: 20 },
+    { id: 'p5', x: 30, y: 30 }
+  ]
+}
+
+const polygonAnnotation: IAnnotation = {
   id: 'a2',
-  type: AnnotationType.Mask,
+  type: AnnotationType.Polygon,
   labelId: 'l2',
   points: [
     { id: 'p2', x: 0, y: 0 },
@@ -37,6 +60,8 @@ const maskAnnotation: IAnnotation = {
 const setMode = vi.fn()
 const selectAnnotation = vi.fn()
 const deleteAnnotation = vi.fn()
+const setHoveredAnnotation = vi.fn()
+const setAnnotationsDrawerHovered = vi.fn()
 
 const makeStore = (
   annotations: IAnnotation[],
@@ -59,13 +84,18 @@ const makeStore = (
     labelsMap: Object.fromEntries(labels.map((l) => [l.id, l])),
     setMode,
     selectAnnotation,
-    deleteAnnotation
+    deleteAnnotation,
+    setHoveredAnnotation,
+    setAnnotationsDrawerHovered
   })) as unknown as UseBoundStore<StoreApi<LabelerStore>>
 
 beforeEach(() => {
   setMode.mockClear()
   selectAnnotation.mockClear()
   deleteAnnotation.mockClear()
+  setHoveredAnnotation.mockClear()
+  setAnnotationsDrawerHovered.mockClear()
+  onRouteLeave.current = null
 })
 
 describe('AnnotationsDrawer', () => {
@@ -75,10 +105,10 @@ describe('AnnotationsDrawer', () => {
     expect(screen.getByText('No annotations yet')).toBeInTheDocument()
   })
 
-  it('lists each annotation with its label name', () => {
+  it('groups annotations under a header per label, with a count', () => {
     renderWithProviders(
       <AnnotationsDrawer
-        store={makeStore([boxAnnotation, maskAnnotation])}
+        store={makeStore([boxAnnotation, secondBoxAnnotation, polygonAnnotation])}
         opened
         onClose={vi.fn()}
       />
@@ -86,6 +116,33 @@ describe('AnnotationsDrawer', () => {
 
     expect(screen.getByText('Stop Sign')).toBeInTheDocument()
     expect(screen.getByText('Yield Sign')).toBeInTheDocument()
+    // 2 Stop Sign annotations, 1 Yield Sign annotation.
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('Box 1')).toBeInTheDocument()
+    expect(screen.getByText('Box 2')).toBeInTheDocument()
+    expect(screen.getByText('Polygon 1')).toBeInTheDocument()
+  })
+
+  it('groups an annotation whose label no longer resolves under "Unknown label"', () => {
+    const orphan: IAnnotation = { ...boxAnnotation, id: 'a4', labelId: 'deleted-label' }
+    renderWithProviders(<AnnotationsDrawer store={makeStore([orphan])} opened onClose={vi.fn()} />)
+
+    expect(screen.getByText('Unknown label')).toBeInTheDocument()
+  })
+
+  it('starts with every group expanded, and collapses/expands on header click', () => {
+    renderWithProviders(
+      <AnnotationsDrawer store={makeStore([boxAnnotation])} opened onClose={vi.fn()} />
+    )
+
+    expect(screen.getByText('Box 1')).toBeVisible()
+
+    fireEvent.click(screen.getByText('Stop Sign'))
+    expect(screen.getByText('Box 1')).not.toBeVisible()
+
+    fireEvent.click(screen.getByText('Stop Sign'))
+    expect(screen.getByText('Box 1')).toBeVisible()
   })
 
   it('selects an annotation when its row is clicked, without changing mode if already in Select', () => {
@@ -97,7 +154,7 @@ describe('AnnotationsDrawer', () => {
       />
     )
 
-    fireEvent.click(screen.getByText('Stop Sign'))
+    fireEvent.click(screen.getByText('Box 1'))
 
     expect(selectAnnotation).toHaveBeenCalledWith('a1')
     expect(setMode).not.toHaveBeenCalled()
@@ -112,7 +169,7 @@ describe('AnnotationsDrawer', () => {
       />
     )
 
-    fireEvent.click(screen.getByText('Stop Sign'))
+    fireEvent.click(screen.getByText('Box 1'))
 
     expect(setMode).toHaveBeenCalledWith(LabelerMode.Select)
     expect(selectAnnotation).toHaveBeenCalledWith('a1')
@@ -127,5 +184,55 @@ describe('AnnotationsDrawer', () => {
 
     expect(deleteAnnotation).toHaveBeenCalledWith('a1')
     expect(selectAnnotation).not.toHaveBeenCalled()
+  })
+
+  it('sets the hovered annotation on mouse enter and clears it on mouse leave', () => {
+    renderWithProviders(
+      <AnnotationsDrawer store={makeStore([boxAnnotation])} opened onClose={vi.fn()} />
+    )
+
+    const row = screen.getByText('Box 1')
+    fireEvent.mouseEnter(row)
+    expect(setHoveredAnnotation).toHaveBeenCalledWith('a1')
+
+    fireEvent.mouseLeave(row)
+    expect(setHoveredAnnotation).toHaveBeenLastCalledWith(null)
+  })
+
+  it('clears the drawer-hover (and canvas dim) when the drawer closes', () => {
+    const store = makeStore([boxAnnotation])
+    const { rerender } = renderWithProviders(
+      <AnnotationsDrawer store={store} opened onClose={vi.fn()} />
+    )
+    setAnnotationsDrawerHovered.mockClear()
+
+    rerender(<AnnotationsDrawer store={store} opened={false} onClose={vi.fn()} />)
+
+    expect(setAnnotationsDrawerHovered).toHaveBeenCalledWith(false)
+  })
+
+  it('clears the drawer-hover (and canvas dim) when the router reports leaving the label page', () => {
+    renderWithProviders(
+      <AnnotationsDrawer store={makeStore([boxAnnotation])} opened onClose={vi.fn()} />
+    )
+    setAnnotationsDrawerHovered.mockClear()
+
+    act(() => onRouteLeave.current?.())
+
+    expect(setAnnotationsDrawerHovered).toHaveBeenCalledWith(false)
+  })
+
+  it('marks the drawer as hovered on mouse enter and clears it on mouse leave', () => {
+    renderWithProviders(
+      <AnnotationsDrawer store={makeStore([boxAnnotation])} opened onClose={vi.fn()} />
+    )
+
+    const panel = screen.getByTestId('annotations-drawer-content')
+
+    fireEvent.mouseEnter(panel)
+    expect(setAnnotationsDrawerHovered).toHaveBeenCalledWith(true)
+
+    fireEvent.mouseLeave(panel)
+    expect(setAnnotationsDrawerHovered).toHaveBeenLastCalledWith(false)
   })
 })

--- a/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
+++ b/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
@@ -10,6 +10,10 @@ const setMode = vi.fn()
 const setLabelId = vi.fn()
 const selectAnnotation = vi.fn()
 const deleteAnnotation = vi.fn()
+const setHoveredAnnotation = vi.fn()
+const setAnnotationsDrawerHovered = vi.fn()
+const markAllDirty = vi.fn()
+const cancelPendingSampleLoad = vi.fn()
 
 vi.mock('@renderer/components/Labeler', () => ({
   Labeler: () => <div data-testid="labeler-stub" />
@@ -33,7 +37,11 @@ vi.mock('@renderer/hooks/useLabeler', () => ({
       setMode,
       setLabelId,
       selectAnnotation,
-      deleteAnnotation
+      deleteAnnotation,
+      setHoveredAnnotation,
+      setAnnotationsDrawerHovered,
+      markAllDirty,
+      cancelPendingSampleLoad
     }))
   })
 }))
@@ -47,10 +55,27 @@ vi.mock('@renderer/hooks/useAppStore', async () => {
   return { useAppStore }
 })
 
+// A Set, not a single ref: LabelPage and the AnnotationsDrawer it renders each register
+// their own useOnRouteLeave callback, so a single "last one wins" slot would let the
+// drawer's registration clobber the page's.
+const { onRouteEnterCallbacks, onRouteLeaveCallbacks } = vi.hoisted(() => ({
+  onRouteEnterCallbacks: new Set<() => void>(),
+  onRouteLeaveCallbacks: new Set<() => void>()
+}))
+
 vi.mock('@renderer/router/appRouter', () => ({
   navigate: vi.fn(),
-  back: vi.fn()
+  back: vi.fn(),
+  useOnRouteEnter: (callback: () => void) => {
+    onRouteEnterCallbacks.add(callback)
+  },
+  useOnRouteLeave: (callback: () => void) => {
+    onRouteLeaveCallbacks.add(callback)
+  }
 }))
+
+const fireRouteEnter = () => onRouteEnterCallbacks.forEach((callback) => callback())
+const fireRouteLeave = () => onRouteLeaveCallbacks.forEach((callback) => callback())
 
 import { LabelPage } from '../LabelPage'
 
@@ -77,6 +102,12 @@ beforeEach(() => {
   setSample.mockClear()
   setMode.mockClear()
   setLabelId.mockClear()
+  setHoveredAnnotation.mockClear()
+  setAnnotationsDrawerHovered.mockClear()
+  markAllDirty.mockClear()
+  cancelPendingSampleLoad.mockClear()
+  onRouteEnterCallbacks.clear()
+  onRouteLeaveCallbacks.clear()
 })
 
 describe('LabelPage', () => {
@@ -120,11 +151,10 @@ describe('LabelPage', () => {
     expect(scrollArea.style.maxWidth).toBeTruthy()
   })
 
-  it('shows the completed toggle for the current sample', () => {
+  it('shows a button reflecting the current sample completion state', () => {
     renderLabelPage()
 
-    expect(screen.getByText('In Progress')).toBeInTheDocument()
-    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Mark Complete' })).toBeInTheDocument()
   })
 
   it('opens the annotations drawer when the toggle button is clicked', async () => {
@@ -135,5 +165,22 @@ describe('LabelPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Annotations' }))
 
     expect(await screen.findByText('No annotations yet')).toBeInTheDocument()
+  })
+
+  it('forces a full repaint when the router reports this page becoming visible again', () => {
+    renderLabelPage()
+    markAllDirty.mockClear()
+
+    fireRouteEnter()
+
+    expect(markAllDirty).toHaveBeenCalled()
+  })
+
+  it('cancels an in-flight sample load when the router reports leaving the page', () => {
+    renderLabelPage()
+
+    fireRouteLeave()
+
+    expect(cancelPendingSampleLoad).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/routes/projects/EditProjectModal.tsx
+++ b/src/renderer/src/routes/projects/EditProjectModal.tsx
@@ -1,19 +1,28 @@
-import { Badge, Button, Group, Modal, Stack, TextInput } from '@mantine/core'
-import type { IProject } from '@shared/types'
+import { Button, Flex, Group, Modal, ScrollArea, Stack, TextInput } from '@mantine/core'
+import type { ILabel, IProject } from '@shared/types'
 import { useState, type FC } from 'react'
-import tinycolor from 'tinycolor2'
 import { ZIndex } from '@renderer/zIndex'
 import { AsyncButton } from '@renderer/components/AsyncButton'
+import { ColorPicker } from '@renderer/components/ColorPicker'
+import { useArray } from '@renderer/hooks/useArray'
+import { randomHexColor } from '@shared/color'
+import { makeUUID } from '@shared/utils'
+import { MdDeleteOutline } from 'react-icons/md'
 
 export type EditProjectModalProps = {
   opened: boolean
   project: IProject | null
   onCancel: () => void
-  onConfirm: (name: string, labels: { id: string; name: string }[]) => Promise<unknown>
+  onConfirm: (
+    name: string,
+    labels: { id: string; name: string; color: string }[]
+  ) => Promise<unknown>
 }
 
-/** Only renames the project and its existing labels - adding/removing labels isn't
- *  supported here since a label already used by an annotation can't be deleted. Controlled
+/** Renames the project, edits existing labels (including their colors), and lets new
+ *  labels be added - existing labels still can't be removed here, since one already
+ *  used by an annotation can't be deleted. A label added (and not yet saved) in this
+ *  same session can be removed again freely, since nothing references it yet. Controlled
  *  by mounting with `key={project?.id}` so state resets when the target project changes. */
 export const EditProjectModal: FC<EditProjectModalProps> = ({
   opened,
@@ -22,20 +31,19 @@ export const EditProjectModal: FC<EditProjectModalProps> = ({
   onConfirm
 }) => {
   const [name, setName] = useState(project?.name ?? '')
-  const [labelNames, setLabelNames] = useState<Record<string, string>>(
-    Object.fromEntries((project?.labels ?? []).map((l) => [l.id, l.name]))
-  )
+  // Only ids the project already had when this modal opened are "existing" - anything
+  // added afterward stays removable for the rest of this session.
+  const [existingLabelIds] = useState(() => new Set((project?.labels ?? []).map((l) => l.id)))
+  // useArray mutates its initial array in place (push/splice/etc. act directly on the
+  // reference it's given) - a shallow copy here keeps that from reaching back into
+  // project.labels itself, which react-query still owns.
+  const labels = useArray<ILabel>((project?.labels ?? []).map((l) => ({ ...l })))
 
-  const labels = project?.labels ?? []
-  const canSave =
-    name.trim().length > 0 && labels.every((l) => (labelNames[l.id] ?? '').trim().length > 0)
+  const canSave = name.trim().length > 0 && labels.every((l) => l.name.trim().length > 0)
 
   const confirm = () => {
     if (!canSave) return Promise.resolve()
-    return onConfirm(
-      name.trim(),
-      labels.map((l) => ({ id: l.id, name: (labelNames[l.id] ?? l.name).trim() }))
-    )
+    return onConfirm(name.trim(), labels.resolve())
   }
 
   return (
@@ -53,28 +61,62 @@ export const EditProjectModal: FC<EditProjectModalProps> = ({
           onChange={(e) => setName(e.target.value)}
           data-autofocus
         />
+        <Flex justify="flex-end">
+          <Button
+            variant="outline"
+            onClick={() => {
+              labels.push({ id: makeUUID(), name: '', color: randomHexColor() })
+            }}
+          >
+            Add Label
+          </Button>
+        </Flex>
         {labels.length > 0 && (
-          <Stack gap="xs">
-            {labels.map((label) => (
-              <TextInput
-                key={label.id}
-                value={labelNames[label.id] ?? label.name}
-                onChange={(e) =>
-                  setLabelNames((current) => ({ ...current, [label.id]: e.target.value }))
-                }
-                leftSection={
-                  <Badge
-                    size="xs"
-                    circle
-                    style={{
-                      backgroundColor: label.color,
-                      color: tinycolor(label.color).isLight() ? '#000' : '#fff'
+          <ScrollArea style={{ maxHeight: 240 }} type="always" scrollbars="y">
+            <Stack gap="xs">
+              {labels.map((label) => (
+                <Flex key={label.id} align="center" gap="xs">
+                  <TextInput
+                    flex={1}
+                    placeholder="Label Name"
+                    required
+                    value={label.name}
+                    leftSection={
+                      <ColorPicker
+                        initial={label.color}
+                        style={{ width: 18, height: 18, borderRadius: '50%' }}
+                        onChange={(color) => {
+                          labels.mutate((arr) => {
+                            const item = arr.find((l) => l.id === label.id)
+                            if (item !== undefined) item.color = color
+                          })
+                        }}
+                      />
+                    }
+                    onChange={(e) => {
+                      labels.mutate((arr) => {
+                        const item = arr.find((l) => l.id === label.id)
+                        if (item !== undefined) item.name = e.target.value
+                      })
                     }}
                   />
-                }
-              />
-            ))}
-          </Stack>
+                  {!existingLabelIds.has(label.id) && (
+                    <Button
+                      aria-label={`Remove ${label.name.trim() || 'label'}`}
+                      variant="subtle"
+                      color="red"
+                      onClick={() => {
+                        const idx = labels.findIndex((l) => l.id === label.id)
+                        if (idx !== -1) labels.splice(idx, 1)
+                      }}
+                    >
+                      <MdDeleteOutline />
+                    </Button>
+                  )}
+                </Flex>
+              ))}
+            </Stack>
+          </ScrollArea>
         )}
         <Group justify="flex-end">
           <Button variant="outline" onClick={onCancel}>

--- a/src/renderer/src/routes/projects/ProjectsPage.tsx
+++ b/src/renderer/src/routes/projects/ProjectsPage.tsx
@@ -1,26 +1,21 @@
-import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
 import {
   BasicListPageItem,
   BasicListPageItemSkeleton
 } from '@renderer/components/BasicListPageItem'
+import { VirtualizedItemList } from '@renderer/components/VirtualizedItemList'
 import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
 import { EditProjectModal } from './EditProjectModal'
-import { styled } from '@linaria/react'
+import { AnnotatorsModal } from '@renderer/components/annotators/AnnotatorsModal'
 import { Badge, Button, Divider, Group, Stack, Text, TextInput } from '@mantine/core'
 import { CiSearch } from 'react-icons/ci'
 import { MdDeleteOutline, MdFolder } from 'react-icons/md'
 import { CreateProjectButton } from './CreateProjectButton'
 import { useProjects } from '@renderer/hooks/useProjects'
-import { useMemo, useState } from 'react'
+import { useOnRouteLeave } from '@renderer/router/appRouter'
+import { useMemo, useRef, useState } from 'react'
 import { ILabel, IProject } from '@shared/types'
 import tinycolor from 'tinycolor2'
-
-const TopContainer = styled.div`
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  justify-content: space-between;
-`
 
 const LabelTags = ({ labels }: { labels: ILabel[] }) => (
   <Group gap={4} mt={4}>
@@ -46,9 +41,11 @@ const LabelTags = ({ labels }: { labels: ILabel[] }) => (
 
 export const ProjectsPage = () => {
   const { items, create, open, update, remove, removeMany, isLoading } = useProjects()
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [search, setSearch] = useState('')
   const [pendingDelete, setPendingDelete] = useState<IProject | null>(null)
   const [pendingEdit, setPendingEdit] = useState<IProject | null>(null)
+  const [pendingAnnotators, setPendingAnnotators] = useState<IProject | null>(null)
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(new Set())
   const [isBatchDeletePending, setIsBatchDeletePending] = useState(false)
@@ -71,6 +68,10 @@ export const ProjectsPage = () => {
     setSelectedProjectIds(new Set())
   }
 
+  // Multiselect shouldn't still be armed when the user comes back to this page later -
+  // Activity preserves this state across a hide/show, so it has to be cleared explicitly.
+  useOnRouteLeave(exitSelectMode)
+
   const toggleSelected = (projectId: string, selected: boolean) => {
     setSelectedProjectIds((current) => {
       const next = new Set(current)
@@ -81,6 +82,14 @@ export const ProjectsPage = () => {
       }
       return next
     })
+  }
+
+  // Enters select mode with just this one project selected - the context menu's "Select"
+  // entry point outside select mode (see selectAll/selectAbove/selectBelow below for the
+  // batch variants offered once already in select mode).
+  const selectOnly = (projectId: string) => {
+    setIsSelectMode(true)
+    setSelectedProjectIds(new Set([projectId]))
   }
 
   // Selection helpers operate on filteredItems (the currently visible/filtered list),
@@ -136,9 +145,17 @@ export const ProjectsPage = () => {
           return result
         }}
       />
+      {pendingAnnotators !== null && (
+        <AnnotatorsModal
+          opened
+          project={pendingAnnotators}
+          onClose={() => setPendingAnnotators(null)}
+        />
+      )}
       <BasicListPage
+        scrollContainerRef={scrollContainerRef}
         top={
-          <TopContainer>
+          <BasicListPageTopBar>
             <Group>
               <CreateProjectButton create={create} />
               {!isSelectMode && (
@@ -176,7 +193,7 @@ export const ProjectsPage = () => {
                 onChange={(e) => setSearch(e.target.value)}
               />
             </Group>
-          </TopContainer>
+          </BasicListPageTopBar>
         }
       >
         <Stack>
@@ -196,26 +213,36 @@ export const ProjectsPage = () => {
                 : 'No projects match your search.'}
             </Text>
           )}
-          {!isLoading &&
-            filteredItems.map((p, index) => (
+        </Stack>
+        {!isLoading && filteredItems.length > 0 && (
+          <VirtualizedItemList
+            items={filteredItems}
+            getKey={(p) => p.id}
+            scrollContainerRef={scrollContainerRef}
+            // Closer to a row with a label badge line than the component's generic
+            // default (90) - most projects have at least one label.
+            estimateSize={80}
+            renderItem={(p, index) => (
               <BasicListPageItem
-                key={p.id}
                 icon={<MdFolder size={18} />}
                 title={p.name}
                 subtitle={p.labels.length === 0 ? 'No labels' : undefined}
                 tags={p.labels.length > 0 ? <LabelTags labels={p.labels} /> : undefined}
                 onClick={() => open(p)}
                 onEdit={() => setPendingEdit(p)}
+                onManageAnnotators={() => setPendingAnnotators(p)}
                 onDelete={() => setPendingDelete(p)}
                 selectMode={isSelectMode}
                 selected={selectedProjectIds.has(p.id)}
                 onSelectedChange={(selected) => toggleSelected(p.id, selected)}
+                onSelect={() => selectOnly(p.id)}
                 onSelectAll={selectAll}
                 onSelectAbove={() => selectAbove(index)}
                 onSelectBelow={() => selectBelow(index)}
               />
-            ))}
-        </Stack>
+            )}
+          />
+        )}
       </BasicListPage>
     </>
   )

--- a/src/renderer/src/routes/projects/__tests__/EditProjectModal.test.tsx
+++ b/src/renderer/src/routes/projects/__tests__/EditProjectModal.test.tsx
@@ -32,7 +32,7 @@ describe('EditProjectModal', () => {
     expect(screen.queryByText('Edit Project')).not.toBeInTheDocument()
   })
 
-  it('calls onConfirm with the updated project name and label names', () => {
+  it('calls onConfirm with the updated project name, label names, and unchanged label colors', () => {
     const onConfirm = vi.fn().mockResolvedValue(undefined)
     renderWithProviders(
       <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={onConfirm} />
@@ -45,8 +45,27 @@ describe('EditProjectModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(onConfirm).toHaveBeenCalledWith('Renamed Project', [
-      { id: 'l1', name: 'Stop Sign Renamed' },
-      { id: 'l2', name: 'Yield Sign' }
+      { id: 'l1', name: 'Stop Sign Renamed', color: '#ff0000' },
+      { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+    ])
+  })
+
+  it('calls onConfirm with an updated label color', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(
+      <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={onConfirm} />
+    )
+
+    const stopSignRow = screen.getByDisplayValue('Stop Sign').closest('.mantine-TextInput-root')
+    const colorInput = (stopSignRow as HTMLElement).querySelector(
+      'input[type="color"]'
+    ) as HTMLInputElement
+    fireEvent.change(colorInput, { target: { value: '#123456' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onConfirm).toHaveBeenCalledWith('Street Signs', [
+      { id: 'l1', name: 'Stop Sign', color: '#123456' },
+      { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
     ])
   })
 
@@ -70,13 +89,63 @@ describe('EditProjectModal', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
-  it('does not add or remove label rows', () => {
+  it('does not offer to remove an existing label', () => {
     renderWithProviders(
       <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={vi.fn()} />
     )
 
-    expect(screen.queryByRole('button', { name: 'Add Label' })).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Remove label')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Remove /i })).not.toBeInTheDocument()
+  })
+
+  it('adds a new label via Add Label and includes it on Save', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(
+      <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={onConfirm} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Label' }))
+    // Every label row shares the "Label Name" placeholder (existing rows just don't show
+    // it, since they already have a value) - the new one is the last row appended.
+    const labelInputsBeforeEdit = screen.getAllByPlaceholderText('Label Name')
+    fireEvent.change(labelInputsBeforeEdit[labelInputsBeforeEdit.length - 1], {
+      target: { value: 'Speed Limit' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    const [savedName, savedLabels] = onConfirm.mock.calls[0]
+    expect(savedName).toBe('Street Signs')
+    expect(savedLabels).toHaveLength(3)
+    expect(savedLabels.slice(0, 2)).toEqual(project.labels)
+    expect(savedLabels[2]).toMatchObject({ name: 'Speed Limit' })
+  })
+
+  it('can remove a newly-added label before saving, but not an existing one', () => {
+    renderWithProviders(
+      <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={vi.fn()} />
+    )
+
+    // 2 existing labels to start with.
+    expect(screen.getAllByPlaceholderText('Label Name')).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Label' }))
+    expect(screen.getAllByPlaceholderText('Label Name')).toHaveLength(3)
+    expect(screen.getByRole('button', { name: 'Remove label' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove label' }))
+
+    expect(screen.getAllByPlaceholderText('Label Name')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /^Remove /i })).not.toBeInTheDocument()
+  })
+
+  it('disables Save when a newly-added label is left blank', () => {
+    renderWithProviders(
+      <EditProjectModal opened project={project} onCancel={vi.fn()} onConfirm={vi.fn()} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Label' }))
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
   it('calls onCancel when Cancel is clicked', () => {

--- a/src/renderer/src/routes/projects/__tests__/ProjectsPage.test.tsx
+++ b/src/renderer/src/routes/projects/__tests__/ProjectsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { act, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
 import { IProject } from '@shared/types'
 
@@ -12,9 +12,16 @@ vi.mock('@renderer/hooks/useAppStore', async () => {
   return { useAppStore }
 })
 
+const { onRouteLeave } = vi.hoisted(() => ({
+  onRouteLeave: { current: null as (() => void) | null }
+}))
+
 vi.mock('@renderer/router/appRouter', () => ({
   navigate: vi.fn(),
-  back: vi.fn()
+  back: vi.fn(),
+  useOnRouteLeave: (callback: () => void) => {
+    onRouteLeave.current = callback
+  }
 }))
 
 import { useAppStore } from '@renderer/hooks/useAppStore'
@@ -40,6 +47,7 @@ const projects: IProject[] = [
 beforeEach(() => {
   vi.mocked(navigate).mockReset()
   vi.mocked(useAppStore.getState().store.getProjects).mockReset().mockResolvedValue(projects)
+  onRouteLeave.current = null
 })
 
 describe('ProjectsPage', () => {
@@ -89,8 +97,8 @@ describe('ProjectsPage', () => {
         ...projects[0],
         name: updates[0].name ?? projects[0].name,
         labels: projects[0].labels.map((label) => {
-          const renamed = updates[0].labels?.find((l) => l.id === label.id)
-          return renamed ? { ...label, name: renamed.name } : label
+          const updated = updates[0].labels?.find((l) => l.id === label.id)
+          return updated ? { ...label, name: updated.name, color: updated.color } : label
         })
       }
     ])
@@ -123,8 +131,8 @@ describe('ProjectsPage', () => {
           id: 'p1',
           name: 'Renamed Signs',
           labels: [
-            { id: 'l1', name: 'Stop Sign Renamed' },
-            { id: 'l2', name: 'Yield Sign' }
+            { id: 'l1', name: 'Stop Sign Renamed', color: '#ff0000' },
+            { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
           ]
         }
       ])
@@ -176,10 +184,31 @@ describe('ProjectsPage', () => {
     expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
   })
 
+  it('right-click Select enters select mode with just that project selected', async () => {
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByText('Street Signs')
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+
+    fireEvent.contextMenu(screen.getByText('Street Signs'))
+    expect(screen.queryByText('Select All')).not.toBeInTheDocument()
+    // The toolbar's own "Select" button is still visible outside select mode too, so
+    // disambiguate by only clicking the context menu's copy of the text.
+    const [selectMenuItem] = screen
+      .getAllByText('Select')
+      .filter((el) => el.closest('.mantine-contextmenu-item-button') !== null)
+    fireEvent.click(selectMenuItem)
+
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Select Street Signs' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Select Wildlife Cams' })).not.toBeChecked()
+  })
+
   it('right-click Select All selects every currently visible (filtered) project', async () => {
     renderWithProviders(<ProjectsPage />)
     await screen.findByText('Street Signs')
 
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     fireEvent.contextMenu(screen.getByText('Street Signs'))
     fireEvent.click(screen.getByText('Select All'))
 
@@ -196,12 +225,27 @@ describe('ProjectsPage', () => {
     renderWithProviders(<ProjectsPage />)
     await screen.findByText('Street Signs')
 
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     fireEvent.contextMenu(screen.getByText('Wildlife Cams'))
     fireEvent.click(screen.getByText('Select Above'))
 
     expect(screen.getByRole('checkbox', { name: 'Select Street Signs' })).toBeChecked()
     expect(screen.getByRole('checkbox', { name: 'Select Wildlife Cams' })).toBeChecked()
     expect(screen.getByRole('checkbox', { name: 'Select Gamma' })).not.toBeChecked()
+  })
+
+  it('exits select mode and clears the selection when the router reports leaving the page', async () => {
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByText('Street Signs')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Street Signs' }))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    act(() => onRouteLeave.current?.())
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
   })
 
   it('disables batch Delete while nothing is selected, and enables it once something is', async () => {

--- a/src/renderer/src/routes/samples/SamplesPage.tsx
+++ b/src/renderer/src/routes/samples/SamplesPage.tsx
@@ -1,10 +1,10 @@
-import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
 import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
 import { RenameModal } from '@renderer/components/RenameModal'
-import { styled } from '@linaria/react'
 import {
   Text,
   Button,
+  Badge,
   Card,
   Group,
   TextInput,
@@ -19,22 +19,18 @@ import {
 import { IoMdArrowBack } from 'react-icons/io'
 import { FaFileImport } from 'react-icons/fa'
 import { CiSearch } from 'react-icons/ci'
-import { MdDeleteOutline, MdEdit } from 'react-icons/md'
+import { MdDeleteOutline, MdEdit, MdOutlineSmartToy } from 'react-icons/md'
 import { useContextMenu } from 'mantine-contextmenu'
-import { IProject, ITask, TrainingSplit } from '@shared/types'
+import { IAnnotation, ILabel, IProject, ITask, TrainingSplit } from '@shared/types'
+import tinycolor from 'tinycolor2'
 import { useSamples } from '@renderer/hooks/useSamples'
 import { useMemo, useState, useSyncExternalStore } from 'react'
 import { OptimisticSample } from '@renderer/types'
 import { useAppStore } from '@renderer/hooks/useAppStore'
+import { useAnnotators } from '@renderer/hooks/useAnnotators'
 import { ImportSamplesModal } from '@renderer/components/sampleIO/ImportSamplesModal'
-import { back } from '@renderer/router/appRouter'
-
-const TopContainer = styled.div`
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  justify-content: space-between;
-`
+import { AnnotatorsModal } from '@renderer/components/annotators/AnnotatorsModal'
+import { back, useOnRouteLeave } from '@renderer/router/appRouter'
 
 const SPLIT_COMBO_BOX_OPTIONS: SegmentedControlItem[] = [
   {
@@ -87,16 +83,68 @@ const STATUS_COMBO_BOX_OPTIONS: SegmentedControlItem[] = [
   }
 ]
 
+// Per-label annotation counts for one sample, e.g. "Stop Sign: 2" - ordered to match the
+// project's own label list rather than first-seen order, and coloured the same way
+// ProjectsPage's LabelTags colours a project's label badges (filled with the label's own
+// color, text contrast picked via tinycolor). A label with zero annotations on this
+// sample is omitted entirely rather than shown as "Label: 0".
+const AnnotationLabelCounts = ({
+  annotations,
+  labels
+}: {
+  annotations: IAnnotation[]
+  labels: ILabel[]
+}) => {
+  const counts = new Map<string, number>()
+  for (const annotation of annotations) {
+    counts.set(annotation.labelId, (counts.get(annotation.labelId) ?? 0) + 1)
+  }
+  const labelsWithCounts = labels.filter((label) => counts.has(label.id))
+
+  if (labelsWithCounts.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        No annotations yet
+      </Text>
+    )
+  }
+
+  return (
+    <Group gap={4}>
+      {labelsWithCounts.map((label) => (
+        <Badge
+          key={label.id}
+          size="sm"
+          variant="filled"
+          radius="sm"
+          style={{
+            backgroundColor: label.color,
+            color: tinycolor(label.color).isLight() ? '#000' : '#fff'
+          }}
+        >
+          {label.name}: {counts.get(label.id)}
+        </Badge>
+      ))}
+    </Group>
+  )
+}
+
 const SampleCard = ({
   optimisticSample,
+  labels,
   onLabel,
   onEdit,
-  onDelete
+  onDelete,
+  canAutoLabel,
+  onAutoLabel
 }: {
   optimisticSample: OptimisticSample
+  labels: ILabel[]
   onLabel: (sampleId: string) => void
   onEdit: (sample: OptimisticSample) => void
   onDelete: (sample: OptimisticSample) => void
+  canAutoLabel: boolean
+  onAutoLabel: (sample: OptimisticSample) => void
 }) => {
   const sample = useSyncExternalStore(
     (c) => optimisticSample.subscribe(() => c()),
@@ -105,6 +153,8 @@ const SampleCard = ({
   const store = useAppStore((s) => s.store)
   const [isLoadingImage, setIsLoadingImage] = useState(true)
   const { showContextMenu } = useContextMenu()
+  const annotations = Object.values(sample.annotations.resolve()).map((a) => a.resolve())
+  const isUnlabeled = annotations.length === 0
   return (
     <Card
       shadow="sm"
@@ -116,6 +166,16 @@ const SampleCard = ({
           title: 'Edit',
           onClick: () => onEdit(optimisticSample)
         },
+        ...(canAutoLabel && isUnlabeled
+          ? [
+              {
+                key: 'auto-label',
+                icon: <MdOutlineSmartToy size={16} />,
+                title: 'Auto-label',
+                onClick: () => onAutoLabel(optimisticSample)
+              }
+            ]
+          : []),
         {
           key: 'delete',
           icon: <MdDeleteOutline size={16} />,
@@ -144,6 +204,8 @@ const SampleCard = ({
             {sample.name}
           </Text>
         </Group>
+
+        <AnnotationLabelCounts annotations={annotations} labels={labels} />
 
         <Flex w={'100%'} justify={'flex-end'} gap={'sm'}>
           <Flex align={'center'} gap={'xs'}>
@@ -208,16 +270,33 @@ export type SamplesPageProps = {
 
 export const SamplesPage = ({ project, task }: SamplesPageProps) => {
   const { items, loading, label, remove, createSamples } = useSamples(project, task)
+  const { items: annotators } = useAnnotators()
   const store = useAppStore((s) => s.store)
   const [search, setSearch] = useState('')
   const [pendingDelete, setPendingDelete] = useState<OptimisticSample | null>(null)
   const [pendingRename, setPendingRename] = useState<OptimisticSample | null>(null)
   const [isImportOpen, setIsImportOpen] = useState(false)
+  // A descriptor, not a frozen sample list - the modal can stay open across multiple runs
+  // (see AnnotatorsModal's "Done" button), so the samples it acts on must be re-derived
+  // from the live `items` on every render rather than snapshotted once at click time, or a
+  // second Run would see samples the first run just labeled as still unlabeled.
+  const [autoLabelSelection, setAutoLabelSelection] = useState<'all' | string | null>(null)
+  const canAutoLabel = annotators.length > 0
+
+  // Don't leave the auto-label modal armed to reopen against a stale target next time
+  // this page becomes visible - Activity preserves this state across a hide/show.
+  useOnRouteLeave(() => setAutoLabelSelection(null))
 
   const filteredItems = useMemo(
     () => items.filter((s) => s.resolve().name.toLowerCase().includes(search.trim().toLowerCase())),
     [items, search]
   )
+
+  const autoLabelTargets = useMemo(() => {
+    if (autoLabelSelection === null) return null
+    if (autoLabelSelection === 'all') return items
+    return items.filter((s) => s.resolve().id === autoLabelSelection)
+  }, [autoLabelSelection, items])
 
   return (
     <>
@@ -258,9 +337,18 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
           await window.system.deleteDirectory(scratchDir).catch(() => {})
         }}
       />
+      {autoLabelTargets !== null && (
+        <AnnotatorsModal
+          opened
+          project={project}
+          tasks={[task]}
+          samples={autoLabelTargets}
+          onClose={() => setAutoLabelSelection(null)}
+        />
+      )}
       <BasicListPage
         top={
-          <TopContainer>
+          <BasicListPageTopBar>
             <Group>
               <Button
                 leftSection={<IoMdArrowBack />}
@@ -274,6 +362,13 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
               <Button leftSection={<FaFileImport />} onClick={() => setIsImportOpen(true)}>
                 Import Samples
               </Button>
+              <Button
+                leftSection={<MdOutlineSmartToy />}
+                variant="outline"
+                onClick={() => setAutoLabelSelection('all')}
+              >
+                Auto-label
+              </Button>
             </Group>
             <Group>
               <TextInput
@@ -283,7 +378,7 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
                 onChange={(e) => setSearch(e.target.value)}
               />
             </Group>
-          </TopContainer>
+          </BasicListPageTopBar>
         }
       >
         <Stack>
@@ -306,9 +401,12 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
             <SampleCard
               key={p.resolve().id}
               optimisticSample={p}
+              labels={project.labels}
               onLabel={label}
               onEdit={setPendingRename}
               onDelete={setPendingDelete}
+              canAutoLabel={canAutoLabel}
+              onAutoLabel={(sample) => setAutoLabelSelection(sample.resolve().id)}
             />
           ))}
         </Stack>

--- a/src/renderer/src/routes/samples/__tests__/SamplesPage.test.tsx
+++ b/src/renderer/src/routes/samples/__tests__/SamplesPage.test.tsx
@@ -1,7 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { act, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
-import { IProject, ISample, ITask, TrainingSplit } from '@shared/types'
+import { AnnotationType, ILabel, IProject, ISample, ITask, TrainingSplit } from '@shared/types'
+import { useAnnotatorRuntime } from '@renderer/hooks/useAnnotatorRuntime'
+
+const { connectToAnnotator, runAnnotatorOnSample, onRouteLeave } = vi.hoisted(() => ({
+  connectToAnnotator: vi.fn(),
+  runAnnotatorOnSample: vi.fn(),
+  onRouteLeave: { current: null as (() => void) | null }
+}))
+
+vi.mock('@renderer/api/ExternalAnnotator', () => ({ connectToAnnotator, runAnnotatorOnSample }))
 
 vi.mock('@renderer/hooks/useAppStore', async () => {
   const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
@@ -14,7 +23,10 @@ vi.mock('@renderer/hooks/useAppStore', async () => {
 
 vi.mock('@renderer/router/appRouter', () => ({
   navigate: vi.fn(),
-  back: vi.fn()
+  back: vi.fn(),
+  useOnRouteLeave: (callback: () => void) => {
+    onRouteLeave.current = callback
+  }
 }))
 
 import { useAppStore } from '@renderer/hooks/useAppStore'
@@ -49,11 +61,22 @@ const samples: ISample[] = [
   }
 ]
 
-const renderSamplesPage = () => renderWithProviders(<SamplesPage project={project} task={task} />)
+const renderSamplesPage = (projectOverride: IProject = project) =>
+  renderWithProviders(<SamplesPage project={projectOverride} task={task} />)
 
 beforeEach(() => {
   vi.mocked(navigate).mockReset()
   vi.mocked(useAppStore.getState().store.getSamplesForTask).mockReset().mockResolvedValue(samples)
+  connectToAnnotator.mockReset().mockResolvedValue([])
+  runAnnotatorOnSample.mockReset()
+  useAnnotatorRuntime.setState({ entries: {} })
+  window.appStore = {
+    getAnnotators: vi.fn().mockResolvedValue([]),
+    createAnnotator: vi.fn(),
+    updateAnnotators: vi.fn().mockResolvedValue([]),
+    deleteAnnotators: vi.fn().mockResolvedValue([])
+  } as unknown as typeof window.appStore
+  onRouteLeave.current = null
 })
 
 describe('SamplesPage', () => {
@@ -62,6 +85,40 @@ describe('SamplesPage', () => {
 
     expect(await screen.findByText('photo-one')).toBeInTheDocument()
     expect(screen.getByText('photo-two')).toBeInTheDocument()
+  })
+
+  it('shows "No annotations yet" on a sample with no annotations', async () => {
+    const labels: ILabel[] = [{ id: 'l1', name: 'Stop Sign', color: '#ff0000' }]
+    renderSamplesPage({ ...project, labels })
+
+    expect(await screen.findByText('photo-one')).toBeInTheDocument()
+    expect(screen.getAllByText('No annotations yet')).toHaveLength(2)
+  })
+
+  it('shows a per-label annotation count badge on a labeled sample', async () => {
+    const labels: ILabel[] = [
+      { id: 'l1', name: 'Stop Sign', color: '#ff0000' },
+      { id: 'l2', name: 'Yield Sign', color: '#00ff00' }
+    ]
+    const labeledSample: ISample = {
+      ...samples[0],
+      annotations: [
+        { id: 'a1', type: AnnotationType.Box, labelId: 'l1', points: [] },
+        { id: 'a2', type: AnnotationType.Box, labelId: 'l1', points: [] },
+        { id: 'a3', type: AnnotationType.Box, labelId: 'l2', points: [] }
+      ]
+    }
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockResolvedValue([
+      labeledSample,
+      samples[1]
+    ])
+
+    renderSamplesPage({ ...project, labels })
+
+    expect(await screen.findByText('Stop Sign: 2')).toBeInTheDocument()
+    expect(screen.getByText('Yield Sign: 1')).toBeInTheDocument()
+    // The other (unlabeled) sample still gets its own empty-state text.
+    expect(screen.getByText('No annotations yet')).toBeInTheDocument()
   })
 
   it('filters samples via the search box', async () => {
@@ -105,6 +162,102 @@ describe('SamplesPage', () => {
       ])
     })
     expect(await screen.findByText('photo-one-renamed')).toBeInTheDocument()
+  })
+
+  it('hides the per-sample Auto-label menu entry when there are no annotators', async () => {
+    renderSamplesPage()
+    await screen.findByText('photo-one')
+
+    fireEvent.contextMenu(screen.getByText('photo-one'))
+    // The top-bar button's own label always renders "Auto-label" - only the per-sample
+    // context-menu entry should be absent here.
+    expect(screen.getAllByText('Auto-label')).toHaveLength(1)
+  })
+
+  it('shows the per-sample Auto-label entry once annotators exist', async () => {
+    vi.mocked(window.appStore.getAnnotators).mockResolvedValue([
+      { id: 'ann1', name: 'My Model', url: 'https://example.com', headers: {} }
+    ])
+    renderSamplesPage()
+    await screen.findByText('photo-one')
+
+    // Open the modal once so the annotators query is known to have resolved (the top-bar
+    // button itself no longer reflects loading state), then close it before checking the
+    // per-sample context menu.
+    fireEvent.click(screen.getByRole('button', { name: 'Auto-label' }))
+    await screen.findByText('My Model')
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    fireEvent.contextMenu(screen.getByText('photo-one'))
+    // More than just the top-bar button's own label - the per-sample menu entry is there too.
+    expect(screen.getAllByText('Auto-label').length).toBeGreaterThan(1)
+  })
+
+  it('opens the merged Auto-label modal from the top bar', async () => {
+    renderSamplesPage()
+    await screen.findByText('photo-one')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auto-label' }))
+
+    expect(await screen.findByRole('dialog', { name: 'Auto-label' })).toBeInTheDocument()
+    expect(screen.getByText('No annotators configured yet.')).toBeInTheDocument()
+  })
+
+  it('does not re-label a sample the modal already auto-labeled once Run is clicked again', async () => {
+    const labeledSampleOne: ISample = {
+      ...samples[0],
+      annotations: [{ id: 'ann1', type: AnnotationType.Box, labelId: 'l1', points: [] }]
+    }
+    vi.mocked(useAppStore.getState().store.getSamplesForTask)
+      .mockResolvedValueOnce(samples)
+      .mockResolvedValue([labeledSampleOne, samples[1]])
+    vi.mocked(window.appStore.getAnnotators).mockResolvedValue([
+      { id: 'ann1', name: 'My Model', url: 'https://example.com', headers: {} }
+    ])
+    runAnnotatorOnSample.mockResolvedValue({
+      annotations: [{ id: 'ann1', type: AnnotationType.Box, labelId: 'l1', points: [] }],
+      skipped: 0
+    })
+
+    renderSamplesPage()
+    await screen.findByText('photo-one')
+
+    fireEvent.contextMenu(screen.getByText('photo-one'))
+    // Scoped to the open context menu - "Auto-label" also matches the top-bar button, and
+    // (depending on portal mount order) isn't reliably the last/first match by index.
+    const menu = screen.getByText('Edit').closest('.mantine-contextmenu')
+    fireEvent.click(within(menu as HTMLElement).getByText('Auto-label'))
+
+    // First run: no mapping known yet, so it shows the (empty, since neither side has
+    // labels) review screen before actually running - wait for that screen to actually
+    // mount before clicking its own Run button, or the second click can land on the
+    // list's (still-pending) Run button instead.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+    await screen.findByRole('button', { name: 'Back' })
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+    await waitFor(() => expect(runAnnotatorOnSample).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Done' }))
+
+    // Run again in the same still-open modal - a mapping is now known so it runs
+    // immediately, and the sample list it sees must be the freshly-refetched one (where
+    // photo-one now has an annotation), not the stale pre-run snapshot.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByText(/1 already labeled/)).toBeInTheDocument())
+    expect(runAnnotatorOnSample).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the auto-label modal when the router reports leaving the page', async () => {
+    renderSamplesPage()
+    await screen.findByText('photo-one')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auto-label' }))
+    expect(await screen.findByRole('dialog', { name: 'Auto-label' })).toBeInTheDocument()
+
+    act(() => onRouteLeave.current?.())
+
+    expect(screen.queryByRole('dialog', { name: 'Auto-label' })).not.toBeInTheDocument()
   })
 
   it('navigates to the labeler when Label is clicked', async () => {

--- a/src/renderer/src/routes/tasks/BatchEditTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/BatchEditTagsModal.tsx
@@ -1,0 +1,102 @@
+import { Button, Chip, Group, Modal, Stack, Text } from '@mantine/core'
+import { useState, type FC } from 'react'
+import { ZIndex } from '@renderer/zIndex'
+import type { IProject, ITag } from '@shared/types'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import { useTags } from '@renderer/hooks/useTags'
+import { TagPicker } from './TagPicker'
+
+export type BatchEditTagsModalProps = {
+  opened: boolean
+  project: IProject
+  taskCount: number
+  /** Tags currently on at least one selected task - the only ones removal makes sense
+   *  for, since there's no single "current" tag list across a batch of possibly
+   *  differently-tagged tasks to diff against (unlike EditTaskTagsModal). */
+  removableTags: ITag[]
+  onCancel: () => void
+  onConfirm: (addedIds: string[], removedIds: string[]) => Promise<unknown>
+}
+
+/** Adds/removes tags across a batch of tasks - "Add" is a creatable combobox (TagPicker,
+ *  same as the single-task modal) and "Remove" is a row of clickable chips (only tags
+ *  already on some selected task, so there's nothing to type there). */
+export const BatchEditTagsModal: FC<BatchEditTagsModalProps> = ({
+  opened,
+  project,
+  taskCount,
+  removableTags,
+  onCancel,
+  onConfirm
+}) => {
+  const { items: allTags, create } = useTags(project)
+  const [addIds, setAddIds] = useState<string[]>([])
+  const [removeIds, setRemoveIds] = useState<Set<string>>(new Set())
+
+  const toggleRemove = (id: string) => {
+    setRemoveIds((current) => {
+      const next = new Set(current)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const save = async () => {
+    await onConfirm(addIds, [...removeIds])
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onCancel}
+      title="Edit Tags"
+      centered
+      zIndex={ZIndex.actionModal}
+    >
+      <Stack gap="lg">
+        <Text size="sm" c="dimmed">
+          Applies to {taskCount} selected task{taskCount === 1 ? '' : 's'}.
+        </Text>
+        <TagPicker
+          label="Add"
+          placeholder="Select or create a tag"
+          allTags={allTags}
+          value={addIds}
+          onChange={setAddIds}
+          onCreate={create}
+        />
+        {removableTags.length > 0 && (
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              Remove
+            </Text>
+            <Group gap="xs">
+              {removableTags.map((tag) => (
+                <Chip
+                  key={tag.id}
+                  checked={removeIds.has(tag.id)}
+                  onChange={() => toggleRemove(tag.id)}
+                  color="red"
+                >
+                  {tag.name}
+                </Chip>
+              ))}
+            </Group>
+          </Stack>
+        )}
+        <Group justify="flex-end">
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <AsyncButton disabled={addIds.length === 0 && removeIds.size === 0} onClick={save}>
+            Save
+          </AsyncButton>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
+++ b/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useState, type FC } from 'react'
+import {
+  Box,
+  Button,
+  Center,
+  Group,
+  Image,
+  Loader,
+  Progress,
+  Select,
+  Stack,
+  Text
+} from '@mantine/core'
+import { IoMdArrowBack } from 'react-icons/io'
+import type { IProject, ITask } from '@shared/types'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { useTasks } from '@renderer/hooks/useTasks'
+import {
+  useCopyAnnotations,
+  type CopyAnnotationsPair,
+  type CopyAnnotationsProgress
+} from '@renderer/hooks/useCopyAnnotations'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
+import type { OptimisticSample } from '@renderer/types'
+import { back } from '@renderer/router/appRouter'
+
+const SKIP_VALUE = '__skip__'
+const THUMBNAIL_SIZE = 96
+
+const summarize = (progress: CopyAnnotationsProgress) => {
+  const copiedInto = progress.completed - progress.failures.length
+  const parts = [`${progress.copied} annotation${progress.copied === 1 ? '' : 's'} copied`]
+  parts.push(`across ${copiedInto} sample${copiedInto === 1 ? '' : 's'}`)
+  if (progress.alreadyLabeled > 0) parts.push(`${progress.alreadyLabeled} already labeled`)
+  if (progress.dimensionMismatch > 0) parts.push(`${progress.dimensionMismatch} size mismatch`)
+  if (progress.duplicateDestination > 0)
+    parts.push(`${progress.duplicateDestination} duplicate mapping(s)`)
+  if (progress.failures.length > 0) parts.push(`${progress.failures.length} failed`)
+  return parts.join(', ')
+}
+
+type SampleMappingRowsProps = {
+  sourceSamples: OptimisticSample[]
+  destinationSamples: OptimisticSample[]
+  mapping: Map<string, string | null>
+  onChange: (sourceSampleId: string, destinationSampleId: string | null) => void
+}
+
+/** Two lines per source sample: its own thumbnail + full name on top, then a Select to
+ *  pick which destination sample it maps to (or Skip) plus a live thumbnail preview of
+ *  whichever destination is currently picked - a closed Select can only show text, and
+ *  visually confirming "this is the same page" is the whole point when the destination
+ *  task's names/text are in a different language. The name gets its own line rather than
+ *  sharing one with the Select (source and destination names here are typically long and
+ *  differ only by a suffix) so it never has to compete with the Select for width and get
+ *  truncated illegibly. Colocated here rather than folded into the shared LabelMapper,
+ *  which 6 importer/exporter callers depend on for a plain text-only "map to a project
+ *  label" row - bolting a thumbnail concept onto it would leak this one caller's needs
+ *  into all of them. */
+const SampleMappingRows: FC<SampleMappingRowsProps> = ({
+  sourceSamples,
+  destinationSamples,
+  mapping,
+  onChange
+}) => {
+  const destinationCounts = new Map<string, number>()
+  for (const destinationId of mapping.values()) {
+    if (destinationId === null) continue
+    destinationCounts.set(destinationId, (destinationCounts.get(destinationId) ?? 0) + 1)
+  }
+  const seenDestinationIds = new Set<string>()
+
+  return (
+    <Stack gap="sm">
+      {sourceSamples.map((sample) => {
+        const source = sample.resolve()
+        const destinationId = mapping.get(source.id) ?? null
+        const destination = destinationSamples.find((d) => d.resolve().id === destinationId)
+        const isDuplicate =
+          destinationId !== null &&
+          (destinationCounts.get(destinationId) ?? 0) > 1 &&
+          seenDestinationIds.has(destinationId)
+        if (destinationId !== null) seenDestinationIds.add(destinationId)
+
+        return (
+          <Stack key={source.id} gap={4}>
+            <Group wrap="nowrap" gap={8}>
+              <Image
+                src={source.imageUri}
+                w={THUMBNAIL_SIZE}
+                h={THUMBNAIL_SIZE}
+                radius="sm"
+                fit="cover"
+              />
+              <Text size="sm" fw={500}>
+                {source.name}
+              </Text>
+            </Group>
+            <Group wrap="nowrap" pl={THUMBNAIL_SIZE + 8}>
+              <Select
+                flex={1}
+                data={[
+                  { value: SKIP_VALUE, label: 'Skip' },
+                  ...destinationSamples.map((d) => ({
+                    value: d.resolve().id,
+                    label: d.resolve().name
+                  }))
+                ]}
+                value={destinationId ?? SKIP_VALUE}
+                onChange={(value) => onChange(source.id, value === SKIP_VALUE ? null : value)}
+                disabled={destinationSamples.length === 0}
+                allowDeselect={false}
+                searchable
+              />
+              {destination ? (
+                <Image
+                  src={destination.resolve().imageUri}
+                  w={THUMBNAIL_SIZE}
+                  h={THUMBNAIL_SIZE}
+                  radius="sm"
+                  fit="cover"
+                />
+              ) : (
+                <Box
+                  w={THUMBNAIL_SIZE}
+                  h={THUMBNAIL_SIZE}
+                  style={{
+                    borderRadius: 'var(--mantine-radius-sm)',
+                    border:
+                      '1px dashed light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-3))',
+                    flexShrink: 0
+                  }}
+                />
+              )}
+            </Group>
+            {isDuplicate && (
+              <Text size="xs" c="red" pl={THUMBNAIL_SIZE + 8}>
+                Also mapped from another sample - only the first copy will run.
+              </Text>
+            )}
+          </Stack>
+        )
+      })}
+    </Stack>
+  )
+}
+
+type CopyAnnotationsRunStepProps = {
+  sourceSamples: OptimisticSample[]
+  destinationTask: ITask
+  destinationSamples: OptimisticSample[]
+  onBack: () => void
+}
+
+const CopyAnnotationsRunStep: FC<CopyAnnotationsRunStepProps> = ({
+  sourceSamples,
+  destinationTask,
+  destinationSamples,
+  onBack
+}) => {
+  const { run, progress, isRunning } = useCopyAnnotations(destinationTask.id)
+  const [hasStarted, setHasStarted] = useState(false)
+  const [mapping, setMapping] = useState<Map<string, string | null>>(
+    () =>
+      new Map(
+        sourceSamples.map((s, i) => [s.resolve().id, destinationSamples[i]?.resolve().id ?? null])
+      )
+  )
+
+  if (destinationSamples.length === 0) {
+    return (
+      <Stack gap="lg">
+        <Text c="dimmed" size="sm">
+          &quot;{destinationTask.name}&quot; has no samples.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="outline" leftSection={<IoMdArrowBack />} onClick={onBack}>
+            Back
+          </Button>
+        </Group>
+      </Stack>
+    )
+  }
+
+  const startRun = async () => {
+    const pairs: CopyAnnotationsPair[] = sourceSamples
+      .map((source) => {
+        const destinationId = mapping.get(source.resolve().id)
+        const destination = destinationSamples.find((d) => d.resolve().id === destinationId)
+        return destination ? { source, destination } : null
+      })
+      .filter((pair): pair is CopyAnnotationsPair => pair !== null)
+
+    setHasStarted(true)
+    await run(pairs)
+  }
+
+  const percent = progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 100
+
+  if (hasStarted) {
+    return (
+      <Stack gap="lg">
+        <Progress value={percent} animated={isRunning} />
+        <Text size="sm" c="dimmed" ta="center">
+          {isRunning ? `Copying… ${progress.completed}/${progress.total}` : summarize(progress)}
+        </Text>
+        {progress.failures.length > 0 && !isRunning && (
+          <Stack gap={4}>
+            {progress.failures.map((failure) => (
+              <Text key={failure.sampleId} size="xs" c="red">
+                {failure.sampleName}: {failure.error}
+              </Text>
+            ))}
+          </Stack>
+        )}
+        <Group justify="flex-end">
+          <Button disabled={isRunning} onClick={onBack}>
+            Done
+          </Button>
+        </Group>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text size="sm" c="dimmed">
+        Into &quot;{destinationTask.name}&quot;, matched by list position - check the thumbnails and
+        adjust any row that&apos;s off. Samples already annotated are skipped.
+      </Text>
+      <SampleMappingRows
+        sourceSamples={sourceSamples}
+        destinationSamples={destinationSamples}
+        mapping={mapping}
+        onChange={(sourceId, destinationId) =>
+          setMapping((current) => new Map(current).set(sourceId, destinationId))
+        }
+      />
+      <Group justify="flex-end">
+        <Button variant="outline" leftSection={<IoMdArrowBack />} onClick={onBack}>
+          Back
+        </Button>
+        <AsyncButton onClick={startRun}>Run</AsyncButton>
+      </Group>
+    </Stack>
+  )
+}
+
+type Step =
+  | { step: 'pick-destination' }
+  | { step: 'run'; destinationTask: ITask; destinationSamples: OptimisticSample[] }
+
+export type CopyAnnotationsPageProps = {
+  project: IProject
+  sourceTask: ITask
+}
+
+export const CopyAnnotationsPage = ({ project, sourceTask }: CopyAnnotationsPageProps) => {
+  const store = useAppStore((s) => s.store)
+  const { items: allTasks } = useTasks(project)
+  const [sourceSamples, setSourceSamples] = useState<OptimisticSample[] | null>(null)
+  const [step, setStep] = useState<Step>({ step: 'pick-destination' })
+  const [destinationTaskId, setDestinationTaskId] = useState<string | null>(null)
+
+  useEffect(() => {
+    store
+      .getSamplesForTask(sourceTask.id)
+      .then((samples) => setSourceSamples(samples.map(toOptimisticSample)))
+  }, [sourceTask.id, store])
+
+  const destinationOptions = allTasks.filter((t) => t.id !== sourceTask.id)
+
+  const continueToMapping = async () => {
+    const destinationTask = destinationOptions.find((t) => t.id === destinationTaskId)
+    if (destinationTask === undefined) return
+    const samples = await store.getSamplesForTask(destinationTask.id)
+    setStep({
+      step: 'run',
+      destinationTask,
+      destinationSamples: samples.map(toOptimisticSample)
+    })
+  }
+
+  return (
+    <BasicListPage
+      wide
+      top={
+        <BasicListPageTopBar>
+          <Group>
+            <Button leftSection={<IoMdArrowBack />} variant="outline" onClick={() => back()}>
+              Back
+            </Button>
+            <Text fw={600} size="lg">
+              Copy Annotations from &quot;{sourceTask.name}&quot;
+            </Text>
+          </Group>
+        </BasicListPageTopBar>
+      }
+    >
+      {sourceSamples === null ? (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      ) : sourceSamples.length === 0 ? (
+        <Text c="dimmed" ta="center" mt="xl">
+          &quot;{sourceTask.name}&quot; has no samples to copy annotations from.
+        </Text>
+      ) : step.step === 'pick-destination' ? (
+        destinationOptions.length === 0 ? (
+          <Text c="dimmed" ta="center" mt="xl">
+            This project has no other tasks yet - create one with the matching pages first.
+          </Text>
+        ) : (
+          <Stack gap="lg" maw={420}>
+            <Text size="sm" c="dimmed">
+              Copy every sample&apos;s annotations into another task in this project.
+            </Text>
+            <Select
+              label="Destination task"
+              placeholder="Select a task"
+              data={destinationOptions.map((t) => ({ value: t.id, label: t.name }))}
+              value={destinationTaskId}
+              onChange={setDestinationTaskId}
+              searchable
+            />
+            <Group justify="flex-end">
+              <AsyncButton disabled={destinationTaskId === null} onClick={continueToMapping}>
+                Continue
+              </AsyncButton>
+            </Group>
+          </Stack>
+        )
+      ) : (
+        <CopyAnnotationsRunStep
+          key={step.destinationTask.id}
+          sourceSamples={sourceSamples}
+          destinationTask={step.destinationTask}
+          destinationSamples={step.destinationSamples}
+          onBack={() => setStep({ step: 'pick-destination' })}
+        />
+      )}
+    </BasicListPage>
+  )
+}

--- a/src/renderer/src/routes/tasks/CreateTaskButton.tsx
+++ b/src/renderer/src/routes/tasks/CreateTaskButton.tsx
@@ -11,7 +11,7 @@ import {
   ScrollArea
 } from '@mantine/core'
 import { styled } from '@linaria/react'
-import { Dropzone, IMAGE_MIME_TYPE, type FileWithPath } from '@mantine/dropzone'
+import { Dropzone, IMAGE_MIME_TYPE, MIME_TYPES, type FileWithPath } from '@mantine/dropzone'
 import { FC, memo, useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { IoMdAdd } from 'react-icons/io'
@@ -19,9 +19,28 @@ import { MdDeleteOutline } from 'react-icons/md'
 import { INewSample, IProject } from '@shared/types'
 import { AsyncButton } from '@renderer/components/AsyncButton'
 import { ImportSamplesModal } from '@renderer/components/sampleIO/ImportSamplesModal'
+import { CvLabelImporterComponent } from '@renderer/components/sampleIO/importers/cvlabel/CvLabelImporterComponent'
 import { filesToSamples } from '@renderer/components/sampleIO/importers/filesToSamples'
 import { folderNameFromDroppedFiles, groupFilesByTopFolder } from '@renderer/utils'
 import { ZIndex } from '@renderer/zIndex'
+
+const CVLABEL_EXTENSION = /\.cvlabel$/i
+
+/** The dropped file's own name, minus the .cvlabel extension - mirrors
+ *  folderNameFromDroppedFiles' role for the image-drop path (both just seed the Create
+ *  Task modal's name field; the user can still rename before creating). */
+const taskNameFromCvLabelFile = (file: FileWithPath) => file.name.replace(CVLABEL_EXTENSION, '')
+
+// Mantine's Dropzone only builds valid file-picker options (and skips a console warning)
+// from the record form of `accept` - a flat array gets turned into one made of the array
+// itself as keys, which breaks for an extension-only entry like .cvlabel that isn't a mime
+// type on its own. Every image mime type maps to no extra extensions (the mime key alone
+// is enough), .cvlabel is keyed under the generic zip mime since it has no real one of its
+// own - same association CvLabelImporterComponent's own Dropzone already uses.
+const DROP_ACCEPT: Record<string, string[]> = {
+  ...Object.fromEntries(IMAGE_MIME_TYPE.map((mimeType) => [mimeType, []])),
+  [MIME_TYPES.zip]: ['.cvlabel']
+}
 
 export type CreateTaskButtonProps = {
   project: IProject
@@ -171,6 +190,13 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
     groups: ImportQueueItem[]
   } | null>(null)
 
+  // A dropped .cvlabel file takes a different path than images: it needs a label-mapping
+  // step (its annotations reference label ids that may not match this project's), so it
+  // opens the same importer wizard used from "Add Samples" instead of going straight into
+  // startQueue. Once mapped, its onComplete lands in the exact same Create Task modal the
+  // image-drop path uses, pre-filled from the file's own name.
+  const [cvLabelDropFile, setCvLabelDropFile] = useState<FileWithPath | null>(null)
+
   // Once a choice is made, importQueue drives the Create Task modal through one item at
   // a time - Skip or Create both advance to the next. The close button means something
   // stronger: abandon the rest of the queue entirely, so it's confirmed separately.
@@ -286,10 +312,16 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
   return (
     <>
       <Dropzone.FullScreen
-        active={!isModalOpen}
+        active={!isModalOpen && cvLabelDropFile === null}
         loading={isDropProcessing}
-        accept={IMAGE_MIME_TYPE}
+        accept={DROP_ACCEPT}
         onDrop={(files) => {
+          const cvLabelFile = files.find((f) => CVLABEL_EXTENSION.test(f.name))
+          if (cvLabelFile) {
+            setCvLabelDropFile(cvLabelFile)
+            return
+          }
+
           const groups = groupFilesByTopFolder(files)
           if (groups.size > 1) {
             setPendingSplit({
@@ -305,6 +337,9 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
           <div>
             <Text size="xl" inline>
               Drop files or folders
+            </Text>
+            <Text size="sm" c="dimmed" inline mt={4} ta="center">
+              or a .cvlabel file
             </Text>
           </div>
         </Group>
@@ -343,6 +378,29 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
             </Button>
           </Group>
         </Stack>
+      </Modal>
+      <Modal
+        opened={cvLabelDropFile !== null}
+        onClose={() => setCvLabelDropFile(null)}
+        title="Import .cvlabel"
+        centered
+        closeOnClickOutside={false}
+        zIndex={ZIndex.actionModal}
+      >
+        {cvLabelDropFile && (
+          <CvLabelImporterComponent
+            project={project}
+            initialFile={cvLabelDropFile}
+            onComplete={(newSamples, scratchDir) => {
+              const name = taskNameFromCvLabelFile(cvLabelDropFile)
+              setCvLabelDropFile(null)
+              setSamples(newSamples)
+              setPendingScratchDirs((dirs) => [...dirs, scratchDir])
+              openModal(name)
+            }}
+            onCancel={() => setCvLabelDropFile(null)}
+          />
+        )}
       </Modal>
       <ImportSamplesModal
         opened={isImportOpen}

--- a/src/renderer/src/routes/tasks/EditTaskTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/EditTaskTagsModal.tsx
@@ -1,0 +1,67 @@
+import { Button, Group, Modal, Stack } from '@mantine/core'
+import { useState, type FC } from 'react'
+import { ZIndex } from '@renderer/zIndex'
+import type { IProject, ITask } from '@shared/types'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import { useTags } from '@renderer/hooks/useTags'
+import { TagPicker } from './TagPicker'
+
+export type EditTaskTagsModalProps = {
+  opened: boolean
+  project: IProject
+  task: ITask | null
+  onCancel: () => void
+  onConfirm: (addedIds: string[], removedIds: string[]) => Promise<unknown>
+}
+
+/** Edits one task's tags via a single creatable combobox (TagPicker), pre-filled with the
+ *  task's current tags as pills - add more by picking (or creating) from the dropdown,
+ *  remove by clicking a pill's own remove button. Diffed against the original set on
+ *  Save. Controlled by mounting with a `key` tied to the task (e.g. `key={task?.id}`),
+ *  same convention as RenameModal, so reopening for a different task doesn't carry over
+ *  the previous selection. */
+export const EditTaskTagsModal: FC<EditTaskTagsModalProps> = ({
+  opened,
+  project,
+  task,
+  onCancel,
+  onConfirm
+}) => {
+  const { items: allTags, create } = useTags(project)
+  const originalIds = new Set((task?.tags ?? []).map((t) => t.id))
+  const [selectedIds, setSelectedIds] = useState<string[]>([...originalIds])
+
+  const save = async () => {
+    const selectedSet = new Set(selectedIds)
+    const added = selectedIds.filter((id) => !originalIds.has(id))
+    const removed = [...originalIds].filter((id) => !selectedSet.has(id))
+    await onConfirm(added, removed)
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onCancel}
+      title="Edit Tags"
+      centered
+      zIndex={ZIndex.actionModal}
+    >
+      <Stack gap="lg">
+        <TagPicker
+          label="Tags"
+          placeholder={allTags.length === 0 ? 'Type to create a tag' : 'Select or create a tag'}
+          allTags={allTags}
+          value={selectedIds}
+          onChange={setSelectedIds}
+          onCreate={create}
+        />
+        <Group justify="flex-end">
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <AsyncButton onClick={save}>Save</AsyncButton>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/renderer/src/routes/tasks/ManageTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/ManageTagsModal.tsx
@@ -1,0 +1,122 @@
+import { useState, type FC } from 'react'
+import { ActionIcon, Button, Group, Modal, Stack, Text, TextInput } from '@mantine/core'
+import { MdAdd, MdDeleteOutline, MdEdit } from 'react-icons/md'
+import type { IProject, ITag } from '@shared/types'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
+import { RenameModal } from '@renderer/components/RenameModal'
+import { useTags } from '@renderer/hooks/useTags'
+import { ZIndex } from '@renderer/zIndex'
+
+export type ManageTagsModalProps = {
+  opened: boolean
+  project: IProject
+  onClose: () => void
+}
+
+/** The one place a project's tag vocabulary is created/renamed/deleted - typing only
+ *  happens here (the "New tag" field); everywhere a tag gets attached to a task, it's
+ *  picked from this list by id (see EditTaskTagsModal, BatchEditTagsModal). */
+export const ManageTagsModal: FC<ManageTagsModalProps> = ({ opened, project, onClose }) => {
+  const { items, isLoading, create, rename, remove } = useTags(project)
+  const [newName, setNewName] = useState('')
+  const [pendingRename, setPendingRename] = useState<ITag | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<ITag | null>(null)
+
+  const addTag = async () => {
+    const name = newName.trim()
+    if (name.length === 0) return
+    await create(name)
+    setNewName('')
+  }
+
+  return (
+    <>
+      <RenameModal
+        key={pendingRename?.id}
+        opened={pendingRename !== null}
+        entityName="tag"
+        initialName={pendingRename?.name ?? ''}
+        onCancel={() => setPendingRename(null)}
+        onConfirm={async (name) => {
+          const result = pendingRename !== null ? rename(pendingRename.id, name) : Promise.resolve()
+          setPendingRename(null)
+          return result
+        }}
+      />
+      <ConfirmDeleteModal
+        opened={pendingDelete !== null}
+        entityName="tag"
+        itemName={pendingDelete?.name}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => (pendingDelete !== null ? remove(pendingDelete.id) : Promise.resolve())}
+      />
+      <Modal
+        opened={opened}
+        onClose={onClose}
+        title="Manage Tags"
+        centered
+        zIndex={ZIndex.actionModal}
+      >
+        <Stack gap="lg">
+          <Stack gap="xs">
+            {!isLoading && items.length === 0 && (
+              <Text c="dimmed" size="sm">
+                No tags yet.
+              </Text>
+            )}
+            {items.map((tag) => (
+              <Group key={tag.id} justify="space-between" wrap="nowrap">
+                <Text truncate>{tag.name}</Text>
+                <Group gap="xs" wrap="nowrap">
+                  <ActionIcon
+                    aria-label={`Rename ${tag.name}`}
+                    variant="subtle"
+                    onClick={() => setPendingRename(tag)}
+                  >
+                    <MdEdit size={16} />
+                  </ActionIcon>
+                  <ActionIcon
+                    aria-label={`Delete ${tag.name}`}
+                    variant="subtle"
+                    color="red"
+                    onClick={() => setPendingDelete(tag)}
+                  >
+                    <MdDeleteOutline size={16} />
+                  </ActionIcon>
+                </Group>
+              </Group>
+            ))}
+          </Stack>
+          <Group wrap="nowrap" align="flex-end">
+            <TextInput
+              label="New tag"
+              placeholder="e.g. Needs Review"
+              flex={1}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && newName.trim().length > 0) {
+                  addTag()
+                }
+              }}
+              data-autofocus
+            />
+            <AsyncButton
+              leftSection={<MdAdd />}
+              disabled={newName.trim().length === 0}
+              onClick={addTag}
+            >
+              Add
+            </AsyncButton>
+          </Group>
+          <Group justify="flex-end">
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  )
+}

--- a/src/renderer/src/routes/tasks/TagPicker.tsx
+++ b/src/renderer/src/routes/tasks/TagPicker.tsx
@@ -1,0 +1,82 @@
+import { MultiSelect } from '@mantine/core'
+import { useState, type FC } from 'react'
+import type { ITag } from '@shared/types'
+import { ZIndex } from '@renderer/zIndex'
+
+const CREATE_PREFIX = '__create-tag__:'
+
+export type TagPickerProps = {
+  label?: string
+  placeholder?: string
+  allTags: ITag[]
+  /** Selected tag ids. */
+  value: string[]
+  onChange: (ids: string[]) => void
+  onCreate: (name: string) => Promise<ITag>
+}
+
+/** A single combobox that's both "pick an existing tag" (click, no typing needed) and
+ *  "create a new one" (typing only reveals a "+ Create …" option when nothing matches -
+ *  clicking that is what actually creates it, never automatic on Enter). Selected tags
+ *  render as removable pills in the input itself, standard MultiSelect behavior. */
+export const TagPicker: FC<TagPickerProps> = ({
+  label,
+  placeholder,
+  allTags,
+  value,
+  onChange,
+  onCreate
+}) => {
+  const [search, setSearch] = useState('')
+  // Bridges the gap between a tag being created and useTags' invalidate-triggered
+  // refetch landing - without this, the just-created pill would briefly show no label
+  // (allTags won't contain it yet).
+  const [pendingNewTags, setPendingNewTags] = useState<ITag[]>([])
+
+  const knownTags = [
+    ...allTags,
+    ...pendingNewTags.filter((tag) => !allTags.some((t) => t.id === tag.id))
+  ]
+
+  const trimmedSearch = search.trim()
+  const hasExactMatch = knownTags.some(
+    (tag) => tag.name.toLowerCase() === trimmedSearch.toLowerCase()
+  )
+
+  const data = [
+    ...knownTags.map((tag) => ({ value: tag.id, label: tag.name })),
+    ...(trimmedSearch.length > 0 && !hasExactMatch
+      ? [{ value: `${CREATE_PREFIX}${trimmedSearch}`, label: `+ Create "${trimmedSearch}"` }]
+      : [])
+  ]
+
+  const handleChange = (nextValues: string[]) => {
+    const createValue = nextValues.find((v) => v.startsWith(CREATE_PREFIX))
+    if (createValue === undefined) {
+      onChange(nextValues)
+      return
+    }
+
+    const name = createValue.slice(CREATE_PREFIX.length)
+    void onCreate(name).then((tag) => {
+      setPendingNewTags((current) => [...current, tag])
+      setSearch('')
+      onChange([...nextValues.filter((v) => v !== createValue), tag.id])
+    })
+  }
+
+  return (
+    <MultiSelect
+      label={label}
+      placeholder={placeholder}
+      data={data}
+      value={value}
+      onChange={handleChange}
+      searchable
+      searchValue={search}
+      onSearchChange={setSearch}
+      hidePickedOptions
+      comboboxProps={{ zIndex: ZIndex.actionModalContent }}
+    />
+  )
+}

--- a/src/renderer/src/routes/tasks/TasksPage.tsx
+++ b/src/renderer/src/routes/tasks/TasksPage.tsx
@@ -1,61 +1,156 @@
-import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
 import {
   BasicListPageItem,
   BasicListPageItemSkeleton
 } from '@renderer/components/BasicListPageItem'
+import { VirtualizedItemList } from '@renderer/components/VirtualizedItemList'
 import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
 import { RenameModal } from '@renderer/components/RenameModal'
-import { styled } from '@linaria/react'
-import { Button, Divider, Group, Stack, Text, TextInput } from '@mantine/core'
+import { AsyncButton } from '@renderer/components/AsyncButton'
+import {
+  Badge,
+  Button,
+  Divider,
+  Group,
+  MultiSelect,
+  Progress,
+  Stack,
+  Text,
+  TextInput
+} from '@mantine/core'
 import { IoMdArrowBack } from 'react-icons/io'
 import { CiSearch } from 'react-icons/ci'
-import { MdDeleteOutline, MdOutlineAssignment } from 'react-icons/md'
+import { MdDeleteOutline, MdLabel, MdOutlineAssignment, MdOutlineSmartToy } from 'react-icons/md'
 import { FaFileExport } from 'react-icons/fa'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { CreateTaskButton } from './CreateTaskButton'
+import { EditTaskTagsModal } from './EditTaskTagsModal'
+import { BatchEditTagsModal } from './BatchEditTagsModal'
+import { ManageTagsModal } from './ManageTagsModal'
 import { useTasks } from '@renderer/hooks/useTasks'
-import { IProject, ITask } from '@shared/types'
+import { useTags } from '@renderer/hooks/useTags'
+import { useAnnotators } from '@renderer/hooks/useAnnotators'
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { IProject, ITag, ITask } from '@shared/types'
+import { OptimisticSample } from '@renderer/types'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
 import { ExportSamplesModal } from '@renderer/components/sampleIO/ExportSamplesModal'
-import { back } from '@renderer/router/appRouter'
+import { AnnotatorsModal } from '@renderer/components/annotators/AnnotatorsModal'
+import { back, navigate, useOnRouteLeave } from '@renderer/router/appRouter'
 
-const TopContainer = styled.div`
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  justify-content: space-between;
-`
+const TaskProgress = ({
+  sampleCount = 0,
+  completedSampleCount = 0
+}: {
+  sampleCount?: number
+  completedSampleCount?: number
+}) => {
+  if (sampleCount === 0) {
+    return (
+      <Text size="xs" c="dimmed" mt={4}>
+        No samples yet
+      </Text>
+    )
+  }
+
+  const percent = Math.round((completedSampleCount / sampleCount) * 100)
+
+  return (
+    <Group gap="xs" wrap="nowrap" mt={4}>
+      <Progress value={percent} size="sm" style={{ flex: 1, maxWidth: 160 }} />
+      <Text size="xs" c="dimmed">
+        {completedSampleCount}/{sampleCount} labeled
+      </Text>
+    </Group>
+  )
+}
+
+const TagBadges = ({ tags }: { tags: ITask['tags'] }) => {
+  if (tags === undefined || tags.length === 0) return null
+
+  return (
+    <Group gap={4} mt={4}>
+      {tags.map((tag) => (
+        <Badge key={tag.id} size="sm" variant="light" radius="sm">
+          {tag.name}
+        </Badge>
+      ))}
+    </Group>
+  )
+}
 
 export type TasksPageProps = {
   project: IProject
 }
 
 export const TasksPage = ({ project }: TasksPageProps) => {
-  const { items, create, open, update, remove, removeMany, isLoading } = useTasks(project)
+  const { items, create, open, update, remove, removeMany, addTags, removeTags, isLoading } =
+    useTasks(project)
+  const { items: allTags } = useTags(project)
+  const { items: annotators } = useAnnotators()
+  const store = useAppStore((s) => s.store)
+  const canAutoLabel = annotators.length > 0
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [search, setSearch] = useState('')
+  const [tagFilter, setTagFilter] = useState<string[]>([])
   const [pendingDelete, setPendingDelete] = useState<ITask | null>(null)
   const [pendingRename, setPendingRename] = useState<ITask | null>(null)
+  const [pendingEditTags, setPendingEditTags] = useState<ITask | null>(null)
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set())
-  const [isBatchExportOpen, setIsBatchExportOpen] = useState(false)
+  // Covers both batch export (the toolbar button, acting on the current selection) and
+  // per-task export (the context menu's single-item entry, offered outside select mode) -
+  // one modal, whichever list of tasks last triggered it.
+  const [exportTarget, setExportTarget] = useState<ITask[] | null>(null)
   const [isBatchDeletePending, setIsBatchDeletePending] = useState(false)
+  const [isBatchTagsOpen, setIsBatchTagsOpen] = useState(false)
+  const [isManageTagsOpen, setIsManageTagsOpen] = useState(false)
+  const [autoLabelTarget, setAutoLabelTarget] = useState<{
+    tasks: ITask[]
+    samples: OptimisticSample[]
+  } | null>(null)
 
-  // Selected tasks stay visible even if a search narrows the list below them, so batch
-  // actions never silently lose track of a selection the user can no longer see.
+  const tagFilterData = useMemo(
+    () => allTags.map((tag) => ({ value: tag.id, label: tag.name })),
+    [allTags]
+  )
+
+  // Selected tasks stay visible even if a search or tag filter narrows the list below
+  // them, so batch actions never silently lose track of a selection the user can no
+  // longer see.
   const filteredItems = useMemo(
     () =>
-      items.filter(
-        (t) =>
-          selectedTaskIds.has(t.id) || t.name.toLowerCase().includes(search.trim().toLowerCase())
-      ),
-    [items, search, selectedTaskIds]
+      items.filter((t) => {
+        if (selectedTaskIds.has(t.id)) return true
+        if (!t.name.toLowerCase().includes(search.trim().toLowerCase())) return false
+        if (tagFilter.length === 0) return true
+        const taskTagIds = new Set((t.tags ?? []).map((tag) => tag.id))
+        return tagFilter.some((id) => taskTagIds.has(id))
+      }),
+    [items, search, tagFilter, selectedTaskIds]
   )
 
   const selectedTasks = items.filter((t) => selectedTaskIds.has(t.id))
+
+  // Tags currently on at least one selected task - the "Remove" side of the batch modal.
+  const removableTags = useMemo(() => {
+    const byId = new Map<string, ITag>()
+    for (const task of selectedTasks) {
+      for (const tag of task.tags ?? []) {
+        byId.set(tag.id, tag)
+      }
+    }
+    return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }, [selectedTasks])
 
   const exitSelectMode = () => {
     setIsSelectMode(false)
     setSelectedTaskIds(new Set())
   }
+
+  // Multiselect shouldn't still be armed when the user comes back to this page later -
+  // Activity preserves this state across a hide/show, so it has to be cleared explicitly.
+  useOnRouteLeave(exitSelectMode)
 
   const toggleSelected = (taskId: string, selected: boolean) => {
     setSelectedTaskIds((current) => {
@@ -67,6 +162,14 @@ export const TasksPage = ({ project }: TasksPageProps) => {
       }
       return next
     })
+  }
+
+  // Enters select mode with just this one task selected - the context menu's "Select"
+  // entry point outside select mode (see selectAll/selectAbove/selectBelow below for the
+  // batch variants offered once already in select mode).
+  const selectOnly = (taskId: string) => {
+    setIsSelectMode(true)
+    setSelectedTaskIds(new Set([taskId]))
   }
 
   // Selection helpers operate on filteredItems (the currently visible/filtered list),
@@ -84,6 +187,17 @@ export const TasksPage = ({ project }: TasksPageProps) => {
   const selectBelow = (index: number) => {
     setIsSelectMode(true)
     setSelectedTaskIds(new Set(filteredItems.slice(index).map((t) => t.id)))
+  }
+
+  // Fetches each task's samples fresh (this page never loads sample data otherwise) and
+  // opens the AnnotatorsModal run flow against all of them at once - lets a batch of tasks
+  // get auto-labeled without opening each one's Samples page individually.
+  const runAutoLabelOn = async (tasksToRun: ITask[]) => {
+    const samplesByTask = await Promise.all(tasksToRun.map((t) => store.getSamplesForTask(t.id)))
+    setAutoLabelTarget({
+      tasks: tasksToRun,
+      samples: samplesByTask.flat().map(toOptimisticSample)
+    })
   }
 
   return (
@@ -121,14 +235,56 @@ export const TasksPage = ({ project }: TasksPageProps) => {
         }}
       />
       <ExportSamplesModal
-        opened={isBatchExportOpen}
+        opened={exportTarget !== null}
         project={project}
-        tasks={selectedTasks}
-        onClose={() => setIsBatchExportOpen(false)}
+        tasks={exportTarget ?? []}
+        onClose={() => setExportTarget(null)}
       />
+      <ManageTagsModal
+        opened={isManageTagsOpen}
+        project={project}
+        onClose={() => setIsManageTagsOpen(false)}
+      />
+      <EditTaskTagsModal
+        key={pendingEditTags?.id}
+        opened={pendingEditTags !== null}
+        project={project}
+        task={pendingEditTags}
+        onCancel={() => setPendingEditTags(null)}
+        onConfirm={async (added, removed) => {
+          if (pendingEditTags === null) return
+          await Promise.all([
+            addTags([pendingEditTags.id], added),
+            removeTags([pendingEditTags.id], removed)
+          ])
+          setPendingEditTags(null)
+        }}
+      />
+      <BatchEditTagsModal
+        opened={isBatchTagsOpen}
+        project={project}
+        taskCount={selectedTasks.length}
+        removableTags={removableTags}
+        onCancel={() => setIsBatchTagsOpen(false)}
+        onConfirm={async (added, removed) => {
+          const taskIds = selectedTasks.map((t) => t.id)
+          await Promise.all([addTags(taskIds, added), removeTags(taskIds, removed)])
+          setIsBatchTagsOpen(false)
+        }}
+      />
+      {autoLabelTarget !== null && (
+        <AnnotatorsModal
+          opened
+          project={project}
+          tasks={autoLabelTarget.tasks}
+          samples={autoLabelTarget.samples}
+          onClose={() => setAutoLabelTarget(null)}
+        />
+      )}
       <BasicListPage
+        scrollContainerRef={scrollContainerRef}
         top={
-          <TopContainer>
+          <BasicListPageTopBar>
             <Group>
               <Button
                 leftSection={<IoMdArrowBack />}
@@ -140,6 +296,14 @@ export const TasksPage = ({ project }: TasksPageProps) => {
                 Back
               </Button>
               <CreateTaskButton project={project} create={create} />
+              <Button
+                size="xs"
+                variant="outline"
+                leftSection={<MdLabel size={14} />}
+                onClick={() => setIsManageTagsOpen(true)}
+              >
+                Manage Tags
+              </Button>
               {!isSelectMode && (
                 <Button size="xs" variant="outline" onClick={() => setIsSelectMode(true)}>
                   Select
@@ -156,9 +320,29 @@ export const TasksPage = ({ project }: TasksPageProps) => {
                     variant="outline"
                     leftSection={<FaFileExport size={14} />}
                     disabled={selectedTaskIds.size === 0}
-                    onClick={() => setIsBatchExportOpen(true)}
+                    onClick={() => setExportTarget(selectedTasks)}
                   >
                     Export
+                  </Button>
+                  {canAutoLabel && (
+                    <AsyncButton
+                      size="xs"
+                      variant="outline"
+                      leftSection={<MdOutlineSmartToy size={14} />}
+                      disabled={selectedTaskIds.size === 0}
+                      onClick={() => runAutoLabelOn(selectedTasks)}
+                    >
+                      Auto-label
+                    </AsyncButton>
+                  )}
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    leftSection={<MdLabel size={14} />}
+                    disabled={selectedTaskIds.size === 0}
+                    onClick={() => setIsBatchTagsOpen(true)}
+                  >
+                    Tags
                   </Button>
                   <Button
                     size="xs"
@@ -177,6 +361,16 @@ export const TasksPage = ({ project }: TasksPageProps) => {
               )}
             </Group>
             <Group>
+              {allTags.length > 0 && (
+                <MultiSelect
+                  placeholder="Filter by tag"
+                  data={tagFilterData}
+                  value={tagFilter}
+                  onChange={setTagFilter}
+                  clearable
+                  w={220}
+                />
+              )}
               <TextInput
                 placeholder="Search"
                 rightSection={<CiSearch />}
@@ -184,7 +378,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
                 onChange={(e) => setSearch(e.target.value)}
               />
             </Group>
-          </TopContainer>
+          </BasicListPageTopBar>
         }
       >
         <Stack>
@@ -204,24 +398,47 @@ export const TasksPage = ({ project }: TasksPageProps) => {
                 : 'No tasks match your search.'}
             </Text>
           )}
-          {!isLoading &&
-            filteredItems.map((t, index) => (
+        </Stack>
+        {!isLoading && filteredItems.length > 0 && (
+          <VirtualizedItemList
+            items={filteredItems}
+            getKey={(t) => t.id}
+            scrollContainerRef={scrollContainerRef}
+            // Closer to a row with both a tag line and the progress line than the
+            // component's generic default (90) - every task row shows progress, and
+            // most show tags too.
+            estimateSize={104}
+            renderItem={(t, index) => (
               <BasicListPageItem
-                key={t.id}
                 icon={<MdOutlineAssignment size={18} />}
                 title={t.name}
+                tags={
+                  <>
+                    <TagBadges tags={t.tags} />
+                    <TaskProgress
+                      sampleCount={t.sampleCount}
+                      completedSampleCount={t.completedSampleCount}
+                    />
+                  </>
+                }
                 onClick={() => open(t)}
                 onEdit={() => setPendingRename(t)}
+                onAutoLabel={canAutoLabel ? () => runAutoLabelOn([t]) : undefined}
+                onEditTags={() => setPendingEditTags(t)}
+                onExport={() => setExportTarget([t])}
+                onCopyAnnotations={() => navigate('copy-annotations', { project, sourceTask: t })}
                 onDelete={() => setPendingDelete(t)}
                 selectMode={isSelectMode}
                 selected={selectedTaskIds.has(t.id)}
                 onSelectedChange={(selected) => toggleSelected(t.id, selected)}
+                onSelect={() => selectOnly(t.id)}
                 onSelectAll={selectAll}
                 onSelectAbove={() => selectAbove(index)}
                 onSelectBelow={() => selectBelow(index)}
               />
-            ))}
-        </Stack>
+            )}
+          />
+        )}
       </BasicListPage>
     </>
   )

--- a/src/renderer/src/routes/tasks/__tests__/CopyAnnotationsPage.test.tsx
+++ b/src/renderer/src/routes/tasks/__tests__/CopyAnnotationsPage.test.tsx
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { AnnotationType, IProject, ISample, ITask, TrainingSplit } from '@shared/types'
+
+vi.mock('@renderer/hooks/useAppStore', async () => {
+  const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
+  const state = { store: createMockDataStore() }
+  const useAppStore = Object.assign((selector: (s: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+  return { useAppStore }
+})
+
+const { back } = vi.hoisted(() => ({ back: vi.fn() }))
+
+vi.mock('@renderer/router/appRouter', () => ({
+  navigate: vi.fn(),
+  back
+}))
+
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { CopyAnnotationsPage } from '../CopyAnnotationsPage'
+
+const project: IProject = {
+  id: 'p1',
+  name: 'Docs',
+  labels: [{ id: 'l1', name: 'Text', color: '#fff' }]
+}
+const sourceTask: ITask = { id: 'src', name: 'English' }
+const destinationTask: ITask = { id: 'dst', name: 'French' }
+const otherDestinationTask: ITask = { id: 'dst2', name: 'German' }
+
+const makeSample = (overrides: Partial<ISample> & Pick<ISample, 'id' | 'name'>): ISample => ({
+  imageUri: `cv-label-image://${overrides.id}`,
+  split: TrainingSplit.Train,
+  width: 100,
+  height: 100,
+  annotations: [],
+  completedAt: null,
+  createdAt: new Date().toISOString(),
+  ...overrides
+})
+
+const annotated = (id: string) => [
+  {
+    id: `a-${id}`,
+    type: AnnotationType.Box,
+    labelId: 'l1',
+    points: [{ id: `p-${id}`, x: 1, y: 1 }]
+  }
+]
+
+const renderPage = () =>
+  renderWithProviders(<CopyAnnotationsPage project={project} sourceTask={sourceTask} />)
+
+const pickDestinationAndContinue = async (name: string) => {
+  fireEvent.click(await screen.findByPlaceholderText('Select a task'))
+  fireEvent.click(await screen.findByText(name))
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+  await screen.findByRole('button', { name: 'Run' })
+}
+
+beforeEach(() => {
+  back.mockReset()
+  vi.mocked(useAppStore.getState().store.getTasksForProject)
+    .mockReset()
+    .mockResolvedValue([sourceTask, destinationTask, otherDestinationTask])
+  vi.mocked(useAppStore.getState().store.getSamplesForTask)
+    .mockReset()
+    .mockImplementation((taskId) => {
+      if (taskId === sourceTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 's1', name: 'sample-1', annotations: annotated('s1') }),
+          makeSample({ id: 's2', name: 'sample-2', annotations: annotated('s2') })
+        ])
+      }
+      if (taskId === destinationTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 'd1', name: 'dest-1' }),
+          makeSample({ id: 'd2', name: 'dest-2' })
+        ])
+      }
+      return Promise.resolve([])
+    })
+  vi.mocked(useAppStore.getState().store.createAnnotations).mockReset().mockResolvedValue([])
+})
+
+describe('CopyAnnotationsPage', () => {
+  it('shows the destination picker once source samples load', async () => {
+    renderPage()
+
+    expect(await screen.findByPlaceholderText('Select a task')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the source task has no samples', async () => {
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockImplementation((taskId) =>
+      Promise.resolve(taskId === sourceTask.id ? [] : [])
+    )
+    renderPage()
+
+    expect(
+      await screen.findByText('"English" has no samples to copy annotations from.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the project has no other tasks', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([sourceTask])
+    renderPage()
+
+    expect(
+      await screen.findByText(
+        'This project has no other tasks yet - create one with the matching pages first.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('copies annotations by default position mapping and reports a summary', async () => {
+    renderPage()
+    await pickDestinationAndContinue('French')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+    expect(useAppStore.getState().store.createAnnotations).toHaveBeenCalledTimes(2)
+    expect(useAppStore.getState().store.createAnnotations).toHaveBeenCalledWith(
+      'd1',
+      expect.arrayContaining([expect.objectContaining({ labelId: 'l1' })])
+    )
+    expect(useAppStore.getState().store.createAnnotations).toHaveBeenCalledWith(
+      'd2',
+      expect.arrayContaining([expect.objectContaining({ labelId: 'l1' })])
+    )
+    expect(screen.getByText(/2 annotations copied, across 2 samples/)).toBeInTheDocument()
+  })
+
+  it('skips a destination sample that already has an annotation', async () => {
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockImplementation((taskId) => {
+      if (taskId === sourceTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 's1', name: 'sample-1', annotations: annotated('s1') })
+        ])
+      }
+      if (taskId === destinationTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 'd1', name: 'dest-1', annotations: annotated('d1') })
+        ])
+      }
+      return Promise.resolve([])
+    })
+    renderPage()
+    await pickDestinationAndContinue('French')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+    expect(useAppStore.getState().store.createAnnotations).not.toHaveBeenCalled()
+    expect(screen.getByText(/1 already labeled/)).toBeInTheDocument()
+  })
+
+  it('skips a pair whose source and destination dimensions differ', async () => {
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockImplementation((taskId) => {
+      if (taskId === sourceTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 's1', name: 'sample-1', annotations: annotated('s1') })
+        ])
+      }
+      if (taskId === destinationTask.id) {
+        return Promise.resolve([makeSample({ id: 'd1', name: 'dest-1', width: 200, height: 200 })])
+      }
+      return Promise.resolve([])
+    })
+    renderPage()
+    await pickDestinationAndContinue('French')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+    expect(useAppStore.getState().store.createAnnotations).not.toHaveBeenCalled()
+    expect(screen.getByText(/1 size mismatch/)).toBeInTheDocument()
+  })
+
+  it('warns and only copies once when two rows are mapped to the same destination', async () => {
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockImplementation((taskId) => {
+      if (taskId === sourceTask.id) {
+        return Promise.resolve([
+          makeSample({ id: 's1', name: 'sample-1', annotations: annotated('s1') }),
+          makeSample({ id: 's2', name: 'sample-2', annotations: annotated('s2') })
+        ])
+      }
+      if (taskId === destinationTask.id) {
+        return Promise.resolve([makeSample({ id: 'd1', name: 'dest-1' })])
+      }
+      return Promise.resolve([])
+    })
+    renderPage()
+    await pickDestinationAndContinue('French')
+
+    // sample-2's row defaults to Skip (only one destination sample exists) - remap it onto
+    // the same destination sample-1 already uses.
+    fireEvent.click(screen.getByDisplayValue('Skip'))
+    fireEvent.click(await screen.findByRole('option', { name: 'dest-1' }))
+
+    expect(
+      screen.getByText('Also mapped from another sample - only the first copy will run.')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+    expect(useAppStore.getState().store.createAnnotations).toHaveBeenCalledTimes(1)
+    expect(screen.getByText(/1 duplicate mapping/)).toBeInTheDocument()
+  })
+
+  it('isolates a per-pair failure without stopping the rest of the run', async () => {
+    vi.mocked(useAppStore.getState().store.createAnnotations).mockImplementation((sampleId) =>
+      sampleId === 'd1' ? Promise.reject(new Error('boom')) : Promise.resolve([])
+    )
+    renderPage()
+    await pickDestinationAndContinue('French')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+    expect(screen.getByText(/1 failed/)).toBeInTheDocument()
+    expect(screen.getByText(/dest-1: boom/)).toBeInTheDocument()
+  })
+
+  it('returns to the destination picker after Done, for a repeat run', async () => {
+    renderPage()
+    await pickDestinationAndContinue('French')
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Done' })).toBeEnabled())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(await screen.findByPlaceholderText('Select a task')).toBeInTheDocument()
+  })
+
+  it('calls the router back() from the top-bar Back button', async () => {
+    renderPage()
+    await screen.findByPlaceholderText('Select a task')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(back).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/routes/tasks/__tests__/CreateTaskButton.test.tsx
+++ b/src/renderer/src/routes/tasks/__tests__/CreateTaskButton.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent, within, waitFor } from '@testing-library/react'
+import JSZip from 'jszip'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
+import { installFakeFileSystem } from '@renderer/components/sampleIO/importers/__tests__/fakeFileSystem'
 import { CreateTaskButton } from '../CreateTaskButton'
 import { IProject } from '@shared/types'
 
@@ -64,6 +66,31 @@ const dropFiles = (files: File[]) => {
   const input = document.querySelector('input[type=file]') as HTMLInputElement
   fireEvent.change(input, { target: { files } })
 }
+
+const projectWithLabel: IProject = {
+  id: 'project-1',
+  name: 'Test Project',
+  labels: [{ id: 'l1', name: 'Text', color: '#fff' }]
+}
+
+const makeCvLabelFile = async (name: string, labels: unknown[], samples: unknown[]) => {
+  const zip = new JSZip()
+  zip.file('manifest.json', JSON.stringify({ labels, samples }))
+  zip.file('images/s1.jpg', 'fake-image-bytes')
+  const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+  return new File([buffer], name)
+}
+
+const oneCvLabelSample = [
+  {
+    id: 's1',
+    name: 'photo-one',
+    split: 'train',
+    annotations: [{ id: 'a1', type: 'box', labelId: 'l1', points: [] }],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    imageFile: 'images/s1.jpg'
+  }
+]
 
 describe('CreateTaskButton', () => {
   it('opens the modal showing an empty file list', async () => {
@@ -336,5 +363,82 @@ describe('CreateTaskButton', () => {
     expect(create).toHaveBeenCalledTimes(1)
     expect(create.mock.calls[0][0]).toBe('Combined Batch')
     expect(create.mock.calls[0][1]).toHaveLength(2)
+  })
+
+  describe('dropping a .cvlabel file', () => {
+    beforeEach(() => {
+      // .cvlabel parsing goes through virtualFilesFromExtractedZip (window.zip/fileUtils),
+      // a different pipeline than the plain-image drop path's filesToSamples - this
+      // installs the fuller fake filesystem those need, layered on top of the getFileSize/
+      // getScratchPreviewUri/deleteDirectory stubs the outer beforeEach already set up for
+      // the Create Task modal's own sample list and cleanup.
+      installFakeFileSystem()
+      window.system = {
+        ...window.system,
+        getScratchPreviewUri,
+        deleteDirectory
+      } as unknown as typeof window.system
+    })
+
+    it('drops straight into the label-mapping step, skipping the picker', async () => {
+      const file = await makeCvLabelFile(
+        'French Batch.cvlabel',
+        [{ id: 'l1', name: 'Texte' }],
+        oneCvLabelSample
+      )
+      renderWithProviders(<CreateTaskButton project={projectWithLabel} create={vi.fn()} />)
+
+      dropFiles([file])
+
+      expect(await screen.findByRole('dialog', { name: 'Import .cvlabel' })).toBeInTheDocument()
+      expect(await screen.findByText('Texte')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Text')).toBeInTheDocument()
+    })
+
+    it('prefills the Create Task modal from the file name and mapped samples', async () => {
+      const file = await makeCvLabelFile(
+        'French Batch.cvlabel',
+        [{ id: 'l1', name: 'Texte' }],
+        oneCvLabelSample
+      )
+      const create = vi.fn().mockResolvedValue(undefined)
+      renderWithProviders(<CreateTaskButton project={projectWithLabel} create={create} />)
+
+      dropFiles([file])
+      await screen.findByRole('dialog', { name: 'Import .cvlabel' })
+      fireEvent.click(await screen.findByRole('button', { name: 'Import' }))
+
+      expect(await screen.findByRole('dialog', { name: 'Create Task' })).toBeInTheDocument()
+      expect(screen.getByLabelText('Name')).toHaveValue('French Batch')
+      expect(await screen.findByText('photo-one')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+      expect(create).toHaveBeenCalledTimes(1)
+      expect(create.mock.calls[0][0]).toBe('French Batch')
+      expect(create.mock.calls[0][1]).toHaveLength(1)
+      expect(create.mock.calls[0][1][0].annotations[0].labelId).toBe('l1')
+    })
+
+    it('closes without opening Create Task when the cv-label wizard is dismissed', async () => {
+      const file = await makeCvLabelFile(
+        'French Batch.cvlabel',
+        [{ id: 'l1', name: 'Texte' }],
+        oneCvLabelSample
+      )
+      renderWithProviders(<CreateTaskButton project={projectWithLabel} create={vi.fn()} />)
+
+      dropFiles([file])
+      await screen.findByRole('dialog', { name: 'Import .cvlabel' })
+      // The drop lands straight on the mapping step (no Cancel button there, only on the
+      // picker step it skips) - dismissing via Escape exercises the modal's own onClose,
+      // same as a user closing it any other way once past that first step.
+      fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' })
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: 'Import .cvlabel' })).not.toBeInTheDocument()
+      })
+      expect(screen.queryByRole('dialog', { name: 'Create Task' })).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/renderer/src/routes/tasks/__tests__/TasksPage.test.tsx
+++ b/src/renderer/src/routes/tasks/__tests__/TasksPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { act, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
-import { IProject, ITask } from '@shared/types'
+import { IProject, ITask, TrainingSplit } from '@shared/types'
 
 vi.mock('@renderer/hooks/useAppStore', async () => {
   const { createMockDataStore } = await import('@renderer/__tests__/mockDataStore')
@@ -12,9 +12,16 @@ vi.mock('@renderer/hooks/useAppStore', async () => {
   return { useAppStore }
 })
 
+const { onRouteLeave } = vi.hoisted(() => ({
+  onRouteLeave: { current: null as (() => void) | null }
+}))
+
 vi.mock('@renderer/router/appRouter', () => ({
   navigate: vi.fn(),
-  back: vi.fn()
+  back: vi.fn(),
+  useOnRouteLeave: (callback: () => void) => {
+    onRouteLeave.current = callback
+  }
 }))
 
 import { useAppStore } from '@renderer/hooks/useAppStore'
@@ -32,6 +39,22 @@ const renderTasksPage = () => renderWithProviders(<TasksPage project={project} /
 beforeEach(() => {
   vi.mocked(navigate).mockReset()
   vi.mocked(useAppStore.getState().store.getTasksForProject).mockReset().mockResolvedValue(tasks)
+  vi.mocked(useAppStore.getState().store.getTagsForProject).mockReset().mockResolvedValue([])
+  vi.mocked(useAppStore.getState().store.createTag).mockReset()
+  vi.mocked(useAppStore.getState().store.updateTags).mockReset().mockResolvedValue([])
+  vi.mocked(useAppStore.getState().store.deleteTags).mockReset().mockResolvedValue([true])
+  vi.mocked(useAppStore.getState().store.addTagsToTasks).mockReset().mockResolvedValue(undefined)
+  vi.mocked(useAppStore.getState().store.removeTagsFromTasks)
+    .mockReset()
+    .mockResolvedValue(undefined)
+  vi.mocked(useAppStore.getState().store.getSamplesForTask).mockReset().mockResolvedValue([])
+  window.appStore = {
+    getAnnotators: vi.fn().mockResolvedValue([]),
+    createAnnotator: vi.fn(),
+    updateAnnotators: vi.fn().mockResolvedValue([]),
+    deleteAnnotators: vi.fn().mockResolvedValue([])
+  } as unknown as typeof window.appStore
+  onRouteLeave.current = null
 })
 
 describe('TasksPage', () => {
@@ -47,6 +70,24 @@ describe('TasksPage', () => {
 
     expect(await screen.findByText('Batch 1')).toBeInTheDocument()
     expect(screen.getByText('Batch 2')).toBeInTheDocument()
+  })
+
+  it('shows "No samples yet" for a task with no samples', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', sampleCount: 0, completedSampleCount: 0 }
+    ])
+    renderTasksPage()
+
+    expect(await screen.findByText('No samples yet')).toBeInTheDocument()
+  })
+
+  it('shows a labeled-progress fraction for a task with samples', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', sampleCount: 10, completedSampleCount: 3 }
+    ])
+    renderTasksPage()
+
+    expect(await screen.findByText('3/10 labeled')).toBeInTheDocument()
   })
 
   it('filters the list via the search box', async () => {
@@ -140,6 +181,40 @@ describe('TasksPage', () => {
     expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
   })
 
+  it('exits select mode and clears the selection when the router reports leaving the page', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 1' }))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    act(() => onRouteLeave.current?.())
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
+  })
+
+  it('right-click Select enters select mode with just that task selected', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    expect(screen.queryByText('Select All')).not.toBeInTheDocument()
+    // The toolbar's own "Select" button is still visible outside select mode too, so
+    // disambiguate by only clicking the context menu's copy of the text.
+    const [selectMenuItem] = screen
+      .getAllByText('Select')
+      .filter((el) => el.closest('.mantine-contextmenu-item-button') !== null)
+    fireEvent.click(selectMenuItem)
+
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Select Batch 1' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Select Batch 2' })).not.toBeChecked()
+  })
+
   it('right-click Select All selects every currently visible (filtered) task', async () => {
     vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
       ...tasks,
@@ -150,6 +225,7 @@ describe('TasksPage', () => {
 
     // Filter down to only the "Batch" tasks before selecting all.
     fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'Batch' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     fireEvent.contextMenu(screen.getByText('Batch 1'))
     fireEvent.click(screen.getByText('Select All'))
 
@@ -167,6 +243,7 @@ describe('TasksPage', () => {
     renderTasksPage()
     await screen.findByText('Alpha')
 
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     fireEvent.contextMenu(screen.getByText('Beta'))
     fireEvent.click(screen.getByText('Select Above'))
 
@@ -175,6 +252,7 @@ describe('TasksPage', () => {
     expect(screen.getByRole('checkbox', { name: 'Select Gamma' })).not.toBeChecked()
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     fireEvent.contextMenu(screen.getByText('Beta'))
     fireEvent.click(screen.getByText('Select Below'))
 
@@ -198,6 +276,131 @@ describe('TasksPage', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled()
   })
 
+  it('exports a single task via its context menu outside select mode', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    expect(screen.queryByRole('dialog', { name: /Export Samples/ })).not.toBeInTheDocument()
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    fireEvent.click(screen.getByText('Export'))
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Export Samples: Select Format' })
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to Copy Annotations from the context menu outside select mode', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    fireEvent.click(screen.getByText('Copy Annotations'))
+
+    expect(navigate).toHaveBeenCalledWith('copy-annotations', { project, sourceTask: tasks[0] })
+  })
+
+  it('hides the Copy Annotations context-menu entry in select mode', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+
+    expect(screen.queryByText('Copy Annotations')).not.toBeInTheDocument()
+  })
+
+  it('hides the per-task Export context-menu entry in select mode', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    // The toolbar's own batch Export button is now visible too, so disambiguate by count
+    // rather than presence.
+    expect(screen.getAllByText('Export')).toHaveLength(1)
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+
+    expect(screen.getAllByText('Export')).toHaveLength(1)
+  })
+
+  it('hides the batch Auto-label button and the per-task context-menu entry when there are no annotators', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    expect(screen.queryByRole('button', { name: 'Auto-label' })).not.toBeInTheDocument()
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    expect(screen.queryByText('Auto-label')).not.toBeInTheDocument()
+  })
+
+  it('shows the batch Auto-label button once annotators exist, enabled only once something is selected', async () => {
+    vi.mocked(window.appStore.getAnnotators).mockResolvedValue([
+      { id: 'ann1', name: 'My Model', url: 'https://example.com', headers: {} }
+    ])
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    expect(await screen.findByRole('button', { name: 'Auto-label' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 1' }))
+    expect(screen.getByRole('button', { name: 'Auto-label' })).toBeEnabled()
+  })
+
+  it('fetches samples for every selected task and opens the Auto-label modal against all of them', async () => {
+    vi.mocked(window.appStore.getAnnotators).mockResolvedValue([
+      { id: 'ann1', name: 'My Model', url: 'https://example.com', headers: {} }
+    ])
+    vi.mocked(useAppStore.getState().store.getSamplesForTask).mockImplementation((taskId) =>
+      Promise.resolve([
+        {
+          id: `${taskId}-s1`,
+          name: `${taskId}-sample`,
+          imageUri: `cv-label-image://${taskId}-s1`,
+          split: TrainingSplit.Train,
+          width: 100,
+          height: 100,
+          annotations: [],
+          completedAt: null,
+          createdAt: new Date().toISOString()
+        }
+      ])
+    )
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 1' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 2' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Auto-label' }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().store.getSamplesForTask).toHaveBeenCalledWith('t1')
+      expect(useAppStore.getState().store.getSamplesForTask).toHaveBeenCalledWith('t2')
+    })
+    expect(await screen.findByRole('dialog', { name: 'Auto-label' })).toBeInTheDocument()
+    expect(await screen.findByText('My Model')).toBeInTheDocument()
+  })
+
+  it('runs Auto-label for a single task via its context menu', async () => {
+    vi.mocked(window.appStore.getAnnotators).mockResolvedValue([
+      { id: 'ann1', name: 'My Model', url: 'https://example.com', headers: {} }
+    ])
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    fireEvent.click(screen.getByText('Auto-label'))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().store.getSamplesForTask).toHaveBeenCalledWith('t1')
+    })
+    expect(useAppStore.getState().store.getSamplesForTask).not.toHaveBeenCalledWith('t2')
+    expect(await screen.findByRole('dialog', { name: 'Auto-label' })).toBeInTheDocument()
+  })
+
   it('deletes a task after confirming', async () => {
     vi.mocked(useAppStore.getState().store.deleteTasks).mockResolvedValue([true])
     renderTasksPage()
@@ -211,6 +414,245 @@ describe('TasksPage', () => {
 
     await waitFor(() => {
       expect(useAppStore.getState().store.deleteTasks).toHaveBeenCalledWith(['t1'])
+    })
+  })
+
+  it('hides the tag filter when the project has no tags', async () => {
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    expect(screen.queryByPlaceholderText('Filter by tag')).not.toBeInTheDocument()
+  })
+
+  it('shows tag badges on a task and the tag filter once the project has tags', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', tags: [{ id: 'tag1', name: 'Needs Review' }] },
+      tasks[1]
+    ])
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Needs Review' }
+    ])
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    // "Needs Review" also matches the (closed, but still DOM-present) tag filter's own
+    // option text - scope to the task row itself to find just the badge.
+    const row = screen.getByText('Batch 1').closest('.mantine-Paper-root')
+    expect(within(row as HTMLElement).getByText('Needs Review')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter by tag')).toBeInTheDocument()
+  })
+
+  it('filters the list by a selected tag', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', tags: [{ id: 'tag1', name: 'Urgent' }] },
+      { id: 't2', name: 'Batch 2', tags: [] }
+    ])
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Urgent' }
+    ])
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    const filterInput = screen.getByPlaceholderText('Filter by tag')
+    fireEvent.focus(filterInput)
+    fireEvent.click(filterInput)
+
+    // The dropdown's options render into the DOM regardless of whether the popover's own
+    // open/close CSS has actually flipped in jsdom (it doesn't reliably, since Mantine's
+    // Popover positioning relies on a real layout pass) - clicking the option still
+    // works, but finding it needs `hidden: true` (it's inside that possibly-still-hidden
+    // popover) and scoping to the listbox (plain text is ambiguous against this same
+    // tag's own row badge).
+    const listbox = await screen.findByRole('listbox', { hidden: true })
+    fireEvent.click(within(listbox).getByText('Urgent'))
+
+    expect(screen.getByText('Batch 1')).toBeInTheDocument()
+    expect(screen.queryByText('Batch 2')).not.toBeInTheDocument()
+  })
+
+  it("edits one task's tags via the TagPicker combobox, diffing against its current tags", async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', tags: [{ id: 'tag1', name: 'Old' }] },
+      tasks[1]
+    ])
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old' }
+    ])
+    vi.mocked(useAppStore.getState().store.createTag).mockResolvedValue({
+      id: 'tag2',
+      name: 'New'
+    })
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.contextMenu(screen.getByText('Batch 1'))
+    fireEvent.click(screen.getByText('Edit Tags'))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Edit Tags' })
+    const combobox = within(dialog).getByLabelText('Tags')
+
+    // "Old" starts as a pill (it's already on this task) - its remove button is
+    // aria-hidden (Mantine treats the pill's own text as the accessible content), so
+    // scope down to it directly rather than querying by accessible name.
+    const oldPill = within(dialog).getByText('Old').closest('.mantine-Pill-root')
+    fireEvent.click(within(oldPill as HTMLElement).getByRole('button', { hidden: true }))
+
+    // Typing only reveals a "+ Create" option - clicking it (not Enter) is what
+    // actually creates the tag. Creation invalidates and refetches the vocabulary, so
+    // the mock must start returning the new tag too, same as the "renames a task" test
+    // above does for a post-mutation refetch.
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old' },
+      { id: 'tag2', name: 'New' }
+    ])
+    fireEvent.click(combobox)
+    fireEvent.change(combobox, { target: { value: 'New' } })
+    // The dropdown is portaled to document.body, not nested under the dialog, so DOM-tree
+    // scoping (within(dialog)) can't find it - and the toolbar's own tag filter is also a
+    // MultiSelect with its own (closed, but still DOM-present) listbox, so plain
+    // findByRole would be ambiguous. aria-controls on the combobox names its own listbox
+    // by id, unambiguously.
+    const listboxId = combobox.getAttribute('aria-controls')
+    const listbox = document.getElementById(listboxId ?? '') as HTMLElement
+    fireEvent.click(within(listbox).getByText('+ Create "New"'))
+
+    await screen.findByText('New')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().store.createTag).toHaveBeenCalledWith(
+        project.id,
+        expect.any(String),
+        'New'
+      )
+    })
+    expect(useAppStore.getState().store.addTagsToTasks).toHaveBeenCalledWith(['t1'], ['tag2'])
+    expect(useAppStore.getState().store.removeTagsFromTasks).toHaveBeenCalledWith(['t1'], ['tag1'])
+  })
+
+  it('adds a newly-created tag across a batch of selected tasks via the Add combobox', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', tags: [{ id: 'tag1', name: 'Old' }] },
+      { id: 't2', name: 'Batch 2', tags: [] }
+    ])
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old' }
+    ])
+    vi.mocked(useAppStore.getState().store.createTag).mockResolvedValue({
+      id: 'tag2',
+      name: 'Reviewed'
+    })
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 1' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 2' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Tags' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Edit Tags' })
+    const combobox = within(dialog).getByLabelText('Add')
+    // Creation invalidates and refetches the vocabulary, so the mock must start
+    // returning the new tag too.
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old' },
+      { id: 'tag2', name: 'Reviewed' }
+    ])
+    fireEvent.click(combobox)
+    fireEvent.change(combobox, { target: { value: 'Reviewed' } })
+    // The dropdown is portaled to document.body, not nested under the dialog, and the
+    // toolbar's own tag filter is also a MultiSelect with its own listbox - aria-controls
+    // on the combobox names its own listbox by id, unambiguously.
+    const listboxId = combobox.getAttribute('aria-controls')
+    const listbox = document.getElementById(listboxId ?? '') as HTMLElement
+    fireEvent.click(within(listbox).getByText('+ Create "Reviewed"'))
+
+    await screen.findByText('Reviewed')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().store.addTagsToTasks).toHaveBeenCalledWith(
+        ['t1', 't2'],
+        ['tag2']
+      )
+    })
+    expect(useAppStore.getState().store.removeTagsFromTasks).not.toHaveBeenCalled()
+  })
+
+  it('removes an existing tag from a batch of selected tasks by clicking it in the Remove group', async () => {
+    vi.mocked(useAppStore.getState().store.getTasksForProject).mockResolvedValue([
+      { id: 't1', name: 'Batch 1', tags: [{ id: 'tag1', name: 'Old' }] },
+      { id: 't2', name: 'Batch 2', tags: [] }
+    ])
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old' }
+    ])
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 1' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Batch 2' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Tags' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Edit Tags' })
+    // "Old" is only in the "Remove" group's chips now - the "Add" combobox has no chips.
+    fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Old' }))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().store.removeTagsFromTasks).toHaveBeenCalledWith(
+        ['t1', 't2'],
+        ['tag1']
+      )
+    })
+    expect(useAppStore.getState().store.addTagsToTasks).not.toHaveBeenCalled()
+  })
+
+  it('creates, renames, and deletes tags from the Manage Tags modal', async () => {
+    vi.mocked(useAppStore.getState().store.getTagsForProject).mockResolvedValue([
+      { id: 'tag1', name: 'Old Name' }
+    ])
+    vi.mocked(useAppStore.getState().store.createTag).mockResolvedValue({
+      id: 'tag2',
+      name: 'Brand New'
+    })
+    renderTasksPage()
+    await screen.findByText('Batch 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage Tags' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Manage Tags' })
+    await within(dialog).findByText('Old Name')
+
+    fireEvent.change(within(dialog).getByLabelText('New tag'), {
+      target: { value: 'Brand New' }
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add' }))
+    await waitFor(() => {
+      expect(useAppStore.getState().store.createTag).toHaveBeenCalledWith(
+        project.id,
+        expect.any(String),
+        'Brand New'
+      )
+    })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Rename Old Name' }))
+    const renameDialog = await screen.findByRole('dialog', { name: 'Rename tag' })
+    fireEvent.change(within(renameDialog).getByLabelText('Name'), {
+      target: { value: 'New Name' }
+    })
+    fireEvent.click(within(renameDialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      expect(useAppStore.getState().store.updateTags).toHaveBeenCalledWith([
+        { id: 'tag1', name: 'New Name' }
+      ])
+    })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete Old Name' }))
+    const confirmDialog = await screen.findByRole('dialog', { name: 'Delete tag' })
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(useAppStore.getState().store.deleteTags).toHaveBeenCalledWith(['tag1'])
     })
   })
 })

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -4,11 +4,11 @@ import { OptimisticObject } from './util/optimistic_object'
 export enum LabelerMode {
   Select = 'select',
   CreateBox = 'create-box',
-  CreateMask = 'create-mask'
+  CreatePolygon = 'create-polygon'
 }
 
-type AnnotatorLabel = OmitV2<ILabel, 'color'>
-type AnnotatorPoint = OmitV2<IPoint, 'id'>
+export type AnnotatorLabel = OmitV2<ILabel, 'color'>
+export type AnnotatorPoint = OmitV2<IPoint, 'id'>
 
 export type AnnotatorInfoResponse = {
   labels: AnnotatorLabel[]

--- a/src/renderer/src/util/toOptimisticSample.ts
+++ b/src/renderer/src/util/toOptimisticSample.ts
@@ -1,0 +1,17 @@
+import { IAnnotation, ISample } from '@shared/types'
+import { OptimisticObject } from './optimistic_object'
+import { OptimisticSample } from '@renderer/types'
+
+/** Wraps a raw ISample (and its annotations) in the OptimisticObject layer the rest of the
+ *  app expects a sample to already be in - shared by anything that fetches samples outside
+ *  useSamples' own query (e.g. a batch action that pulls samples for several tasks at once). */
+export const toOptimisticSample = (sample: ISample): OptimisticSample => {
+  const annotationsObj = sample.annotations.reduce<{
+    [key: string]: OptimisticObject<IAnnotation>
+  }>((acc, annotation) => ({ ...acc, [annotation.id]: new OptimisticObject(annotation) }), {})
+
+  return new OptimisticObject({
+    ...sample,
+    annotations: new OptimisticObject(annotationsObj, true)
+  })
+}

--- a/src/shared/__tests__/utils.test.ts
+++ b/src/shared/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { arrayBufferToBase64 } from '../utils'
+
+describe('arrayBufferToBase64', () => {
+  afterEach(() => {
+    delete Uint8Array.prototype.toBase64
+  })
+
+  it('uses the native Uint8Array.prototype.toBase64 when the runtime has it', () => {
+    Uint8Array.prototype.toBase64 = function () {
+      return 'native-result'
+    }
+    const bytes = new Uint8Array([0x4d, 0x61, 0x6e]) // "Man"
+
+    expect(arrayBufferToBase64(bytes.buffer)).toBe('native-result')
+  })
+
+  it('encodes an empty buffer', () => {
+    expect(arrayBufferToBase64(new ArrayBuffer(0))).toBe('')
+  })
+
+  it('encodes a buffer whose length is a multiple of 3', () => {
+    const bytes = new Uint8Array([0x4d, 0x61, 0x6e]) // "Man"
+    expect(arrayBufferToBase64(bytes.buffer)).toBe('TWFu')
+  })
+
+  it('pads a buffer with a remainder of 1 byte', () => {
+    const bytes = new Uint8Array([0x4d]) // "M"
+    expect(arrayBufferToBase64(bytes.buffer)).toBe('TQ==')
+  })
+
+  it('pads a buffer with a remainder of 2 bytes', () => {
+    const bytes = new Uint8Array([0x4d, 0x61]) // "Ma"
+    expect(arrayBufferToBase64(bytes.buffer)).toBe('TWE=')
+  })
+
+  it('matches btoa on a larger buffer', () => {
+    const bytes = new Uint8Array(4096).map((_, i) => i % 256)
+    const expected = btoa(String.fromCharCode(...bytes))
+    expect(arrayBufferToBase64(bytes.buffer)).toBe(expected)
+  })
+})

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,17 +54,35 @@ export interface IProject {
   labels: ILabel[]
 }
 
-/** Renames the project and/or existing labels - does not add or remove labels, since
- *  removing one that's already used by an annotation would violate a foreign key. */
+/** Renames the project, edits existing labels, and can add new labels (an id not
+ *  already on the project is inserted rather than treated as a rename) - existing
+ *  labels still can't be removed here, since one already used by an annotation would
+ *  violate a foreign key. */
 export interface IProjectUpdate {
   id: IProject['id']
   name?: string
-  labels?: Pick<ILabel, 'id' | 'name'>[]
+  labels?: Pick<ILabel, 'id' | 'name' | 'color'>[]
+}
+
+export interface ITag {
+  id: string
+  name: string
+}
+
+export interface ITagUpdate {
+  id: ITag['id']
+  name?: string
 }
 
 export interface ITask {
   id: string
   name: string
+  /** Optional since not every code path that returns an ITask computes these (e.g.
+   *  updateTasks, which only renames - its result is never read for progress display,
+   *  only getTasksForProject/createTask populate them). Absent, not 0, when unknown. */
+  sampleCount?: number
+  completedSampleCount?: number
+  tags?: ITag[]
 }
 
 export interface ITaskUpdate {
@@ -102,6 +120,10 @@ export interface ISampleUpdate extends Partial<OmitV2<ISample, 'annotations' | '
   id: ISample['id']
 }
 
+/** Store-agnostic and project-agnostic connection info for an external annotator server -
+ *  see main/appStore.ts. Neither its label vocabulary nor any mapping against a project's
+ *  labels is ever persisted - both are fetched/built live and held only in renderer memory
+ *  (see hooks/useAnnotatorRuntime.ts, api/ExternalAnnotator.ts). */
 export interface INewAnnotator {
   id: string
   name: string
@@ -110,6 +132,10 @@ export interface INewAnnotator {
 }
 
 export interface IAnnotator extends INewAnnotator {}
+
+export interface IAnnotatorUpdate extends Partial<OmitV2<IAnnotator, 'id'>> {
+  id: IAnnotator['id']
+}
 
 export interface INewAnnotation {
   id: string
@@ -151,6 +177,20 @@ export interface IDataStore {
   updateTasks(updates: ITaskUpdate[]): Promise<ITask[]>
   deleteTasks(taskIds: string[]): Promise<boolean[]>
 
+  /** A project-global vocabulary managed from one place (ManageTagsModal) - typing only
+   *  happens here, when a tag is actually being created/renamed. Everywhere a tag gets
+   *  attached to a task, it's picked from this list by id, never typed. */
+  getTagsForProject(projectId: string): Promise<ITag[]>
+  createTag(projectId: string, id: string, name: string): Promise<ITag>
+  updateTags(updates: ITagUpdate[]): Promise<ITag[]>
+  deleteTags(tagIds: string[]): Promise<boolean[]>
+
+  /** Attaches/detaches existing tags (by id) to/from every task in taskIds - never a
+   *  per-task "replace the whole set" operation, so batch add/remove across differently-
+   *  tagged tasks doesn't require knowing each task's current tags up front. */
+  addTagsToTasks(taskIds: string[], tagIds: string[]): Promise<void>
+  removeTagsFromTasks(taskIds: string[], tagIds: string[]): Promise<void>
+
   getSamplesForTask(taskId: string): Promise<ISample[]>
   getSamples(sampleIds: string[]): Promise<ISample[]>
   createSamples(taskId: string, samples: INewSample[]): Promise<ISample[]>
@@ -162,17 +202,22 @@ export interface IDataStore {
   updateAnnotations(updates: IAnnotationUpdate[]): Promise<IAnnotation[]>
   deleteAnnotations(annotationsIds: string[]): Promise<boolean[]>
 
-  getAnnotators(projectId: string): Promise<IAnnotator[]>
+  replacePoints(annotationId: string, points: IPointReplacement[]): Promise<IPoint[]>
+}
+
+/** The always-on, store-agnostic counterpart to IDataStore - annotators live here instead
+ *  of in whichever IDataStore is currently active (see main/appStore.ts), so main routes
+ *  App_* IPC straight to a single fixed AppStore rather than through StoreOrchestrator. */
+export interface IAppDataStore {
+  getAnnotators(): Promise<IAnnotator[]>
   createAnnotator(
-    projectId: string,
     id: string,
     name: string,
     url: string,
     headers: Record<string, string>
   ): Promise<IAnnotator>
+  updateAnnotators(updates: IAnnotatorUpdate[]): Promise<IAnnotator[]>
   deleteAnnotators(annotatorIds: string[]): Promise<boolean[]>
-
-  replacePoints(annotationId: string, points: IPointReplacement[]): Promise<IPoint[]>
 }
 
 export type StoreDescriptor = { id: string; name: string }
@@ -257,6 +302,12 @@ export enum IPCKeys {
   Store_CreateTask = 'store-createTask',
   Store_UpdateTasks = 'store-updateTasks',
   Store_DeleteTasks = 'store-deleteTasks',
+  Store_GetTagsForProject = 'store-getTagsForProject',
+  Store_CreateTag = 'store-createTag',
+  Store_UpdateTags = 'store-updateTags',
+  Store_DeleteTags = 'store-deleteTags',
+  Store_AddTagsToTasks = 'store-addTagsToTasks',
+  Store_RemoveTagsFromTasks = 'store-removeTagsFromTasks',
   Store_GetSamplesForTask = 'store-getSamplesForTask',
   Store_GetSamples = 'store-getSamples',
   Store_CreateSamples = 'store-createSamples',
@@ -266,12 +317,15 @@ export enum IPCKeys {
   Store_CreateAnnotations = 'store-createAnnotations',
   Store_UpdateAnnotations = 'store-updateAnnotations',
   Store_DeleteAnnotations = 'store-deleteAnnotations',
-  Store_GetAnnotators = 'store-getAnnotators',
-  Store_CreateAnnotator = 'store-createAnnotator',
-  Store_DeleteAnnotators = 'store-deleteAnnotators',
   Store_ReplacePoints = 'store-replacePoints',
   Store_List = 'store-list',
   Store_UseStore = 'store-useStore',
+
+  // App (store-agnostic, always active - see main/appStore.ts)
+  App_GetAnnotators = 'app-getAnnotators',
+  App_CreateAnnotator = 'app-createAnnotator',
+  App_UpdateAnnotators = 'app-updateAnnotators',
+  App_DeleteAnnotators = 'app-deleteAnnotators',
 
   // System
   System_CreateTemporaryDirectory = 'system-createTemporaryDirectory',
@@ -307,6 +361,12 @@ export type IPCEvents = {
   [IPCKeys.Store_CreateTask]: IDataStore['createTask']
   [IPCKeys.Store_UpdateTasks]: IDataStore['updateTasks']
   [IPCKeys.Store_DeleteTasks]: IDataStore['deleteTasks']
+  [IPCKeys.Store_GetTagsForProject]: IDataStore['getTagsForProject']
+  [IPCKeys.Store_CreateTag]: IDataStore['createTag']
+  [IPCKeys.Store_UpdateTags]: IDataStore['updateTags']
+  [IPCKeys.Store_DeleteTags]: IDataStore['deleteTags']
+  [IPCKeys.Store_AddTagsToTasks]: IDataStore['addTagsToTasks']
+  [IPCKeys.Store_RemoveTagsFromTasks]: IDataStore['removeTagsFromTasks']
   [IPCKeys.Store_GetSamplesForTask]: IDataStore['getSamplesForTask']
   [IPCKeys.Store_GetSamples]: IDataStore['getSamples']
   [IPCKeys.Store_CreateSamples]: IDataStore['createSamples']
@@ -316,12 +376,15 @@ export type IPCEvents = {
   [IPCKeys.Store_CreateAnnotations]: IDataStore['createAnnotations']
   [IPCKeys.Store_UpdateAnnotations]: IDataStore['updateAnnotations']
   [IPCKeys.Store_DeleteAnnotations]: IDataStore['deleteAnnotations']
-  [IPCKeys.Store_GetAnnotators]: IDataStore['getAnnotators']
-  [IPCKeys.Store_CreateAnnotator]: IDataStore['createAnnotator']
-  [IPCKeys.Store_DeleteAnnotators]: IDataStore['deleteAnnotators']
   [IPCKeys.Store_ReplacePoints]: IDataStore['replacePoints']
   [IPCKeys.Store_List]: IStoreManager['listStores']
   [IPCKeys.Store_UseStore]: IStoreManager['useStore']
+
+  // App
+  [IPCKeys.App_GetAnnotators]: IAppDataStore['getAnnotators']
+  [IPCKeys.App_CreateAnnotator]: IAppDataStore['createAnnotator']
+  [IPCKeys.App_UpdateAnnotators]: IAppDataStore['updateAnnotators']
+  [IPCKeys.App_DeleteAnnotators]: IAppDataStore['deleteAnnotators']
 
   // System
   [IPCKeys.System_CreateTemporaryDirectory]: ISystem['createTemporaryDirectory']

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,7 +34,7 @@ export type BoundaryResult<T> =
 
 export const enum AnnotationType {
   Box = 'box',
-  Mask = 'mask'
+  Polygon = 'polygon'
 }
 export interface IPoint {
   id: string

--- a/src/shared/uint8array.d.ts
+++ b/src/shared/uint8array.d.ts
@@ -1,0 +1,11 @@
+// TypeScript's bundled lib.d.ts doesn't have types for the Uint8Array base64/hex methods
+// yet, even though Electron's renderer (Chromium 133+) has shipped them for a while - see
+// arrayBufferToBase64 in utils.ts. Optional, not everywhere this code type-checks against
+// actually has it at runtime (e.g. this project's own dev/test Node) - callers feature-detect.
+export {}
+
+declare global {
+  interface Uint8Array {
+    toBase64?(): string
+  }
+}

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -16,6 +16,27 @@ export const checkBoundaryResult = <T>(result: Promise<BoundaryResult<T>>) =>
 
 export const mod = (x: number, m: number) => ((x % m) + m) % m
 
+// Chunk size for the fallback path below - comfortably under engines' call-stack-depth
+// limit for a spread argument list, so a multi-megabyte image still encodes without
+// blowing the stack the way `btoa(String.fromCharCode(...bytes))` would in one shot.
+const CHUNK_SIZE = 0x8000
+
+/** Encodes raw bytes as base64, preferring the native `Uint8Array.prototype.toBase64`
+ *  (Electron's renderer has it, but this app's test/dev Node doesn't always) - the
+ *  fallback builds the binary string one chunk at a time before a single `btoa()` call,
+ *  for the same reason: `btoa(String.fromCharCode(...bytes))` in one shot blows the call
+ *  stack on a multi-megabyte image. */
+export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer)
+  if (typeof bytes.toBase64 === 'function') return bytes.toBase64()
+
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE))
+  }
+  return btoa(binary)
+}
+
 export const errorToString = (error: unknown) => {
   if (error instanceof Error) {
     return error.message


### PR DESCRIPTION
## Summary

A batch of features accumulated on top of `9008dd9`, split into 12
logically-scoped commits (see commit log for the full breakdown):

- **Tags** - a project-scoped vocabulary on tasks, managed from one
  place and picked (not typed) everywhere it's attached.
- **Auto-label annotators** - connect to an external HTTP annotator
  and run it over a batch of unlabeled samples; connection configs
  live in a new app-level SQLite store since they're project-agnostic.
- **Labeler**: undo/redo via a command-pattern history, the label
  selector now syncs to whichever annotation you click, and the
  `mask` annotation type is renamed to `polygon` (with a data
  migration).
- **Editable project labels** - add new labels to an existing
  project, not just rename existing ones; labels also get a color.
- **Per-task export** with a filename that defaults to the task's own
  name, and a shared `LabelMapper` UI reused across every
  importer/exporter, adding real label routing (merge/exclude) on
  export.
- **Copy Annotations** - copy one task's annotations onto another
  task's matching samples (by position, per-row override), for
  same-layout content in a different language.
- **`.cvlabel` drag-and-drop** - drop a `.cvlabel` file onto the Tasks
  page to jump straight into its label-mapping step and land in a
  prefilled Create Task modal, same as the existing image/folder drop.
- **Virtualized list rendering** (react-virtuoso) for the
  Projects/Tasks/Samples lists, plus route lifecycle hooks
  (`useOnRouteEnter`/`useOnRouteLeave`) so a page can reset transient
  state (e.g. select mode) when navigated away from.

## Test plan

- [x] `pnpm typecheck` - clean
- [x] `pnpm lint` - clean (2 pre-existing warnings unrelated to this change)
- [x] `pnpm test` - 451/451 passing
- [ ] `pnpm test:e2e` - written/updated but not run as part of this PR (per repo convention, it's slow and requires a build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)