### PR TITLE
Add required Typecheck and Lint CI checks, with lint auto-fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,30 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup pnpm
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
-        with:
-          install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run unit tests
-        run: pnpm exec vitest run
-
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
@@ -68,6 +44,7 @@ jobs:
 
   lint:
     name: Lint
+    needs: typecheck
     runs-on: ubuntu-latest
     # Needs write access to push auto-fixes back - a fork PR's token stays read-only regardless.
     permissions:
@@ -107,3 +84,28 @@ jobs:
       # Reports the real pass/fail after auto-fixing - catches whatever --fix couldn't.
       - name: Lint
         run: pnpm lint
+
+  unit-tests:
+    name: Unit tests
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm exec vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,69 @@ jobs:
 
       - name: Run unit tests
         run: pnpm exec vitest run
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    # Needs write access to push auto-fixes back - a fork PR's token stays read-only regardless.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Auto-fix and commit
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          pnpm eslint --fix . || true
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Auto-fix lint issues"
+            git push
+          fi
+
+      # Reports the real pass/fail after auto-fixing - catches whatever --fix couldn't.
+      - name: Lint
+        run: pnpm lint


### PR DESCRIPTION
## Summary
CI only ran unit tests before this - a lint or type error could land on `master` completely undetected, which is exactly what happened with #31 (the auto-merged grouped dependency bump that broke lint via a new `eslint-plugin-react-hooks` rule - see #38).

- **Typecheck**: new job, just `pnpm typecheck`. Type errors aren't mechanically fixable, so this only reports pass/fail.
- **Lint**: new job that runs `pnpm eslint --fix .` first, and if that changed anything, commits and pushes it back to the PR branch (guarded to same-repo PRs only - a fork PR's token is read-only regardless, matching the fork-safety pattern already used in `dependabot-auto-merge.yml`/`comment-approve.yml`). Then runs a final unfixed `pnpm lint` to report the real pass/fail - whatever `--fix` couldn't resolve (like the React Compiler memoization error from #38) still fails the check.

Tested locally: `eslint --fix .` on the current (pre-#38) lint-broken state correctly auto-fixed the prettier issue in `makeRouter.tsx` and left the 2 real errors (`BasicListPage.tsx`, `Labeler.tsx`) failing, confirming the split works as intended.

## Follow-up needed after merge
Once this lands and runs at least once (so the check names exist), branch protection on `master` needs "Typecheck" and "Lint" added to required status checks, alongside the existing "Unit tests" - I'll do that once this is merged, since GitHub needs the checks to have reported at least once first.

## Test plan
- [x] Verified `eslint --fix .` + final `pnpm lint` split locally against the known-broken lint state from #31
- [ ] Watch this PR's own Lint job run for real once pushed