### PR TITLE
Add a /approve comment command for self-approving your own PRs

### DIFF
--- a/.github/workflows/comment-approve.yml
+++ b/.github/workflows/comment-approve.yml
@@ -1,0 +1,28 @@
+name: Approve via comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  approve:
+    name: Approve and enable auto-merge
+    runs-on: ubuntu-latest
+    # issue_comment skips pull_request's fork-token downgrade, so this must gate itself: only the repo owner, on their own PR.
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/approve' &&
+      github.event.comment.user.login == github.event.issue.user.login &&
+      github.event.comment.author_association == 'OWNER'
+    steps:
+      - name: Approve and enable auto-merge
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.issue.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This was originally part of #26 but got lost in a merge-timing race - the merge landed on an earlier commit of that branch before this one was pushed. Recovering it here as its own PR.

- `.github/workflows/comment-approve.yml`: lets the repo owner comment `/approve` on their own PR to have it approved (as `github-actions[bot]`, a different actor, so it's not a self-approval) and auto-merge enabled. GitHub blocks approving your own PR regardless of admin status, so without this, required-review branch protection means an admin bypass on every solo PR.
- Gated on `author_association == 'OWNER'` and commenter == PR author, since `issue_comment` (unlike `pull_request`) doesn't get a fork-token downgrade and would otherwise run at full privilege for any comment on any PR.

## Test plan
- [ ] Comment `/approve` on this PR to confirm the workflow actually fires and merges it