### PR TITLE
Add keyboard shortcuts to the Labeler page

### DIFF
--- a/src/renderer/src/components/ConfirmDeleteModal.tsx
+++ b/src/renderer/src/components/ConfirmDeleteModal.tsx
@@ -7,6 +7,8 @@ export type ConfirmDeleteModalProps = {
   opened: boolean
   entityName: string
   itemName?: string
+  /** True if the deletion can be undone (e.g. via Ctrl+Z). */
+  undoable?: boolean
   onCancel: () => void
   onConfirm: () => Promise<unknown>
 }
@@ -15,9 +17,11 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
   opened,
   entityName,
   itemName,
+  undoable = false,
   onCancel,
   onConfirm
 }) => {
+  const caveat = undoable ? 'You can undo this with Ctrl+Z.' : 'This cannot be undone.'
   return (
     <Modal
       opened={opened}
@@ -29,10 +33,10 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
       <Text size="sm">
         {itemName ? (
           <>
-            Are you sure you want to delete <b>{itemName}</b>? This cannot be undone.
+            Are you sure you want to delete <b>{itemName}</b>? {caveat}
           </>
         ) : (
-          `Are you sure you want to delete this ${entityName}? This cannot be undone.`
+          `Are you sure you want to delete this ${entityName}? ${caveat}`
         )}
       </Text>
       <Group justify="flex-end" mt="lg">

--- a/src/renderer/src/components/__tests__/ConfirmDeleteModal.test.tsx
+++ b/src/renderer/src/components/__tests__/ConfirmDeleteModal.test.tsx
@@ -43,6 +43,24 @@ describe('ConfirmDeleteModal', () => {
     ).toBeInTheDocument()
   })
 
+  it('swaps in an undo hint when undoable is set', () => {
+    renderWithProviders(
+      <ConfirmDeleteModal
+        opened
+        entityName="annotation"
+        undoable
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete this annotation? You can undo this with Ctrl+Z.'
+      )
+    ).toBeInTheDocument()
+  })
+
   it('calls only onCancel when Cancel is clicked', () => {
     const onCancel = vi.fn()
     const onConfirm = vi.fn()

--- a/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
@@ -570,3 +570,38 @@ describe('useLabeler label picker sync', () => {
     expect(store.getState().selectedLabelId).toBe('l1')
   })
 })
+
+describe('useLabeler cancelActiveAction', () => {
+  it('deselects the current annotation, leaving the mode alone', () => {
+    const store = setup([annotationA])
+    act(() => {
+      store.getState().setMode(LabelerMode.Select)
+      store.getState().selectAnnotation('a1')
+    })
+
+    act(() => store.getState().cancelActiveAction())
+
+    expect(store.getState().selectedAnnotation).toBeNull()
+    expect(store.getState().mode).toBe(LabelerMode.Select)
+  })
+
+  it('drops out of a create mode back to Select when nothing is selected', () => {
+    const store = setup([])
+    act(() => store.getState().setMode(LabelerMode.CreatePolygon))
+
+    act(() => store.getState().cancelActiveAction())
+
+    expect(store.getState().mode).toBe(LabelerMode.Select)
+    expect(store.getState().annotationBeingCreated).toBeNull()
+  })
+
+  it('is a no-op in Select mode with nothing selected', () => {
+    const store = setup([])
+    act(() => store.getState().setMode(LabelerMode.Select))
+
+    act(() => store.getState().cancelActiveAction())
+
+    expect(store.getState().mode).toBe(LabelerMode.Select)
+    expect(store.getState().selectedAnnotation).toBeNull()
+  })
+})

--- a/src/renderer/src/hooks/useLabeler.ts
+++ b/src/renderer/src/hooks/useLabeler.ts
@@ -284,6 +284,8 @@ type LabelerStoreActions = {
   setMode: (mode: LabelerMode) => void
   setLabelId: (labelId: string) => void
   selectAnnotation: (id: string | null) => void
+  /** Escape: deselects, or else drops back to Select mode. */
+  cancelActiveAction: () => void
   onMouseMove: (x: number, y: number) => void
   onConfirmPoint: (x: number, y: number) => void
   onConfirmAnnotationCreation: (discardLivePoint?: boolean) => void
@@ -1007,6 +1009,17 @@ export const useLabeler = (labels: ILabel[]) => {
               // some default, since there's nothing meaningful to switch it to.
               ...(annotation !== null ? { selectedLabelId: annotation.resolve().labelId } : {})
             })
+          },
+          cancelActiveAction: () => {
+            const state = get()
+            if (state.selectedAnnotation !== null) {
+              state.selectAnnotation(null)
+              return
+            }
+
+            if (state.mode !== LabelerMode.Select) {
+              state.setMode(LabelerMode.Select)
+            }
           },
           onConfirmPoint: (x: number, y: number) => {
             const state = get()

--- a/src/renderer/src/routes/label/LabelPage.tsx
+++ b/src/renderer/src/routes/label/LabelPage.tsx
@@ -12,10 +12,11 @@ import {
 } from '@mantine/core'
 import { useHotkeys } from '@mantine/hooks'
 import { AsyncButton } from '@renderer/components/AsyncButton'
+import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
 import { Labeler } from '@renderer/components/Labeler'
 import { useLabeler } from '@renderer/hooks/useLabeler'
 import { LabelerMode, OptimisticSample } from '@renderer/types'
-import { useCallback, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { IoMdArrowBack } from 'react-icons/io'
 import { PiHandPalmBold, PiPolygonLight } from 'react-icons/pi'
 import { BsBoundingBoxCircles } from 'react-icons/bs'
@@ -233,6 +234,7 @@ export type LabelPageProps = {
 export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
   const [index, setIndex] = useState(initial)
   const [isAnnotationsDrawerOpen, setIsAnnotationsDrawerOpen] = useState(false)
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
   const { store } = useLabeler(project.labels)
   const mode = store((s) => s.mode)
   const selecteLabelId = store((s) => s.selectedLabelId)
@@ -282,13 +284,81 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
   // hidden store) after the user has already left it.
   useOnRouteLeave(() => store.getState().cancelPendingSampleLoad())
 
+  const goToSample = useCallback(
+    (delta: number) => setIndex((i) => mod(i + delta, samples.length)),
+    [samples.length]
+  )
+
+  const hotkeys = useMemo<Parameters<typeof useHotkeys>[0]>(
+    () => [
+      ['mod+z', () => store.getState().undo()],
+      ['mod+shift+z', () => store.getState().redo()],
+      ['mod+d', () => store.getState().duplicateSelectedAnnotation()],
+      [
+        'delete',
+        () => {
+          if (!isDeleteConfirmOpen && store.getState().selectedAnnotation !== null) {
+            setIsDeleteConfirmOpen(true)
+          }
+        }
+      ],
+      [
+        'backspace',
+        () => {
+          if (!isDeleteConfirmOpen && store.getState().selectedAnnotation !== null) {
+            setIsDeleteConfirmOpen(true)
+          }
+        }
+      ],
+      // Let Modal's own onClose handle Escape while the delete confirmation is open.
+      ['escape', () => !isDeleteConfirmOpen && store.getState().cancelActiveAction()],
+      ['1', () => store.getState().setMode(LabelerMode.Select)],
+      ['2', () => store.getState().setMode(LabelerMode.CreateBox)],
+      ['3', () => store.getState().setMode(LabelerMode.CreatePolygon)],
+      ['arrowleft', () => goToSample(-1)],
+      ['arrowright', () => goToSample(1)],
+      [
+        'space',
+        () => {
+          if (currentSampleId !== null) {
+            onSampleCompletedChanged(
+              currentSampleId,
+              sampleCompletedAt === null ? new Date().toISOString() : null
+            )
+          }
+        }
+      ]
+    ],
+    [
+      store,
+      isDeleteConfirmOpen,
+      goToSample,
+      currentSampleId,
+      sampleCompletedAt,
+      onSampleCompletedChanged
+    ]
+  )
+
   // useHotkeys ignores INPUT/TEXTAREA/SELECT targets by default, so this doesn't fire
   // while e.g. the sample index NumberInput below is focused.
-  useHotkeys([
-    ['mod+z', () => store.getState().undo()],
-    ['mod+shift+z', () => store.getState().redo()],
-    ['mod+d', () => store.getState().duplicateSelectedAnnotation()]
-  ])
+  useHotkeys(hotkeys)
+
+  useEffect(() => {
+    // event.button 3/4 are the mouse's back/forward side buttons - preventDefault on
+    // mousedown, which is where Electron/Chromium's own back/forward would otherwise fire.
+    const onMouseDown = (event: MouseEvent) => {
+      if (isDeleteConfirmOpen) return
+      if (event.button === 3) {
+        event.preventDefault()
+        goToSample(-1)
+      } else if (event.button === 4) {
+        event.preventDefault()
+        goToSample(1)
+      }
+    }
+    document.documentElement.addEventListener('mousedown', onMouseDown)
+    return () => document.documentElement.removeEventListener('mousedown', onMouseDown)
+  }, [goToSample, isDeleteConfirmOpen])
 
   return (
     <Container>
@@ -313,6 +383,16 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
         store={store}
         opened={isAnnotationsDrawerOpen}
         onClose={() => setIsAnnotationsDrawerOpen(false)}
+      />
+      <ConfirmDeleteModal
+        opened={isDeleteConfirmOpen}
+        entityName="annotation"
+        undoable
+        onCancel={() => setIsDeleteConfirmOpen(false)}
+        onConfirm={() => {
+          store.getState().deleteSelectedAnnotation()
+          return Promise.resolve()
+        }}
       />
       <Flex style={{ position: 'absolute', bottom: 20, left: 20 }} gap={'md'}>
         <LabelerModeControl value={mode} onChange={(e) => store.getState().setMode(e)} />

--- a/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
+++ b/src/renderer/src/routes/label/__tests__/LabelPage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/__tests__/renderWithProviders'
-import { IProject, ITask } from '@shared/types'
+import { IProject, ITask, TrainingSplit } from '@shared/types'
 import { LabelerMode, OptimisticSample } from '@renderer/types'
+import { toOptimisticSample } from '@renderer/util/toOptimisticSample'
 import { create } from 'zustand'
 
 const setSample = vi.fn()
@@ -10,10 +11,17 @@ const setMode = vi.fn()
 const setLabelId = vi.fn()
 const selectAnnotation = vi.fn()
 const deleteAnnotation = vi.fn()
+const deleteSelectedAnnotation = vi.fn()
+const cancelActiveAction = vi.fn()
 const setHoveredAnnotation = vi.fn()
 const setAnnotationsDrawerHovered = vi.fn()
 const markAllDirty = vi.fn()
 const cancelPendingSampleLoad = vi.fn()
+
+// Overridden per-test to control what store.getState().selectedAnnotation is at mount -
+// the mock store below isn't memoized like the real useLabeler, so this is read fresh
+// each render rather than settable via store.setState from a test.
+let mockSelectedAnnotation: { resolve: () => { id: string } } | null = null
 
 vi.mock('@renderer/components/Labeler', () => ({
   Labeler: () => <div data-testid="labeler-stub" />
@@ -31,13 +39,15 @@ vi.mock('@renderer/hooks/useLabeler', () => ({
           annotations: { resolve: () => ({}) }
         })
       },
-      selectedAnnotation: null,
+      selectedAnnotation: mockSelectedAnnotation,
       labelsMap: {},
       setSample,
       setMode,
       setLabelId,
       selectAnnotation,
       deleteAnnotation,
+      deleteSelectedAnnotation,
+      cancelActiveAction,
       setHoveredAnnotation,
       setAnnotationsDrawerHovered,
       markAllDirty,
@@ -78,6 +88,8 @@ const fireRouteEnter = () => onRouteEnterCallbacks.forEach((callback) => callbac
 const fireRouteLeave = () => onRouteLeaveCallbacks.forEach((callback) => callback())
 
 import { LabelPage } from '../LabelPage'
+import { useAppStore } from '@renderer/hooks/useAppStore'
+import { createMockDataStore } from '@renderer/__tests__/mockDataStore'
 
 const project: IProject = {
   id: 'p1',
@@ -88,10 +100,22 @@ const project: IProject = {
   ]
 }
 const task: ITask = { id: 't1', name: 'Batch 1' }
-const fakeSamples = [
-  { resolve: () => ({ id: 'sample-1' }) },
-  { resolve: () => ({ id: 'sample-2' }) }
-] as unknown as OptimisticSample[]
+const makeFakeSample = (id: string) =>
+  toOptimisticSample({
+    id,
+    name: id,
+    split: TrainingSplit.Train,
+    createdAt: new Date().toISOString(),
+    imageUri: 'about:blank',
+    width: 100,
+    height: 100,
+    completedAt: null,
+    annotations: []
+  })
+// Reassigned fresh in beforeEach: each sample is a real OptimisticObject that
+// accumulates update() diffs, so reusing one instance across tests would leak the
+// completion toggle from one test's assertions into the next.
+let fakeSamples: OptimisticSample[]
 
 const renderLabelPage = (projectOverride: IProject = project) =>
   renderWithProviders(
@@ -102,12 +126,17 @@ beforeEach(() => {
   setSample.mockClear()
   setMode.mockClear()
   setLabelId.mockClear()
+  deleteSelectedAnnotation.mockClear()
+  cancelActiveAction.mockClear()
   setHoveredAnnotation.mockClear()
   setAnnotationsDrawerHovered.mockClear()
   markAllDirty.mockClear()
   cancelPendingSampleLoad.mockClear()
   onRouteEnterCallbacks.clear()
   onRouteLeaveCallbacks.clear()
+  mockSelectedAnnotation = null
+  fakeSamples = [makeFakeSample('sample-1'), makeFakeSample('sample-2')]
+  Object.assign(useAppStore.getState().store, createMockDataStore())
 })
 
 describe('LabelPage', () => {
@@ -182,5 +211,140 @@ describe('LabelPage', () => {
     fireRouteLeave()
 
     expect(cancelPendingSampleLoad).toHaveBeenCalled()
+  })
+
+  describe('keyboard shortcuts', () => {
+    it('switches mode via 1/2/3', () => {
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: '2' })
+      expect(setMode).toHaveBeenCalledWith(LabelerMode.CreateBox)
+
+      fireEvent.keyDown(document.documentElement, { key: '3' })
+      expect(setMode).toHaveBeenCalledWith(LabelerMode.CreatePolygon)
+
+      fireEvent.keyDown(document.documentElement, { key: '1' })
+      expect(setMode).toHaveBeenCalledWith(LabelerMode.Select)
+    })
+
+    it('navigates to the next/previous sample with arrow keys, wrapping around', () => {
+      renderLabelPage()
+      setSample.mockClear()
+
+      fireEvent.keyDown(document.documentElement, { key: 'ArrowRight' })
+      expect(setSample).toHaveBeenCalledWith(fakeSamples[1])
+
+      setSample.mockClear()
+      fireEvent.keyDown(document.documentElement, { key: 'ArrowLeft' })
+      expect(setSample).toHaveBeenCalledWith(fakeSamples[0])
+    })
+
+    it('navigates to the next/previous sample with the mouse back/forward buttons, wrapping around', () => {
+      renderLabelPage()
+      setSample.mockClear()
+
+      fireEvent.mouseDown(document.documentElement, { button: 4 })
+      expect(setSample).toHaveBeenCalledWith(fakeSamples[1])
+
+      setSample.mockClear()
+      fireEvent.mouseDown(document.documentElement, { button: 3 })
+      expect(setSample).toHaveBeenCalledWith(fakeSamples[0])
+    })
+
+    it('ignores other mouse buttons', () => {
+      renderLabelPage()
+      setSample.mockClear()
+
+      fireEvent.mouseDown(document.documentElement, { button: 0 })
+      fireEvent.mouseDown(document.documentElement, { button: 1 })
+      fireEvent.mouseDown(document.documentElement, { button: 2 })
+
+      expect(setSample).not.toHaveBeenCalled()
+    })
+
+    it('ignores the mouse back/forward buttons while the delete confirmation is open', async () => {
+      mockSelectedAnnotation = { resolve: () => ({ id: 'a1' }) }
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Delete' })
+      await screen.findByText('Delete annotation')
+      setSample.mockClear()
+
+      fireEvent.mouseDown(document.documentElement, { button: 4 })
+
+      expect(setSample).not.toHaveBeenCalled()
+    })
+
+    it('toggles sample completion via spacebar', async () => {
+      renderLabelPage()
+      const dataStore = useAppStore.getState().store
+
+      fireEvent.keyDown(document.documentElement, { key: ' ' })
+
+      await waitFor(() =>
+        expect(dataStore.updateSamples).toHaveBeenCalledWith([
+          { id: 'sample-1', completedAt: expect.any(String) }
+        ])
+      )
+    })
+
+    it('deselects via Escape', () => {
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Escape' })
+
+      expect(cancelActiveAction).toHaveBeenCalledTimes(1)
+    })
+
+    it('does nothing on Delete/Backspace when no annotation is selected', () => {
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Delete' })
+      fireEvent.keyDown(document.documentElement, { key: 'Backspace' })
+
+      expect(screen.queryByText('Delete annotation')).not.toBeInTheDocument()
+    })
+
+    it('asks for confirmation before deleting the selected annotation via Delete, then deletes on confirm', async () => {
+      mockSelectedAnnotation = { resolve: () => ({ id: 'a1' }) }
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Delete' })
+      expect(await screen.findByText('Delete annotation')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+      expect(deleteSelectedAnnotation).toHaveBeenCalledTimes(1)
+    })
+
+    it('also opens the delete confirmation via Backspace', async () => {
+      mockSelectedAnnotation = { resolve: () => ({ id: 'a1' }) }
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Backspace' })
+
+      expect(await screen.findByText('Delete annotation')).toBeInTheDocument()
+    })
+
+    it('does not delete when the confirmation is cancelled', async () => {
+      mockSelectedAnnotation = { resolve: () => ({ id: 'a1' }) }
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Delete' })
+      fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+      expect(deleteSelectedAnnotation).not.toHaveBeenCalled()
+      await waitFor(() => expect(screen.queryByText('Delete annotation')).not.toBeInTheDocument())
+    })
+
+    it('does not deselect via Escape while the delete confirmation is open', () => {
+      mockSelectedAnnotation = { resolve: () => ({ id: 'a1' }) }
+      renderLabelPage()
+
+      fireEvent.keyDown(document.documentElement, { key: 'Delete' })
+      fireEvent.keyDown(document.documentElement, { key: 'Escape' })
+
+      expect(cancelActiveAction).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Delete/Backspace deletes the selected annotation, with a confirmation dialog (undoable via Ctrl+Z, so the dialog says so)
- Escape deselects, or drops out of Create Box/Polygon mode back to Select
- 1/2/3 switch tools (Select/Create Box/Create Polygon)
- Left/Right arrow keys and the mouse's back/forward side buttons navigate to the previous/next sample, wrapping around
- Space toggles the current sample's completion state
- `useHotkeys`'s hotkey list is now memoized so the keydown listener isn't torn down/re-added on every render

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (467 tests passing)