### PR TITLE
Group Dependabot PRs and auto-merge minor/patch bumps after a cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Also acts as a supply-chain-attack buffer - most malicious releases get caught within days.
+    # Security updates bypass this entirely and stay instant - this is just for routine bumps.
     cooldown:
-      default-days: 4
-      semver-major-days: 7
-      semver-minor-days: 4
-      semver-patch-days: 3
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -29,7 +26,4 @@ updates:
           - "minor"
           - "patch"
     cooldown:
-      default-days: 4
-      semver-major-days: 7
-      semver-minor-days: 4
-      semver-patch-days: 3
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,32 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # pnpm's minimumReleaseAge policy (see package.json's packageManager, pnpm 11+)
-    # rejects installing any lockfile entry published in the last 24h. Without a
-    # cooldown, Dependabot routinely resolves to versions still inside that window
-    # (it bumps to whatever's newest the moment it runs), so `pnpm install
-    # --frozen-lockfile` fails in CI before anything else even runs. A 2-day
-    # cooldown gives a comfortable margin so Dependabot never proposes a version pnpm
-    # would refuse.
+    groups:
+      # Majors stay ungrouped - those are the ones worth reviewing individually.
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    # Also acts as a supply-chain-attack buffer - most malicious releases get caught within days.
     cooldown:
-      default-days: 2
+      default-days: 4
+      semver-major-days: 7
+      semver-minor-days: 4
+      semver-patch-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 4
+      semver-major-days: 7
+      semver-minor-days: 4
+      semver-patch-days: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for minor/patch bumps
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Approving as github-actions[bot], not dependabot[bot], so this isn't a self-approval.
+      - name: Approve and enable auto-merge
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml`: groups minor/patch version updates into a single PR per ecosystem (majors still get individual PRs for review); replaces the flat 2-day cooldown with a flat 7-day one, sized as a supply-chain-attack buffer for routine bumps - known vulnerabilities bypass this entirely via Dependabot's separate security-update path (confirmed already enabled on this repo), so there's no urgency tradeoff to staying a week behind on routine version bumps
- `.github/workflows/dependabot-auto-merge.yml`: new workflow that approves and enables auto-merge for Dependabot PRs classified as minor/patch by `dependabot/fetch-metadata`; majors are left for manual review
  - Triggered by `pull_request` (not `pull_request_target`) and never checks out PR code
  - Gated on both `github.actor == 'dependabot[bot]'` and the PR's head repo matching the base repo (belt-and-suspenders against fork-based trickery, even though Dependabot PRs are never fork-based)
  - PR URL passed through `env:` + a shell variable rather than inline `${{ }}` interpolation in the `run:` block, avoiding script injection
  - `dependabot/fetch-metadata` pinned by commit SHA, matching this repo's existing Actions-pinning convention
- `.github/workflows/comment-approve.yml`: new workflow letting the repo owner comment `/approve` on their own PR to have it approved (as `github-actions[bot]`, a different actor, so it's not a self-approval) and auto-merge enabled - GitHub blocks approving your own PR regardless of admin status, so without this, required-review branch protection means an admin bypass on every solo PR
  - Gated on `author_association == 'OWNER'` and commenter == PR author, since `issue_comment` (unlike `pull_request`) doesn't get a fork-token downgrade and would otherwise run at full privilege for any comment on any PR

## Repo settings changed (already applied live via the API, not part of this diff)
- `allow_auto_merge`: `false` → `true`
- Branch protection on `master`: required approvals `0` → `1`; `dismiss_stale_reviews` `false` → `true` (so a post-approval push can't ride on a stale approval)

Dependabot's own approval step satisfies the 1-approval requirement for qualifying PRs; the new `/approve` command satisfies it for the owner's own PRs; everyone else (or a Dependabot major) still needs a real reviewer.

## Test plan
- [x] Both YAML files validated with `yaml.safe_load`
- [x] `allow_auto_merge` and branch protection settings confirmed live via `gh api`
- [ ] Watch the next real Dependabot PR to confirm grouping + auto-merge behave as expected
- [ ] Comment `/approve` on this PR to confirm the self-approve workflow works