### PR TITLE
Fix the 2 lint errors introduced by the eslint-plugin-react-hooks bump

### DIFF
--- a/src/renderer/src/components/BasicListPage.tsx
+++ b/src/renderer/src/components/BasicListPage.tsx
@@ -17,20 +17,6 @@ const TopArea = styled.div`
   /* padding: 0% max(20%, 100px); */
 `
 
-// Shared by every list page's toolbar (Projects/Tasks/Samples): a left-hand action-button
-// group and a right-hand filter/search group. flex-wrap lets the right group drop to its
-// own line instead of being squeezed off-screen once the left group grows past one row
-// (e.g. select mode's batch action buttons) - TopArea's fixed width doesn't grow with them.
-export const BasicListPageTopBar = styled.div`
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-`
-
 const ContentArea = styled.div`
   display: flex;
   flex: 1;

--- a/src/renderer/src/components/BasicListPageTopBar.tsx
+++ b/src/renderer/src/components/BasicListPageTopBar.tsx
@@ -1,0 +1,15 @@
+import { styled } from '@linaria/react'
+
+// Shared by every list page's toolbar (Projects/Tasks/Samples): a left-hand action-button
+// group and a right-hand filter/search group. flex-wrap lets the right group drop to its
+// own line instead of being squeezed off-screen once the left group grows past one row
+// (e.g. select mode's batch action buttons) - TopArea's fixed width doesn't grow with them.
+export const BasicListPageTopBar = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`

--- a/src/renderer/src/components/Labeler.tsx
+++ b/src/renderer/src/components/Labeler.tsx
@@ -659,6 +659,7 @@ const useCanvasDraw = (
   annotationCanvas: RefObject<HTMLCanvasElement | null>,
   crosshairCanvas: RefObject<HTMLCanvasElement | null>
 ) => {
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- refs/store are stable; deps track identity, not .current
   const drawCanvases = useCallback(() => {
     const imageCanvasElement = imageCanvas.current
     const annotationCanvasElement = annotationCanvas.current

--- a/src/renderer/src/router/makeRouter.tsx
+++ b/src/renderer/src/router/makeRouter.tsx
@@ -14,8 +14,7 @@ import { makeUUID } from '@shared/utils'
 export type RouteParamsMap = Record<string, unknown>
 
 type NavigateArgs<Routes extends RouteParamsMap, K extends keyof Routes> = Routes[K] extends
-  | undefined
-  | void
+  undefined | void
   ? [screen: K]
   : [screen: K, params: Routes[K]]
 

--- a/src/renderer/src/routes/projects/ProjectsPage.tsx
+++ b/src/renderer/src/routes/projects/ProjectsPage.tsx
@@ -1,4 +1,5 @@
-import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
+import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPageTopBar } from '@renderer/components/BasicListPageTopBar'
 import {
   BasicListPageItem,
   BasicListPageItemSkeleton

--- a/src/renderer/src/routes/samples/SamplesPage.tsx
+++ b/src/renderer/src/routes/samples/SamplesPage.tsx
@@ -1,4 +1,5 @@
-import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
+import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPageTopBar } from '@renderer/components/BasicListPageTopBar'
 import { ConfirmDeleteModal } from '@renderer/components/ConfirmDeleteModal'
 import { RenameModal } from '@renderer/components/RenameModal'
 import {

--- a/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
+++ b/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
@@ -14,7 +14,8 @@ import {
 import { IoMdArrowBack } from 'react-icons/io'
 import type { IProject, ITask } from '@shared/types'
 import { AsyncButton } from '@renderer/components/AsyncButton'
-import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
+import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPageTopBar } from '@renderer/components/BasicListPageTopBar'
 import { useAppStore } from '@renderer/hooks/useAppStore'
 import { useTasks } from '@renderer/hooks/useTasks'
 import {

--- a/src/renderer/src/routes/tasks/TasksPage.tsx
+++ b/src/renderer/src/routes/tasks/TasksPage.tsx
@@ -1,4 +1,5 @@
-import { BasicListPage, BasicListPageTopBar } from '@renderer/components/BasicListPage'
+import { BasicListPage } from '@renderer/components/BasicListPage'
+import { BasicListPageTopBar } from '@renderer/components/BasicListPageTopBar'
 import {
   BasicListPageItem,
   BasicListPageItemSkeleton


### PR DESCRIPTION
## Summary
`master`'s lint is currently broken (confirmed - not caused by anything in this session's other PRs). The auto-merged grouped dependency PR (#31) bumped `eslint-plugin-react-hooks` to v7 and `eslint-plugin-react-refresh`, which introduced/tightened 2 rules that now fail on pre-existing code. CI never runs `pnpm lint` or `pnpm typecheck` as required checks - only unit tests - so this landed silently.

- **`react-refresh/only-export-components`**: `BasicListPage.tsx` exported both the `BasicListPage` component and a styled-component constant (`BasicListPageTopBar`), which breaks Fast Refresh's single-component-per-file assumption. Moved `BasicListPageTopBar` into its own file (`BasicListPageTopBar.tsx`), per the rule's own suggested fix, and updated its 4 consumers (`TasksPage`, `SamplesPage`, `ProjectsPage`, `CopyAnnotationsPage`).
- **`react-hooks/preserve-manual-memoization`**: a new React-Compiler-powered rule in `Labeler.tsx`'s `drawCanvases` `useCallback`. Its deps list ref/store *identities* (all stable across the component's lifetime), but the callback body reads `.current` off those refs - the compiler infers deps from the property access instead and can't reconcile the two. The array as written is correct (refs are conventionally excluded from dependency comparison, and `drawCanvases`'s stable identity is actually relied on by another effect at line ~1021), so disabled the rule for that one line with an explanation, matching this file's existing precedent for a similar `react-hooks/immutability` false-positive on intentional ref access a few lines below.
- Also fixed an unrelated prettier-only warning in `makeRouter.tsx`, same root cause (a formatting-adjacent rule got stricter).

## Test plan
- [x] `pnpm lint` - 0 errors (2 pre-existing, unrelated warnings in `useTags.ts` remain)
- [x] `pnpm typecheck`
- [x] `pnpm test` (467 passing)