### PR TITLE
Migrate from pnpm/action-setup to its successor pnpm/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
## Summary
`pnpm/action-setup`'s own README points to `pnpm/setup` as its successor. Migrating directly instead of merging the pending `pnpm/action-setup` v6 bump (#17), which I'm closing.

- `pnpm/setup@v2` only supports pnpm v11+ - this repo's `packageManager` field (`pnpm@11.5.2`) already satisfies that, so no version-pin changes needed elsewhere.
- `install: false` is set explicitly - `pnpm/setup` defaults to running its own unpinned `pnpm install` after setup, which would be redundant with (and could drift ahead of) this workflow's existing explicit `pnpm install --frozen-lockfile` step.
- `cache` stays on `actions/setup-node`'s `cache: pnpm` input, unchanged - not duplicated onto the new action.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` unaffected (workflow-only change)
- [ ] CI run on this PR itself is the real test - confirms `pnpm/setup` resolves the pnpm version from `packageManager`, doesn't double-install, and the existing cache/install/test steps still work end to end