### PR TITLE
Remove dead commented-out code and trim verbose comments

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,88 +2,14 @@ import { ipcMain } from 'electron'
 import { BoundaryResult, IPCEvents } from '../shared/types'
 import { errorToString } from '../shared/utils'
 
-// type IpcMainFunc<TResult = unknown, TArgs extends unknown[] = unknown[]> = (
-//   _: IpcMainInvokeEvent,
-//   ...args: TArgs
-// ) => Promise<BoundaryResult<TResult>>
-
-/**
- * Freaky stuff meehn, will wrap a function to work with ipcMain.handle
- * @param func
- * @returns
- */
-// export const wrap = <TResult = unknown, TArgs extends unknown[] = unknown[]>(
-//   func: (...args: TArgs) => Promise<TResult>
-// ): IpcMainFunc<TResult, TArgs> => {
-//   return (_: IpcMainInvokeEvent, ...args: TArgs): Promise<BoundaryResult<TResult>> => {
-//     return func(...args)
-//       .then<BoundaryResult<TResult>>((d) => ({ ok: true, data: d }))
-//       .catch((e) => ({ ok: false, error: e }))
-//   }
-// }
-// export const wrap = <TResult = unknown, TArgs extends unknown[] = unknown[]>(
-//   func: (...args: TArgs) => Promise<TResult>
-// ): IpcMainFunc<TResult, TArgs> => {
-//   return async (_: IpcMainInvokeEvent, ...args: TArgs): Promise<BoundaryResult<TResult>> => {
-//     //await new Promise((rej) => setTimeout(rej, Math.random() * 5000))
-//     return (
-//       func(...args)
-//         // .then(async (c) => {
-//         //   await new Promise((rej) => setTimeout(rej, Math.random() * 5000))
-//         //   return c
-//         // })
-//         .then<BoundaryResult<TResult>>((d) => ({ ok: true, data: d }))
-//         .catch((e) => ({ ok: false, error: errorToString(e) }))
-//         .then((c) => {
-//           // console.log(
-//           //   `${func.name}(${inspect(args, {
-//           //     depth: null,
-//           //     compact: false,
-//           //     maxArrayLength: null,
-//           //     maxStringLength: null
-//           //   })}) => ${inspect(c, {
-//           //     depth: null,
-//           //     compact: false,
-//           //     maxArrayLength: null,
-//           //     maxStringLength: null
-//           //   })}`
-//           // )
-//           return c as BoundaryResult<TResult>
-//         })
-//     )
-//   }
-// }
-
 export const handleIpc = <TChannel extends keyof IPCEvents>(
   channel: TChannel,
   callback: IPCEvents[TChannel]
 ) => {
   ipcMain.handle(channel, (_, ...args) => {
     const func = callback as (...args: unknown[]) => Promise<unknown>
-    return (
-      func(...args)
-        // .then(async (c) => {
-        //   await new Promise((rej) => setTimeout(rej, Math.random() * 5000))
-        //   return c
-        // })
-        .then<BoundaryResult<unknown>>((d) => ({ ok: true, data: d }))
-        .catch((e) => ({ ok: false, error: errorToString(e) }))
-        .then((c) => {
-          // console.log(
-          //   `${func.name}(${inspect(args, {
-          //     depth: null,
-          //     compact: false,
-          //     maxArrayLength: null,
-          //     maxStringLength: null
-          //   })}) => ${inspect(c, {
-          //     depth: null,
-          //     compact: false,
-          //     maxArrayLength: null,
-          //     maxStringLength: null
-          //   })}`
-          // )
-          return c as BoundaryResult<unknown>
-        })
-    )
+    return func(...args)
+      .then<BoundaryResult<unknown>>((d) => ({ ok: true, data: d }))
+      .catch((e) => ({ ok: false, error: errorToString(e) }))
   })
 }

--- a/src/renderer/src/components/Labeler.tsx
+++ b/src/renderer/src/components/Labeler.tsx
@@ -132,8 +132,6 @@ const drawPolygon = (
     ctx.lineTo(nextPoint.x, nextPoint.y)
   }
 
-  //if (closed) ctx.closePath();
-
   if (fill) {
     ctx.fill()
   } else {
@@ -194,8 +192,7 @@ const drawSelectedHitHandles = (
   }
 
   if (selectedAnnotation.type === AnnotationType.Box) {
-    // Edge hit-test lines, drawn before the corner circles below so a corner's hit
-    // area wins over an overlapping edge at the same pixels.
+    // Drawn before the corner circles below so a corner's hit area wins over an overlapping edge.
     const boxCorners = getBoxPoints(points)
     const edgeSentinels = [BOX_EDGE_TOP, BOX_EDGE_RIGHT, BOX_EDGE_BOTTOM, BOX_EDGE_LEFT]
     for (let i = 0; i < boxCorners.length; i++) {
@@ -225,8 +222,7 @@ const drawSelectedHitHandles = (
       0
     )
 
-    // The 2 derived corners (top-right/bottom-left) - purely visual/hit-test handles,
-    // don't correspond to a real IPoint (see BOX_CORNER_HANDLE_TOP_RIGHT).
+    // The 2 derived corners - visual/hit-test only, no real IPoint behind them.
     const topRightHitId = state.selectedAnnotationControlHitIds.getByValue(
       BOX_CORNER_HANDLE_TOP_RIGHT
     )
@@ -344,20 +340,13 @@ const drawCreationPreview = (
 const HOVER_DIM_ALPHA = 0.55
 const HOVER_OUTLINE_WIDTH = 3
 
-/** Dims the whole canvas - since this runs on the annotation canvas layer (stacked above
- *  the image canvas), it darkens both the image and every other annotation already drawn
- *  this frame. Deliberately driven by "is the mouse anywhere over the AnnotationsDrawer",
- *  not "is this specific row hovered": keying the dim itself off a single row would flash
- *  off/on every time the cursor crosses the gap between two rows on its way from one to
- *  another - this way the dim stays on continuously and only the cutout below moves. */
+/** Dims the whole canvas - driven by "is the mouse over the AnnotationsDrawer", not a single row, to avoid flicker crossing row gaps. */
 const dimCanvas = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
   ctx.fillStyle = `rgba(0, 0, 0, ${HOVER_DIM_ALPHA})`
   ctx.fillRect(0, 0, width, height)
 }
 
-/** Cuts a hole exactly matching a shape out of whatever's already been drawn (namely
- *  dimCanvas's overlay) via a destination-out composite, exposing the image and that
- *  shape's own fill/outline at full brightness underneath. */
+/** Cuts a hole matching a shape out of whatever's already drawn (dimCanvas's overlay), via a destination-out composite. */
 const cutoutShape = (ctx: CanvasRenderingContext2D, shapePoints: OmitV2<IPoint, 'id'>[]) => {
   if (shapePoints.length < 2) return
 
@@ -625,8 +614,7 @@ const usePointerInteractions = (
         if (result === PointerResult.Consumed) {
           return
         }
-        // Default: fall through to the pan below (e.g. deselecting on empty canvas
-        // still lets the same drag pan the view).
+        // Default: fall through to the pan below.
       }
 
       // Pan fallback: either forced (ctrl+left-click) or an unconsumed left-click.
@@ -816,7 +804,6 @@ const useCanvasDraw = (
             xScale,
             yScale
           )
-          //const compositeOperation = annotationCtx.globalCompositeOperation // Heavy on performance
           switch (annotation.type) {
             case AnnotationType.Box:
               {
@@ -831,7 +818,6 @@ const useCanvasDraw = (
                   ANNOTATION_ALPHA
                 )
 
-                //annotationCtx.globalCompositeOperation = 'difference'
                 drawPolygon(
                   annotationCtx,
                   actualPoints,
@@ -839,7 +825,6 @@ const useCanvasDraw = (
                   false,
                   2
                 )
-                //annotationCtx.globalCompositeOperation = compositeOperation
               }
               break
 
@@ -854,7 +839,6 @@ const useCanvasDraw = (
                   ANNOTATION_ALPHA
                 )
 
-                //annotationCtx.globalCompositeOperation = 'difference'
                 drawPolygon(
                   annotationCtx,
                   points,
@@ -862,7 +846,6 @@ const useCanvasDraw = (
                   false,
                   2
                 )
-                //annotationCtx.globalCompositeOperation = compositeOperation
               }
               break
           }
@@ -883,8 +866,7 @@ const useCanvasDraw = (
                 drawControlCircle(annotationCtx, points[0], CONTROL_POINT_CIRCLE_RADIUS)
                 drawControlCircle(annotationCtx, points[1], CONTROL_POINT_CIRCLE_RADIUS)
 
-                // Purely visual - the other 2 corners of the box, derived from the same
-                // 2 real points, so dragging them still only ever produces 2 real points.
+                // Purely visual - the other 2 derived corners, from the same 2 real points.
                 drawControlCircle(
                   annotationCtx,
                   { x: points[1].x, y: points[0].y },
@@ -939,8 +921,7 @@ const useCanvasDraw = (
 
             cutoutShape(annotationCtx, spotlightShape)
 
-            // Re-draws the spotlighted annotation's outline crisp and undimmed on top of
-            // the cutout, thicker than normal so it reads clearly as the focused shape.
+            // Redraws the spotlighted annotation's outline undimmed, thicker than normal.
             drawPolygon(
               annotationCtx,
               spotlightShape,
@@ -968,11 +949,7 @@ const useCanvasDraw = (
     }
   }, [annotationCanvas, crosshairCanvas, imageCanvas, store])
 
-  // Render-on-demand: only schedule a frame when the store actually has something
-  // dirty, instead of ticking requestAnimationFrame forever. drawCanvases() detects
-  // canvas-size mismatches itself and marks everything dirty on the first call, which
-  // covers the initial paint; a ResizeObserver covers later container resizes, since
-  // those don't otherwise touch the store.
+  // Render-on-demand: only schedules a frame when the store has something dirty.
   useEffect(() => {
     let frameId: number | null = null
 
@@ -986,8 +963,7 @@ const useCanvasDraw = (
       frameId = requestAnimationFrame(() => {
         frameId = null
         drawCanvases()
-        // Some modes (e.g. crosshair tracking while creating an annotation) keep
-        // marking annotationDirty on every mouse move, so keep going until clean.
+        // Some modes keep marking annotationDirty on every mouse move - keep going until clean.
         if (isDirty()) {
           scheduleFrame()
         }

--- a/src/renderer/src/hooks/useAppStore.ts
+++ b/src/renderer/src/hooks/useAppStore.ts
@@ -4,11 +4,6 @@ import { create } from 'zustand'
 
 type AppStoreState = {
   store: IDataStore
-  // projects: IProject[]
-  // tasks: ITask[]
-  // samples: ISample[]
-  // activeProject: IProject | null
-  // activeTask: ITask | null
 }
 
 type AppStoreActions = object
@@ -16,75 +11,5 @@ type AppStoreActions = object
 export const useAppStore = create<AppStoreState & AppStoreActions>(() => {
   return {
     store: new IpcDataStore()
-    // projects: [],
-    // tasks: [],
-    // samples: [],
-    // activeProject: null,
-    // activeTask: null,
-    // loadProjects: async () => {
-    //   const { store } = get()
-    //   const projects = await store.getProjects()
-    //   set({ projects: projects })
-    // },
-    // createProject: async (name, labels) => {
-    //   const { store, projects } = get()
-    //   const newProject = await store.createProject(makeUUID(), name, labels)
-
-    //   set({ projects: [...projects, newProject] })
-    // },
-    // openProject: async (project) => {
-    //   const { store } = get()
-
-    //   const tasks = await store.getTasks(project.id)
-
-    //   set({ tasks, activeProject: project, activeTask: null, samples: [] })
-
-    //   await navigateToProject(project.id)
-    // },
-    // createTask: async (name, files) => {
-    //   const { store, activeProject } = get()
-    //   if (activeProject === null) throw new Error('There is no active project')
-
-    //   const base64Data = await Promise.all(files.map((c) => fileToBase64(c)))
-    //   const newSamples = files.map<INewSample>((c, idx) => {
-    //     return {
-    //       id: makeUUID(),
-    //       name: normalizeFilename(c.name),
-    //       base64Image: base64Data[idx],
-    //       split: 'train',
-    //       annotations: [],
-    //       createdAt: new Date().toISOString()
-    //     }
-    //   })
-
-    //   const task = await store.createTask(activeProject.id, {
-    //     id: makeUUID(),
-    //     name: name
-    //   })
-
-    //   const samples = await store.createSamples(task.id, newSamples)
-
-    //   console.log(samples)
-
-    //   set((s) => ({ tasks: [...s.tasks, task] }))
-    // },
-    // openTask: async (task) => {
-    //   const { store, activeProject } = get()
-
-    //   if (activeProject === null) throw new Error('There is no active project')
-
-    //   const samples = await store.getSamples(task.id)
-
-    //   set({ activeTask: task, samples: samples })
-
-    //   await navigateToTask(activeProject.id, task.id)
-    // },
-    // loadSamples: async (task) => {
-    //   const { store } = get()
-
-    //   const tasks = await store.getTasks(task.id)
-
-    //   set({ tasks })
-    // }
   }
 })

--- a/src/renderer/src/hooks/useLabeler.ts
+++ b/src/renderer/src/hooks/useLabeler.ts
@@ -17,21 +17,11 @@ const ZOOM_STEP_DELTA = 0.15
 const MIN_ZOOM = 0.05
 const MAX_ZOOM = 32
 
-/** A box only ever has 2 real points (opposite corners, normalized to
- *  [top-left, bottom-right] by normalizeAnnotationPoints), but shows 4 draggable
- *  handles - these 2 sentinels stand in for the other two (derived) corners in
- *  selectedAnnotationControlHitIds/moveAnnotationPoint. Dragging one moves one real
- *  point's x and the other real point's y (see pointIdsBeingMovedAxis) rather than
- *  corresponding to a single real IPoint. Only ever meaningful while a Box is selected,
- *  where there's exactly one of each in play at a time, so a fixed literal (rather than
- *  a per-annotation id) is fine. */
+/** Sentinels for a Box's 2 derived corner handles (see moveAnnotationPoint) - safe as fixed literals since only one Box is ever selected at a time. */
 export const BOX_CORNER_HANDLE_TOP_RIGHT = '__box-corner-top-right__'
 export const BOX_CORNER_HANDLE_BOTTOM_LEFT = '__box-corner-bottom-left__'
 
-/** A box's 4 edges - draggable to resize along a single axis, moving only the real
- *  point on that edge (see moveAnnotationPoint). Unlike a Polygon's lines, these never go
- *  through addControlPoint - a Box only ever has 2 real points, so there's nothing to
- *  insert a new point into. */
+/** A Box's 4 resizable edges (see moveAnnotationPoint) - unlike a Polygon's lines, these never go through addControlPoint. */
 export const BOX_EDGE_TOP = '__box-edge-top__'
 export const BOX_EDGE_RIGHT = '__box-edge-right__'
 export const BOX_EDGE_BOTTOM = '__box-edge-bottom__'
@@ -73,11 +63,7 @@ export const normalizeAnnotationPoints = <T extends Pick<IAnnotation, 'type' | '
   return fixedAnnotation
 }
 
-/** How much of moveCurrent applies to a given point mid-drag: the full (dx, dy) if it
- *  isn't axis-masked (the default for polygon vertices and whole-annotation moves), or just
- *  one axis for a box's 2 derived corner handles (see BOX_CORNER_HANDLE_TOP_RIGHT).
- *  Returns [0, 0] for a point that isn't part of the current drag at all. Shared between
- *  commitAnnotationMove here and the Labeler canvas's live drag preview. */
+/** How much of moveCurrent applies to one point mid-drag - the full delta unless axis-masked (a Box's 2 derived corners); [0, 0] if not part of the drag. */
 export const axisMaskedMoveDelta = (
   pointId: string,
   pointIdsBeingMoved: string[] | null,
@@ -184,16 +170,10 @@ type LabelerStoreState = {
   canvasSize: Vector2
   scale: number
   mousePos: Vector2
-  /**
-   * General purpose xy diff applied contextually to some item
-   */
+  /** General-purpose xy diff applied contextually to some item. */
   moveCurrent: Vector2
   pointIdsBeingMoved: string[] | null
-  /** Parallel array to pointIdsBeingMoved: which axis of moveCurrent each point gets.
-   *  null (or a missing entry) means that point gets the full (dx, dy) - the default for
-   *  polygon vertices and whole-annotation moves. Only a box's 2 derived corner handles
-   *  (top-right/bottom-left) need per-point axis splitting, since dragging one moves one
-   *  real point's x and the other real point's y rather than both axes of a single point. */
+  /** Parallel to pointIdsBeingMoved - which axis each point gets; null means both (the default outside a Box's 2 derived corners). */
   pointIdsBeingMovedAxis: ('x' | 'y' | 'xy')[] | null
   annotationIdBeingMoved: string | null
   mode: LabelerMode
@@ -202,8 +182,6 @@ type LabelerStoreState = {
   sample: OptimisticSample | null
 
   readonly annotationsPendingDelete: Set<string>
-  // readonly activeHitIds: Set<string>
-  // readonly availableHitIds: Set<string>
   readonly hitTestCanvas: OffscreenCanvas
 
   isDragging: boolean
@@ -214,23 +192,13 @@ type LabelerStoreState = {
   selectedLabelId: string
   annotationBeingCreated: INewAnnotation | null
   readonly labelsMap: Record<string, ILabel>
-  // hitHandlers: Map<string,(e: unknown) => void>
 
-  /** Whether the mouse is anywhere over the AnnotationsDrawer's row list - drives
-   *  whether the canvas is dimmed at all. Deliberately broader than hoveredAnnotationId:
-   *  keying the dim itself off a specific row would flicker off/on every time the mouse
-   *  crosses the gap between two rows (or a group header) on its way from one to
-   *  another - this way the dim stays on continuously across the whole drawer, and only
-   *  the spotlighted shape changes as hoveredAnnotationId changes underneath it. */
+  /** Whether the mouse is over the AnnotationsDrawer's row list - drives the canvas dim; broader than hoveredAnnotationId to avoid flicker between rows. */
   isAnnotationsDrawerHovered: boolean
-  /** The annotation whose row is currently hovered, if any - drives which shape (if any)
-   *  gets cut out of the dim/gets its outline emphasized. Not the same as
-   *  selectedAnnotation, which persists across mouse movement. */
+  /** The currently row-hovered annotation, if any - unlike selectedAnnotation, doesn't persist across mouse movement. */
   hoveredAnnotationId: string | null
 
-  /** Per-sample undo/redo history - cleared on setSample (see there). Each entry captures
-   *  enough before/after data to replay a single create/delete/points/relabel mutation in
-   *  either direction via the shared apply* primitives (see undo/redo). */
+  /** Per-sample undo/redo history, cleared on setSample. */
   readonly undoStack: HistoryEntry[]
   readonly redoStack: HistoryEntry[]
 }
@@ -271,16 +239,13 @@ type LabelerStoreActions = {
   preDraw: () => void
   onCanvasResize: (width: number, height: number) => void
   setSample: (sample: OptimisticSample) => void
-  /** Aborts an in-flight bitmap load without starting a new one - for leaving the page
-   *  mid-load, as opposed to setSample's own abort-then-restart when switching samples. */
+  /** Aborts an in-flight bitmap load without restarting it - for leaving the page mid-load. */
   cancelPendingSampleLoad: () => void
   onBitmapLoaded: (bitmap: ImageBitmap) => void
-  //onMouseOver: (x: number, y: number) => void
   zoom: (x: number, y: number, delta: number) => void
   zoomIn: (anchor?: 'center' | 'mouse') => void
   zoomOut: (anchor?: 'center' | 'mouse') => void
   setZoom: (zoom: number) => void
-  //setAnnotations: (annotations: IAnnotation[]) => void
   setMode: (mode: LabelerMode) => void
   setLabelId: (labelId: string) => void
   selectAnnotation: (id: string | null) => void
@@ -319,33 +284,15 @@ export const useLabeler = (labels: ILabel[]) => {
         let activeSampleAbort: AbortController | null = null
         const imageHitId = colorGenerator.make()
         const labelsMap = createLabelsMap(labels)
-        // const activeHitIds = new Set([imageHitId])
-        // const availableHitIds = new Set<string>()
         const hitIdToAnnotationId = new OneToOneMap<string, string>()
         const selectedAnnotationControlHitIds = new OneToOneMap<string, string>()
         const selectedAnnotationLineHitIds = new OneToOneMap<string, string>()
 
         const makeHitId = () => {
-          // const pooledId = availableHitIds.values().next().value
-          // if (pooledId !== undefined) {
-          //   availableHitIds.delete(pooledId)
-          //   activeHitIds.add(pooledId)
-          //   return pooledId
-          // }
-
-          // let color = randomHexColor()
-          // while (activeHitIds.has(color)) {
-          //   color = randomHexColor()
-          // }
-
-          // activeHitIds.add(color)
-          // return color
           return colorGenerator.make()
         }
 
         const freeHitId = (id: string) => {
-          // activeHitIds.delete(id)
-          // availableHitIds.add(id)
           colorGenerator.free(id)
         }
 
@@ -362,14 +309,7 @@ export const useLabeler = (labels: ILabel[]) => {
           selectedAnnotationLineHitIds.clear()
         }
 
-        /** Rebuilds selectedAnnotationControlHitIds/selectedAnnotationLineHitIds from
-         *  scratch for `annotation` - the single source of truth for what a selected
-         *  annotation's hit ids should look like, shared by selectAnnotation and any
-         *  primitive that swaps out a selected annotation's points/type in place
-         *  (replacePoints, type conversion). A Box's derived corner and edge sentinel
-         *  handles only ever get set up here - they're not per-point, so a naive
-         *  "re-add each real point" resync (as addSelectedAnnotationPointId does for
-         *  Polygon) would silently lose them. */
+        /** Rebuilds a selected annotation's hit ids from scratch - a Box's derived corner/edge handles only ever get set up here, not per-point. */
         const rebuildSelectedAnnotationHitIds = (annotation: IAnnotation) => {
           clearSelectedAnnotationHitIds()
 
@@ -470,17 +410,6 @@ export const useLabeler = (labels: ILabel[]) => {
           } satisfies INewAnnotation
         }
 
-        // const applyPointSnapshot = (annotation: IAnnotation, points: IPoint[]) => {
-        //   const pointMap = new Map(points.map((p) => [p.id, p]))
-        //   for (const point of annotation.points) {
-        //     const replacement = pointMap.get(point.id)
-        //     if (replacement !== undefined) {
-        //       point.x = replacement.x
-        //       point.y = replacement.y
-        //     }
-        //   }
-        // }
-
         const fitBitmapToCanvas = () => {
           const state = get()
           if (state.bitmap === null) {
@@ -521,16 +450,11 @@ export const useLabeler = (labels: ILabel[]) => {
           return getCanvasCenter()
         }
 
-        /** Records an undoable mutation and drops any redo history - matches standard
-         *  editor UX (a new edit invalidates whatever was undone before it). Only called by
-         *  the 4 public mutation actions, never by undo()/redo() themselves (those manage
-         *  the two stacks directly so undoing/redoing doesn't clear the other stack). */
+        /** Records an undoable mutation and drops redo history, like standard editor undo. */
         const pushHistory = (entry: HistoryEntry) =>
           set((state) => ({ undoStack: [...state.undoStack, entry], redoStack: [] }))
 
-        /** Optimistically creates `annotation`, then persists it - shared by
-         *  onConfirmAnnotationCreation (a brand new annotation) and undo/redo (replaying a
-         *  previously deleted/created annotation, id and all). */
+        /** Optimistically creates annotation then persists it - shared by creation and undo/redo. */
         const applyCreateAnnotation = (annotation: IAnnotation) => {
           const state = get()
           if (state.sample === null) return
@@ -562,9 +486,7 @@ export const useLabeler = (labels: ILabel[]) => {
             })
         }
 
-        /** Optimistically removes the annotation with id annotationId, then persists the
-         *  delete - shared by deleteAnnotation and undo/redo (undoing a create, or redoing a
-         *  delete). */
+        /** Optimistically removes annotationId then persists the delete - shared by deleteAnnotation and undo/redo. */
         const applyDeleteAnnotation = (annotationId: string) => {
           const state = get()
           const annotations = state.sample?.resolve().annotations
@@ -612,14 +534,7 @@ export const useLabeler = (labels: ILabel[]) => {
             })
         }
 
-        /** Optimistically replaces an annotation's full points array, then persists it -
-         *  the shared primitive behind commitAnnotationMove, addControlPoint,
-         *  deleteControlPoint, and undo/redo of any of those (a move only ever changes
-         *  existing points' coordinates, while add/delete-control-point also changes which
-         *  point ids exist - replacePoints' id-diffing on the main-process side handles
-         *  both the same way, so one primitive covers all of them). Always resyncs the
-         *  selected annotation's hit ids afterward, since the point id set may have
-         *  changed. */
+        /** Optimistically replaces an annotation's points then persists it - shared by move/add/delete-control-point and their undo/redo; resyncs hit ids after. */
         const applyReplacePoints = (annotationId: string, points: IPoint[]) => {
           const state = get()
           const annotation = state.sample?.resolve().annotations.resolve()[annotationId]
@@ -649,11 +564,7 @@ export const useLabeler = (labels: ILabel[]) => {
             })
         }
 
-        /** Optimistically relabels an annotation, then persists it - shared by
-         *  setAnnotationLabelId and undo/redo. Also keeps the label picker in sync if the
-         *  relabeled annotation is the one currently selected, mirroring selectAnnotation's
-         *  own sync - otherwise relabeling via the context menu (or undoing/redoing one)
-         *  would leave the picker showing a label the selection no longer has. */
+        /** Optimistically relabels an annotation then persists it - also syncs the label picker if it's the selected annotation. */
         const applyRelabel = (annotationId: string, labelId: string) => {
           const state = get()
           const targetAnnotation =
@@ -684,12 +595,7 @@ export const useLabeler = (labels: ILabel[]) => {
             })
         }
 
-        /** Optimistically swaps an annotation's type and points together (one atomic
-         *  diff), then persists both - shared by convertAnnotationType and undo/redo of a
-         *  conversion. Persistence is still 2 separate IPC calls (updateAnnotations only
-         *  touches type/labelId, replacePoints only touches points), fired concurrently
-         *  and committed/rolled back together so the optimistic view never shows a
-         *  half-converted annotation (new type, stale points or vice versa). */
+        /** Optimistically swaps an annotation's type+points atomically then persists both via 2 concurrent calls, committed/rolled back together. */
         const applyConvertType = (annotationId: string, type: AnnotationType, points: IPoint[]) => {
           const state = get()
           const annotation = state.sample?.resolve().annotations.resolve()[annotationId]
@@ -721,9 +627,7 @@ export const useLabeler = (labels: ILabel[]) => {
             })
         }
 
-        /** A Box's own 2 real points (top-left/bottom-right, per normalizeAnnotationPoints)
-         *  become a Polygon's 4 corner points - fresh point ids throughout, since a
-         *  Polygon needs more points than a Box ever has. */
+        /** A Box's 2 points become a Polygon's 4 corners, with fresh point ids. */
         const boxPointsToPolygonPoints = (points: IPoint[]): IPoint[] => {
           const [topLeft, bottomRight] = points
           return [
@@ -734,10 +638,7 @@ export const useLabeler = (labels: ILabel[]) => {
           ]
         }
 
-        /** A Polygon's outline is reduced to its axis-aligned bounding box - necessarily
-         *  lossy (a non-rectangular outline can't survive becoming a Box), reusing the
-         *  same boundingBoxOf the exporters already rely on for the same "give every
-         *  annotation a rectangle" reduction. */
+        /** A Polygon reduces to its axis-aligned bounding box - necessarily lossy for a non-rectangular outline. */
         const polygonPointsToBoxPoints = (points: IPoint[]): IPoint[] => {
           const box = boundingBoxOf(points)
           return [
@@ -749,20 +650,11 @@ export const useLabeler = (labels: ILabel[]) => {
         const DUPLICATE_OFFSET_RATIO = 0.08
         const DUPLICATE_OFFSET_MIN = 12
 
-        /** How far a duplicate is nudged from its original, scaled to the source
-         *  annotation's own size (not the image's) so a tiny annotation still gets a
-         *  clearly visible offset and a huge one doesn't jump by an absurd amount -
-         *  floored so a degenerate (near-zero-area) annotation still visibly offsets. */
+        /** How far a duplicate is nudged, scaled to its own size so tiny/huge annotations both offset sensibly. */
         const duplicateOffsetFor = (box: BoundingBox): number =>
           Math.max(DUPLICATE_OFFSET_MIN, Math.max(box.width, box.height) * DUPLICATE_OFFSET_RATIO)
 
-        /** Picks how far to nudge one axis of a duplicate so its whole bounding box stays
-         *  inside [0, extent] - prefers the default positive (down/right) direction, falls
-         *  back to negative (up/left) when that side is the one with room, and only falls
-         *  short of `desired` when the source annotation is close enough to the image's
-         *  full size that neither side has room for it. Always a single scalar applied
-         *  uniformly to every point (see duplicateAnnotation), never a per-point clamp, so
-         *  the duplicate is nudged less far (or the other way) rather than distorted. */
+        /** Nudges a duplicate's axis by desired, flipping direction or shrinking it to keep the bounding box inside [0, extent]. */
         const clampedDuplicateAxisOffset = (
           min: number,
           size: number,
@@ -776,10 +668,7 @@ export const useLabeler = (labels: ILabel[]) => {
           return spaceAfter >= spaceBefore ? spaceAfter : -spaceBefore
         }
 
-        /** Undoing a just-created annotation before its createAnnotations call has
-         *  resolved races the resulting deleteAnnotations call server-side - a pre-existing
-         *  class of risk (the same as a fast create-then-delete via the UI today), not
-         *  introduced or fixed by undo/redo. */
+        /** Undoing a just-created annotation before its create call resolves can race the delete - pre-existing risk, not new. */
         const applyHistoryInverse = (entry: HistoryEntry) => {
           switch (entry.kind) {
             case 'create':
@@ -821,11 +710,8 @@ export const useLabeler = (labels: ILabel[]) => {
           canvasSize: [0, 0],
           scale: 1,
           mousePos: [0, 0],
-          //annotations: new Map(),
           mode: LabelerMode.Select,
           showHitTestDebugOverlay: false,
-          // activeHitIds,
-          // availableHitIds,
           hitTestCanvas: new OffscreenCanvas(0, 0),
           isDragging: false,
           selectedAnnotation: null,
@@ -833,7 +719,6 @@ export const useLabeler = (labels: ILabel[]) => {
           selectedAnnotationControlHitIds,
           selectedAnnotationLineHitIds,
           annotationsPendingDelete: new Set(),
-          //annotationsPendingAdd: new Set(),
           selectedLabelId: labels[0]?.id ?? '',
           annotationBeingCreated: null,
           labelsMap,
@@ -895,12 +780,7 @@ export const useLabeler = (labels: ILabel[]) => {
             set({
               mousePos: [x, y],
               annotationBeingCreated: annotationBeingCreated,
-              // OR'd with the current flag, never overwritten to false here - clearing
-              // dirty flags is preDraw()'s job exclusively. This listens globally (see
-              // usePointerMove), so it fires on every mouse move across the whole app;
-              // unconditionally overwriting annotationDirty raced with (and could
-              // silently clobber) a `true` some other action - e.g. the AnnotationsDrawer's
-              // hover spotlight - had just set moments earlier but hadn't been painted yet.
+              // OR'd, never overwritten to false - only preDraw() clears dirty flags.
               annotationDirty: state.annotationDirty || changed || inCreateMode
             })
           },
@@ -1004,9 +884,7 @@ export const useLabeler = (labels: ILabel[]) => {
               selectedAnnotation: annotation,
               annotationDirty: true,
               hitTestDirty: true,
-              // Selecting an existing annotation switches the label picker to match it -
-              // deselecting (annotation === null) leaves it alone rather than resetting to
-              // some default, since there's nothing meaningful to switch it to.
+              // Selecting an annotation syncs the label picker; deselecting leaves it alone.
               ...(annotation !== null ? { selectedLabelId: annotation.resolve().labelId } : {})
             })
           },
@@ -1164,12 +1042,10 @@ export const useLabeler = (labels: ILabel[]) => {
             ) {
               const boxPoints = state.selectedAnnotation.resolve().points
               if (boxPoints.length !== 2) return
-              // Normalized by normalizeAnnotationPoints, so points[0] is always
-              // top-left and points[1] is always bottom-right.
+              // Normalized: points[0] is top-left, points[1] is bottom-right.
               const [topLeft, bottomRight] = boxPoints
               const isTopRight = pointId === BOX_CORNER_HANDLE_TOP_RIGHT
-              // Top-right's x is the right edge (bottomRight.x); its y is the top edge
-              // (topLeft.y). Bottom-left is the mirror: left edge's x, bottom edge's y.
+              // Top-right takes the right edge's x and top edge's y; bottom-left is the mirror.
               const xSource = isTopRight ? bottomRight : topLeft
               const ySource = isTopRight ? topLeft : bottomRight
 
@@ -1192,8 +1068,7 @@ export const useLabeler = (labels: ILabel[]) => {
             ) {
               const boxPoints = state.selectedAnnotation.resolve().points
               if (boxPoints.length !== 2) return
-              // Normalized by normalizeAnnotationPoints, so points[0] is always
-              // top-left and points[1] is always bottom-right.
+              // Normalized: points[0] is top-left, points[1] is bottom-right.
               const [topLeft, bottomRight] = boxPoints
               const isTopOrLeft = pointId === BOX_EDGE_TOP || pointId === BOX_EDGE_LEFT
               const source = isTopOrLeft ? topLeft : bottomRight
@@ -1454,8 +1329,7 @@ export const useLabeler = (labels: ILabel[]) => {
             if (state.isAnnotationsDrawerHovered === hovered) return
             set({
               isAnnotationsDrawerHovered: hovered,
-              // Leaving the drawer entirely always clears whichever row was hovered too -
-              // belt-and-suspenders alongside each row's own onMouseLeave.
+              // Belt-and-suspenders alongside each row's own onMouseLeave.
               hoveredAnnotationId: hovered ? state.hoveredAnnotationId : null,
               annotationDirty: true
             })

--- a/src/renderer/src/hooks/useTasks.ts
+++ b/src/renderer/src/hooks/useTasks.ts
@@ -4,8 +4,6 @@ import { makeUUID } from '@shared/utils'
 import { useCallback } from 'react'
 import { useAppStore } from './useAppStore'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-//import toast from 'react-hot-toast'
-//toast.promise()
 
 export const useTasks = (project: IProject) => {
   const store = useAppStore((s) => s.store)

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,8 +3,6 @@
 import '@mantine/core/styles.css'
 import '@mantine/dropzone/styles.css'
 import 'mantine-contextmenu/styles.css'
-// import '@mantine/modals/styles.css'
-// import '@mantine/notifications/styles.css'
 import './assets/main.css'
 import { Toaster } from 'react-hot-toast'
 import { StrictMode } from 'react'

--- a/src/renderer/src/routes/label/LabelPage.tsx
+++ b/src/renderer/src/routes/label/LabelPage.tsx
@@ -33,8 +33,6 @@ const Container = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  /* display: flex;
-  flex-direction: column; */
 `
 const StyledLabeler = styled(Labeler)`
   width: 100%;
@@ -137,7 +135,6 @@ const TextSegmentedControl = ({
           display: 'flex'
         },
         control: {
-          // aspectRatio: 1,
           display: 'flex'
         }
       }}
@@ -394,7 +391,7 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
           return Promise.resolve()
         }}
       />
-      <Flex style={{ position: 'absolute', bottom: 20, left: 20 }} gap={'md'}>
+      <Flex style={{ position: 'absolute', bottom: 20, left: 20 }} align={'center'} gap={'md'}>
         <LabelerModeControl value={mode} onChange={(e) => store.getState().setMode(e)} />
 
         {currentSampleId && (


### PR DESCRIPTION
## Summary
- Removed orphaned commented-out code:
  - `src/renderer/src/hooks/useAppStore.ts`: an entire legacy store implementation (superseded by the current `IpcDataStore` + react-query hooks approach)
  - `src/main/ipc.ts`: two unused `wrap()` variants and dead lines inside the live `handleIpc`
  - `src/renderer/src/hooks/useLabeler.ts`: dead hit-id pooling fallback logic (superseded by `ColorGenerator`) and an unused `applyPointSnapshot` helper
  - `src/renderer/src/routes/label/LabelPage.tsx`: duplicate CSS in a styled-component (`display: flex; flex-direction: column;` was both live and commented out directly below itself) and a commented-out `aspectRatio` line
  - `src/renderer/src/components/Labeler.tsx`, `src/renderer/src/main.tsx`, `src/renderer/src/hooks/useTasks.ts`: assorted single dead lines/imports
- Trimmed ~25 multi-line JSDoc/comment blocks in `useLabeler.ts` and `Labeler.tsx` down to one line each - no loss of the actual WHY, just cut the elaboration

Purely a cleanup pass - no behavior changes.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (467 tests passing)
- [ ] `pnpm lint` currently fails on this branch, but that's inherited from `master` - see the separate lint-break issue I'm about to report, unrelated to this diff