### PR TITLE
Trim verbose comments across the full codebase

### DIFF
--- a/src/main/appDatabase.ts
+++ b/src/main/appDatabase.ts
@@ -14,9 +14,7 @@ console.log('App database loaded into worker', APP_PATH)
 assert(APP_PATH !== undefined, 'APP_PATH global was not defined')
 assert(MIGRATIONS_PATH !== undefined, 'MIGRATIONS_PATH global was not defined')
 
-// Sibling to store/database/data.db (see database.ts) - app-level data lives independently
-// of whichever IDataStore is currently active, so it gets its own top-level folder rather
-// than nesting under store/.
+// Sibling to store/database/data.db - app-level data lives independently of whichever IDataStore is active, so it gets its own top-level folder.
 const appPath = path.join(APP_PATH, 'app')
 const databasePath = path.join(appPath, 'database', 'app.db')
 
@@ -96,5 +94,4 @@ const appDatabase = {
   }
 }
 
-// named exports (bindings)
 export const { getAnnotators, createAnnotator, updateAnnotators, deleteAnnotators } = appDatabase

--- a/src/main/appSchema.ts
+++ b/src/main/appSchema.ts
@@ -1,8 +1,6 @@
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-/** Store-agnostic and project-agnostic - an annotator is just connection info (name/url/
- *  headers). Its label vocabulary and mapping against a project's labels are never
- *  persisted - see ExternalAnnotator.ts / useAnnotatorRuntime.ts. */
+/** Store-agnostic and project-agnostic - just connection info. Label vocabulary/mapping is never persisted, see ExternalAnnotator.ts / useAnnotatorRuntime.ts. */
 export const annotators = sqliteTable('annotators', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),

--- a/src/main/appStore.ts
+++ b/src/main/appStore.ts
@@ -5,10 +5,7 @@ import appDatabaseWorkerPath from './appDatabase?modulePath'
 import { IAnnotator, IAnnotatorUpdate, IAppDataStore, IPCKeys } from '../shared/types'
 import { handleIpc } from './ipc'
 
-/** The always-on, store-agnostic counterpart to LocalStore - annotators live in their own
- *  database, independent of whichever IDataStore is currently active (see
- *  storeOrchestrator.ts), so this is instantiated once and never registered with it.
- *  Lazily spawns its worker on first real use, same as LocalStore.ensureWorker(). */
+/** The always-on, store-agnostic counterpart to LocalStore - annotators live in their own database, instantiated once and never registered with storeOrchestrator. Lazily spawns its worker on first use. */
 export class AppStore implements IAppDataStore {
   #workerPromise?: Promise<typeof import('./appDatabase') & { terminate(): Promise<number> }>
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -57,9 +57,7 @@ const makeImageUri = (id: string, extension: string) => {
   return `image://${LOCAL_STORE_ID}/${id}.${extension}`
 }
 
-/** Takes just the `<id>.<ext>` segment (the image:// URL's pathname, minus the leading
- *  slash) - the storeId/scheme parsing happens once, centrally, in the orchestrator's
- *  protocol.handle before this store is ever consulted. */
+/** Takes just the `<id>.<ext>` segment - storeId/scheme parsing happens once, centrally, in the orchestrator's protocol.handle before this store is ever consulted. */
 export const getImagePathForId = async (idWithExtension: string) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [id, _] = idWithExtension.split('.') as [string, string]
@@ -72,31 +70,20 @@ export const getImagePathForId = async (idWithExtension: string) => {
   return path.join(imagesPath, `${imageInfo.hash}.${imageInfo.extension}`)
 }
 
-/** A Node Readable can't cross the worker_threads postMessage boundary, so unlike every
- *  other export here this is never called through the RPC proxy from main - only from
- *  exportSamplesToArchive, in the same worker module. A future non-local IDataStore
- *  implementation would swap this for e.g. an HTTP GET response stream; nothing that
- *  consumes it needs to know which. */
+/** A Node Readable can't cross the worker_threads postMessage boundary - unlike everything else here, never called through the RPC proxy from main, only from exportSamplesToArchive in the same worker. */
 export const getImageStream = async (imageUri: string) => {
   const filePath = await getImagePathForId(new URL(imageUri).pathname.slice(1))
   return filePath === undefined ? undefined : createReadStream(filePath)
 }
 
-// How many image entries can be mid-append (file open, being read/compressed/written) at
-// once. archive.append() only queues an entry and returns immediately, so appending every
-// entry back to back with no bound would open one file descriptor per image up front -
-// fine for a handful of samples, but risks exhausting file descriptors (EMFILE) on
-// datasets with thousands of images. This bounds that to a fixed window instead of either
-// extreme (unbounded, or strictly one-at-a-time).
+// Bounds how many image entries can be mid-append at once - unbounded risks exhausting file descriptors (EMFILE) on large datasets.
 const DEFAULT_EXPORT_CONCURRENCY = 10
 
 export const exportSamplesToArchive = async (
   destinationPath: string,
   manifest: ArchiveManifest,
   concurrency: number = DEFAULT_EXPORT_CONCURRENCY,
-  // Must stay the last parameter: the worker-RPC layer detects a trailing function
-  // argument as an out-of-band progress callback (see main/worker/index.ts) and strips it
-  // before the call crosses into the worker.
+  // Must stay last - the worker-RPC layer detects a trailing function as a progress callback and strips it before crossing into the worker.
   onProgress?: (completed: number, total: number) => void
 ): Promise<void> => {
   const archive = archiver('zip', { zlib: { level: 9 } })
@@ -110,15 +97,11 @@ export const exportSamplesToArchive = async (
 
   archive.pipe(output)
 
-  // Progress is tracked against the manifest's own (fixed, known-upfront) entry count
-  // rather than archiver's own 'progress' event, which only reflects entries queued so far
-  // and would understate the real dataset size while entries are still being appended.
+  // Tracked against the manifest's fixed entry count, not archiver's own 'progress' event, which understates the total while entries are still being appended.
   const total = manifest.textEntries.length + manifest.imageEntries.length
   let completed = 0
 
-  // With several appends in flight at once, archiver's 'entry' event (fired per completed
-  // entry) can't be matched to the right pending promise by registration order - a single
-  // persistent listener correlates each event to its own append by name instead.
+  // With several appends in flight, archiver's 'entry' event can't be matched to the right pending promise by registration order - correlate by name instead.
   const pendingByName = new Map<string, () => void>()
   archive.on('entry', (entryData) => {
     const resolve = pendingByName.get(entryData.name)
@@ -170,8 +153,7 @@ function fetchSampleWithRelations(id: string) {
 // Row shape returned by the sample relational query above (id/image/annotations/points).
 type SampleWithRelationsRow = NonNullable<Awaited<ReturnType<typeof fetchSampleWithRelations>>>
 
-/** Images written before the width/height columns existed have them as null - backfill
- *  lazily on first read rather than a blocking startup migration over every existing file. */
+/** Images written before width/height existed have them as null - backfilled lazily on first read, not a blocking startup migration. */
 const imageDimensions = async (
   image: SampleWithRelationsRow['image']
 ): Promise<{ width: number; height: number }> => {
@@ -229,9 +211,7 @@ const ingestScratchImage = async (imagePath: string): Promise<ImageMetadata> => 
   }
 }
 
-/** Moves a scratch file into the store, falling back to copy+unlink when the scratch
- *  directory (os.tmpdir()) isn't on the same filesystem/drive as the store - fs.rename
- *  throws EXDEV in that case rather than silently failing, so this must not be skipped. */
+/** Falls back to copy+unlink when the scratch dir isn't on the same filesystem/drive as the store - fs.rename throws EXDEV in that case. */
 const moveOrCopyFile = async (source: string, destination: string): Promise<void> => {
   try {
     await fs.rename(source, destination)
@@ -245,9 +225,7 @@ const moveOrCopyFile = async (source: string, destination: string): Promise<void
   }
 }
 
-/** Consumes every scratch file referenced by samples: moves the ones behind a newly
- *  inserted image into the store, and discards the rest (their content is already
- *  covered by an existing store file, per insertedImagesIndex). */
+/** Moves scratch files behind a newly inserted image into the store; discards the rest, already covered by an existing store file per insertedImagesIndex. */
 const consumeScratchFiles = async (
   samples: INewSample[],
   images: ImageMetadata[],

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -197,8 +197,7 @@ const mapSampleRow = async (row: SampleWithRelationsRow): Promise<ISample> => {
 
 type ImageMetadata = { hash: string; extension: string; width: number; height: number }
 
-// Bounds in-flight file handles/hashes during ingestion instead of processing a whole
-// import batch (which can run into the thousands of images) at once.
+// Bounds in-flight file handles/hashes instead of processing a whole (possibly thousands-strong) import batch at once.
 const INGEST_CONCURRENCY = 8
 
 const ingestScratchImage = async (imagePath: string): Promise<ImageMetadata> => {
@@ -381,16 +380,14 @@ const localStore: IDataStore = {
         }
 
         for (const label of update.labels ?? []) {
-          // Scoped to projectId as a defensive check - the renderer only ever sends a project's
-          // own labels back, but this keeps a bad id from silently renaming a label in another project.
+          // Scoped to projectId defensively - keeps a bad id from silently renaming a label in another project.
           const result = tx
             .update(schema.labels)
             .set({ name: label.name, color: label.color })
             .where(and(eq(schema.labels.id, label.id), eq(schema.labels.projectId, update.id)))
             .run()
 
-          // A label id the project doesn't have yet isn't a rename - it's a new label
-          // being added (EditProjectModal's "Add Label"), so insert it instead.
+          // No existing row means this is a new label (EditProjectModal's "Add Label"), not a rename.
           if (result.changes === 0) {
             tx.insert(schema.labels)
               .values({ id: label.id, name: label.name, color: label.color, projectId: update.id })
@@ -424,9 +421,7 @@ const localStore: IDataStore = {
   },
 
   getTasksForProject: async (projectId) => {
-    // count(samples.id) skips the null produced by the left join for a task with no
-    // samples yet; count(samples.completedAt) counts only the non-null (completed) ones -
-    // both fall out of plain SQL COUNT-of-a-column semantics, no CASE/filter needed.
+    // count(samples.id)/count(samples.completedAt) skip nulls by plain SQL COUNT semantics - no CASE/filter needed.
     const taskRows = await db
       .select({
         id: schema.tasks.id,
@@ -444,9 +439,7 @@ const localStore: IDataStore = {
       return []
     }
 
-    // A second, separate query rather than joining task_tags into the query above - that
-    // aggregate already GROUPs by task for the sample counts, and a many-to-many tags join
-    // would multiply rows before the GROUP BY and corrupt those counts.
+    // Separate query, not joined above - a many-to-many tags join would multiply rows before that query's GROUP BY and corrupt the sample counts.
     const tagRows = await db
       .select({
         taskId: schema.taskTags.taskId,
@@ -498,10 +491,7 @@ const localStore: IDataStore = {
   },
 
   createTask: async (projectId, id, name, newSamples = []) => {
-    // Newly created samples never carry a completedAt (INewSample has no such field -
-    // see cvLabelDatasetToSamples etc.), so completedSampleCount is always 0 here -
-    // cheaper than an extra aggregate query for a value we already know. A new task
-    // starts untagged.
+    // Newly created samples never carry a completedAt, so completedSampleCount is always 0 - cheaper than an extra query for a value we already know.
     const task: ITask = {
       id,
       name,
@@ -661,8 +651,7 @@ const localStore: IDataStore = {
   },
 
   updateSamples: async (updates) => {
-    // Read rows and resolve (possibly-backfilled) width/height before the transaction,
-    // since better-sqlite3 transactions run synchronously and sharp's metadata read doesn't.
+    // Resolved before the transaction, since better-sqlite3 transactions run synchronously and sharp's metadata read doesn't.
     const existingRows = updates.map((update) => {
       const row = db.query.samples
         .findFirst({
@@ -806,7 +795,6 @@ const localStore: IDataStore = {
 
   replacePoints: async (annotationId, points) => {
     return db.transaction((tx) => {
-      // Get current points for the annotation
       const currentPoints = tx
         .select({
           id: schema.points.id,
@@ -819,21 +807,17 @@ const localStore: IDataStore = {
         .orderBy(asc(schema.points.sequence))
         .all()
 
-      // Create a map of current points by id
       const currentPointsMap = new Map(currentPoints.map((p) => [p.id, p]))
 
-      // Categorize operations
       const toInsert: { id: string; x: number; y: number; sequence: number }[] = []
       const toUpdate: { id: string; x: number; y: number; sequence: number }[] = []
       const toDelete: string[] = []
 
-      // Process each input point
       for (let sequence = 0; sequence < points.length; sequence++) {
         const pointInput = points[sequence]
         const id = pointInput.id
 
         if (currentPointsMap.has(id)) {
-          // Update existing point
           const existing = currentPointsMap.get(id)!
           toUpdate.push({
             id: id,
@@ -842,7 +826,7 @@ const localStore: IDataStore = {
             sequence: sequence
           })
         } else {
-          // Insert new point - must have x and y
+          // A new point must have x and y.
           if (pointInput.x === undefined || pointInput.y === undefined) {
             throw new Error(`New point with id ${id} missing x or y coordinate`)
           }
@@ -855,7 +839,6 @@ const localStore: IDataStore = {
         }
       }
 
-      // Points to delete: current points not in input
       for (const current of currentPoints) {
         const isInInput = points.some((p) => p.id === current.id)
         if (!isInInput) {
@@ -863,7 +846,6 @@ const localStore: IDataStore = {
         }
       }
 
-      // Perform operations in order: delete, insert, update
       if (toDelete.length > 0) {
         tx.delete(schema.points).where(inArray(schema.points.id, toDelete)).run()
       }
@@ -881,7 +863,6 @@ const localStore: IDataStore = {
           .run()
       }
 
-      // Return the full list of points ordered by sequence
       return tx
         .select({ id: schema.points.id, x: schema.points.x, y: schema.points.y })
         .from(schema.points)
@@ -892,7 +873,6 @@ const localStore: IDataStore = {
   }
 }
 
-// named exports (bindings)
 export const {
   connect,
   disconnect,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,27 +4,16 @@ import { electronApp, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { getAppPath } from './utils'
 
-// Ties Electron's own userData dir (session storage, GPU cache, and - most importantly -
-// the lock file requestSingleInstanceLock() below uses) to the same working directory
-// getAppPath() already scopes the sqlite database/images to, but only once packaged or
-// under an explicit override - plain `pnpm dev` keeps Electron's own default userData
-// location rather than dumping Chromium's session/cache/blob-storage files in the repo
-// root just for running from source. Must run before requestSingleInstanceLock() -
-// Electron reads userData to place its lock file at that point.
-//
-// This makes the single-instance lock per-working-directory rather than global: two
-// packaged instances pointed at the same working directory can't run concurrently
-// (they'd corrupt the same sqlite database), but separate copies of the app in different
-// folders - e.g. a portable install run from two locations - are treated as independent
-// instances and can run side by side. e2e runs always set CV_LABEL_APP_PATH to their own
-// isolated temp dir per run, so they get the same per-working-directory isolation too,
-// unaffected by whichever way the packaged/dev branch goes.
+// Ties Electron's own userData dir (and its single-instance lock file) to the same working
+// directory getAppPath() scopes the database/images to - makes the instance lock
+// per-working-directory rather than global. Only once packaged or under an explicit
+// override, so plain `pnpm dev` keeps Electron's default userData location. Must run
+// before requestSingleInstanceLock() below, which reads userData to place its lock file.
 if (app.isPackaged || process.env.CV_LABEL_APP_PATH) {
   app.setPath('userData', join(getAppPath(), 'userData'))
 }
 
 function createWindow(): void {
-  // Create the browser window.
   const mainWindow = new BrowserWindow({
     width: 900,
     height: 670,
@@ -48,8 +37,7 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
-  // HMR for renderer base on electron-vite cli.
-  // Load the remote URL for development or the local html file for production.
+  // Dev server URL for HMR, local file otherwise.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
@@ -57,9 +45,7 @@ function createWindow(): void {
   }
 }
 
-// Only one instance of the app should run against a given userData dir at a time -
-// two instances writing to the same sqlite database concurrently can corrupt it,
-// and they'd also fight over the same GPU cache dir and renderer dev-server port.
+// Two instances writing to the same sqlite database concurrently would corrupt it.
 const gotSingleInstanceLock = app.requestSingleInstanceLock()
 
 if (!gotSingleInstanceLock) {
@@ -73,38 +59,24 @@ if (!gotSingleInstanceLock) {
     }
   })
 
-  // This method will be called when Electron has finished
-  // initialization and is ready to create browser windows.
-  // Some APIs can only be used after this event occurs.
   app.whenReady().then(() => {
-    // Set app user model id for windows
     electronApp.setAppUserModelId('tarehimself.cv-label')
 
-    // Default open or close DevTools by F12 in development
-    // and ignore CommandOrControl + R in production.
-    // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
     app.on('browser-window-created', (_, window) => {
-      //optimizer.watchWindowShortcuts(window)
       if (is.dev && !process.env.CV_LABEL_APP_PATH) {
         window.webContents.openDevTools()
       }
     })
 
-    // IPC test
     ipcMain.on('ping', () => console.log('pong'))
 
     createWindow()
 
     app.on('activate', function () {
-      // On macOS it's common to re-create a window in the app when the
-      // dock icon is clicked and there are no other windows open.
       if (BrowserWindow.getAllWindows().length === 0) createWindow()
     })
   })
 
-  // Quit when all windows are closed, except on macOS. There, it's common
-  // for applications and their menu bar to stay active until the user quits
-  // explicitly with Cmd + Q.
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {
       app.quit()
@@ -112,10 +84,6 @@ if (!gotSingleInstanceLock) {
   })
 }
 
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
-
-// Ipc based modules
 import './store'
 import './appStore'
 import './zip'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,11 +4,7 @@ import { electronApp, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { getAppPath } from './utils'
 
-// Ties Electron's own userData dir (and its single-instance lock file) to the same working
-// directory getAppPath() scopes the database/images to - makes the instance lock
-// per-working-directory rather than global. Only once packaged or under an explicit
-// override, so plain `pnpm dev` keeps Electron's default userData location. Must run
-// before requestSingleInstanceLock() below, which reads userData to place its lock file.
+// Ties userData (and its single-instance lock) to getAppPath()'s working directory - only once packaged, so plain `pnpm dev` keeps Electron's default location. Must run before requestSingleInstanceLock() below.
 if (app.isPackaged || process.env.CV_LABEL_APP_PATH) {
   app.setPath('userData', join(getAppPath(), 'userData'))
 }

--- a/src/main/localStore.ts
+++ b/src/main/localStore.ts
@@ -23,10 +23,7 @@ import {
 } from '../shared/types'
 import { IMainDataStore } from './storeOrchestrator'
 
-/** The local/worker-backed IDataStore implementation. Lazily spawns its worker (which
- *  opens SQLite and runs migrations) on first real use instead of blocking app boot -
- *  `ensureWorker()` is memoized and self-healing, so there's no ordering requirement on
- *  `connect()` being called first. */
+/** The local/worker-backed IDataStore - lazily spawns its worker (opens SQLite, runs migrations) on first use instead of blocking app boot. ensureWorker() is memoized, no ordering requirement on connect() first. */
 export class LocalStore implements IMainDataStore {
   #workerPromise?: Promise<typeof import('./database') & { terminate(): Promise<number> }>
 

--- a/src/main/schema.ts
+++ b/src/main/schema.ts
@@ -37,8 +37,7 @@ export const tags = sqliteTable(
   },
   (table) => [
     index('idx_tags_projectId').on(table.projectId),
-    // A project-global vocabulary, managed from one place (ManageTagsModal) - this is the
-    // DB-level guard against creating a literal duplicate name in the same project.
+    // DB-level guard against a literal duplicate tag name within the same project.
     uniqueIndex('idx_tags_project_name').on(table.projectId, table.name)
   ]
 )

--- a/src/main/scratchProtocol.ts
+++ b/src/main/scratchProtocol.ts
@@ -4,10 +4,7 @@ import { IPCKeys, SCRATCH_PROTOCOL_URL } from '../shared/types'
 import { makeUUID } from '../shared/utils'
 import { handleIpc } from './ipc'
 
-// Chromium parses a custom "standard" scheme's URL as scheme://host/path, same as
-// images://<id> - there's no way to put an arbitrary local path in that host position
-// (drive letters, colons and backslashes are invalid/mangled host content), so this maps
-// an opaque id to the real path server-side instead of encoding the path into the URL.
+// A raw path can't go in a custom scheme's host position (colons/backslashes are invalid there), so this maps an opaque id to the real path server-side instead.
 const scratchPathById = new Map<string, string>()
 
 handleIpc(IPCKeys.System_GetScratchPreviewUri, async (filePath) => {
@@ -16,11 +13,7 @@ handleIpc(IPCKeys.System_GetScratchPreviewUri, async (filePath) => {
   return `${SCRATCH_PROTOCOL_URL}://${id}`
 })
 
-// protocol.registerSchemesAsPrivileged is a single, global, call-once-per-app-lifetime
-// registration - a second call from a separate module (as this file used to make) is
-// silently dropped, so this scheme would never actually become privileged even though the
-// call itself doesn't throw. It's registered once, centrally, alongside images:// in
-// store.ts; this file only installs the handler, which has no such one-call restriction.
+// protocol.registerSchemesAsPrivileged is call-once-per-app-lifetime; a second call is silently dropped, so this scheme is registered once, centrally, in store.ts - this file only installs the handler.
 app.whenReady().then(() => {
   protocol.handle(SCRATCH_PROTOCOL_URL, async (req) => {
     try {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -13,10 +13,7 @@ orchestrator.register({
   resolveImage: localStore.resolveImage
 })
 
-// protocol.registerSchemesAsPrivileged can only be called once per app lifetime - every
-// custom scheme the app uses (image://, scratch://, ...) must be registered together in
-// this single call, or the ones left out of it silently never become privileged even
-// though registering them separately doesn't throw.
+// Call-once-per-app-lifetime - every custom scheme must be registered together here, or the ones left out silently never become privileged.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: IMAGE_PROTOCOL_URL,
@@ -42,8 +39,7 @@ app.whenReady().then(() => {
   protocol.handle(IMAGE_PROTOCOL_URL, async (req) => {
     try {
       const url = new URL(req.url)
-      // storeId is the host/authority segment (image://<storeId>/<imageId>.<ext>) - same
-      // custom-scheme parsing behavior scratch:// relies on.
+      // storeId is the host segment: image://<storeId>/<imageId>.<ext>
       return await orchestrator.resolveImage(url.host, url.pathname.slice(1))
     } catch (error) {
       console.error(error)

--- a/src/main/storeOrchestrator.ts
+++ b/src/main/storeOrchestrator.ts
@@ -1,8 +1,6 @@
 import { ArchiveManifest, IDataStore, StoreDescriptor } from '../shared/types'
 
-/** What main-only code (the export handler, the image protocol) needs beyond the
- *  renderer-visible IDataStore contract - kept out of the shared IDataStore interface
- *  since a renderer-side type has no business knowing about either concern. */
+/** What main-only code (export handler, image protocol) needs beyond IDataStore - kept out of the shared interface since a renderer-side type has no business knowing about it. */
 export interface IMainDataStore extends IDataStore {
   exportSamplesToArchive(
     destinationPath: string,
@@ -18,10 +16,7 @@ interface RegisteredStore {
   resolveImage: (imageId: string) => Promise<Response>
 }
 
-/** Owns every registered IDataStore and which one is "current" - the Store_* IPC handlers
- *  and the image:// protocol handler in main/store.ts both dispatch through this instead
- *  of a captured, hardcoded store reference. Re-reading `current` on every call means
- *  switching stores takes effect immediately for whatever's called next. */
+/** Owns every registered IDataStore and which is "current" - Store_* IPC and the image:// protocol handler dispatch through this, re-reading `current` each call so a switch takes effect immediately. */
 export class StoreOrchestrator {
   #stores = new Map<string, RegisteredStore>()
   #currentId?: string

--- a/src/main/storeOrchestrator.ts
+++ b/src/main/storeOrchestrator.ts
@@ -37,8 +37,7 @@ export class StoreOrchestrator {
     await entry.store.connect()
     this.#currentId = id
 
-    // Free the store being switched away from - meaningful now that disconnect() does
-    // real teardown instead of being a no-op.
+    // Free the store being switched away from - meaningful now that disconnect() does real teardown, not a no-op.
     if (previousId !== undefined && previousId !== id) {
       await this.#stores.get(previousId)?.store.disconnect()
     }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -6,12 +6,7 @@ export const getAppPath = () =>
   process.env.CV_LABEL_APP_PATH ??
   (app.isPackaged ? path.dirname(app.getPath('exe')) : app.getAppPath())
 
-// electron-vite bundles every src/main/** module flat into out/main/, regardless of which
-// chunk this code ends up in - so this file's own bundled location is always out/main,
-// two levels below the repo root. Deliberately not app.getAppPath(): in dev mode (launched
-// via out/main/index.js, as both `electron-vite dev` and the e2e/manual-test harness do) it
-// resolves to out/main itself, not the repo root, which pointed this at a non-existent
-// out/main/drizzle folder.
+// electron-vite bundles this flat into out/main/ regardless of chunk - not app.getAppPath(), which in dev mode resolves to out/main itself, not the repo root.
 const mainDir = path.dirname(fileURLToPath(import.meta.url))
 
 export const getMigrationsPath = () =>

--- a/src/main/utils_no_electron.ts
+++ b/src/main/utils_no_electron.ts
@@ -2,8 +2,7 @@ import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 
-/** Hashes a file by streaming it through, never buffering the whole thing in memory -
- *  matters for datasets that can run into the thousands of images. */
+/** Hashes a file by streaming it through, never buffering the whole thing in memory. */
 export const hashFile = async (filePath: string): Promise<string> => {
   const hash = createHash('sha256')
   await pipeline(createReadStream(filePath), hash)

--- a/src/main/worker/globals.d.ts
+++ b/src/main/worker/globals.d.ts
@@ -1,7 +1,4 @@
-// Ambient globals injected via `workerData` by importWorkerModule (see worker/index.ts) -
-// shared by every worker-thread module (database.ts, appDatabase.ts, ...) that reads them,
-// so each doesn't redeclare its own (which TS rejects as a duplicate block-scoped binding
-// once more than one such module is part of the same program).
+// Ambient globals injected via `workerData` by importWorkerModule - shared here so every worker-thread module that reads them doesn't redeclare its own (a duplicate block-scoped binding).
 export {}
 
 declare global {

--- a/src/main/worker/index.ts
+++ b/src/main/worker/index.ts
@@ -96,8 +96,7 @@ export async function importWorkerModule<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: any = {}
 
-  // Lets callers tear the worker thread down explicitly (e.g. StoreOrchestrator freeing a
-  // store that's been switched away from) instead of only ever being reaped on app exit.
+  // Lets callers tear the worker down explicitly (e.g. a freed store) instead of only ever being reaped on app exit.
   result.terminate = () => worker.worker.terminate()
 
   for (const property of initResponse.properties) {
@@ -106,8 +105,7 @@ export async function importWorkerModule<T = unknown>(
 
   for (const method of initResponse.methods) {
     result[method.name] = (...args: unknown[]) => {
-      // By convention, a trailing function argument is a progress callback: it can't
-      // cross postMessage, so it's registered locally against this call instead of sent.
+      // By convention, a trailing function arg is a progress callback - can't cross postMessage, so it's registered locally instead of sent.
       const lastArg = args[args.length - 1]
       const hasProgressCallback = typeof lastArg === 'function'
       const onProgress = hasProgressCallback

--- a/src/main/worker/index.ts
+++ b/src/main/worker/index.ts
@@ -82,11 +82,6 @@ class WorkerModule {
   }
 }
 
-/**
- *
- * @param modulePath the fileurl to the module to load
- * @returns
- */
 export async function importWorkerModule<T = unknown>(
   modulePath: URL,
   globals: object = {}

--- a/src/main/worker/module_worker.ts
+++ b/src/main/worker/module_worker.ts
@@ -61,9 +61,7 @@ if (isEntryFile(import.meta.url)) {
 
       if (data.type === ModuleWorkerMessage.Call) {
         const func = methods[data.methodId]
-        // Every call gets a progress reporter as its final argument - unused by methods
-        // that don't declare a trailing progress parameter, but requires no per-method
-        // plumbing for the ones that do (see WorkerProgressMessage).
+        // Every call gets a progress reporter as its final argument - unused unless a method declares a trailing progress parameter (see WorkerProgressMessage).
         const reportProgress = (...args: unknown[]) => {
           const message: WorkerProgressMessage = { type: 'progress', callRef: data.callRef, args }
           parentPort?.postMessage(message)

--- a/src/main/worker/module_worker_utils.ts
+++ b/src/main/worker/module_worker_utils.ts
@@ -27,10 +27,7 @@ export type WorkerResponse<T = unknown> =
       error: string
     }
 
-/** Out-of-band progress update for a still-in-flight Call. Any worker-module export can
- *  opt into this by declaring a real trailing `onProgress?: (...args) => void` parameter
- *  and calling it - the dispatcher always passes one, so it works for any method without
- *  further changes to this transport. */
+/** Out-of-band progress for a still-in-flight Call - any worker export opts in just by declaring a trailing `onProgress?: (...args) => void` param; the dispatcher always passes one. */
 export type WorkerProgressMessage = {
   type: 'progress'
   callRef: string

--- a/src/main/zip.ts
+++ b/src/main/zip.ts
@@ -7,11 +7,7 @@ import { pipeline } from 'node:stream/promises'
 import { handleIpc } from './ipc'
 
 handleIpc(IPCKeys.Zip_ExtractTo, async (filePath, destination) => {
-  // adm-zip (used here previously) reads the whole file into memory via fs.readFileSync
-  // to parse it, even just to list entries - Node refuses to read anything over 2GiB that
-  // way (ERR_FS_FILE_TOO_LARGE), so it can't open real-world datasets past that size at
-  // all. yauzl instead seeks directly to the central directory and streams each entry to
-  // disk one at a time, so memory use stays flat regardless of archive size.
+  // yauzl (unlike adm-zip previously) seeks the central directory and streams entries to disk one at a time, so memory stays flat regardless of archive size.
   const zipfile = await yauzl.openPromise(path.normalize(filePath), {
     lazyEntries: true,
     autoClose: true
@@ -20,9 +16,7 @@ handleIpc(IPCKeys.Zip_ExtractTo, async (filePath, destination) => {
   for await (const entry of zipfile.eachEntry()) {
     const entryPath = path.join(destination, entry.fileName)
 
-    // Guards against a malicious/malformed entry (e.g. "../../etc/passwd") writing
-    // outside destination - matters here since imported archives (YOLO/COCO/.cvlabel)
-    // can come from anywhere, not just this app's own exports.
+    // Guards against a malicious/malformed entry (e.g. "../../etc/passwd") writing outside destination - imported archives can come from anywhere.
     if (path.relative(destination, entryPath).startsWith('..')) {
       throw new Error(`Zip entry escapes destination directory: ${entry.fileName}`)
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -81,8 +81,7 @@ const zipApi: IZip = {
   extractTo: wrap(IPCKeys.Zip_ExtractTo)
 }
 
-// Synchronous and preload-only, unlike everything else here - never crosses IPC, so it
-// doesn't go through wrap()/ipcRenderer.invoke.
+// Synchronous and preload-only, unlike everything else here - never crosses IPC.
 const fileUtilsApi: IFileUtils = {
   getPathForFile: (file) => webUtils.getPathForFile(file)
 }
@@ -96,9 +95,6 @@ const exportApi: IExportApi = {
   }
 }
 
-// Use `contextBridge` APIs to expose Electron APIs to
-// renderer only if context isolation is enabled, otherwise
-// just add to the DOM global.
 if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)

--- a/src/renderer/src/api/ExternalAnnotator.ts
+++ b/src/renderer/src/api/ExternalAnnotator.ts
@@ -35,9 +35,7 @@ const isAnnotatorAnnotation = (value: unknown): value is AnnotatorAnnotation =>
   Array.isArray((value as AnnotatorAnnotation).points) &&
   (value as AnnotatorAnnotation).points.every(isAnnotatorPoint)
 
-/** Calls an annotator server's `/connect` route to fetch its own label vocabulary. The
- *  result is only ever held in memory while the user builds/edits a labelMapping - it's
- *  never persisted, so this needs to be called again any time the mapping UI reopens. */
+/** Calls an annotator server's `/connect` route for its label vocabulary - never persisted, so this must be called again any time the mapping UI reopens. */
 export const connectToAnnotator = async (
   url: string,
   headers: Record<string, string>
@@ -61,9 +59,7 @@ export const connectToAnnotator = async (
   return labels.filter(isAnnotatorLabel)
 }
 
-/** Resolves raw `/predict` output through an annotator's stored labelMapping into real
- *  INewAnnotations. A prediction whose labelId has no mapping (or maps to null/"ignore"),
- *  or that's otherwise malformed, is dropped and counted rather than guessed at. */
+/** Resolves raw `/predict` output through labelMapping into real INewAnnotations - an unmapped or malformed prediction is dropped and counted, never guessed at. */
 export const mapPredictionsToAnnotations = (
   predictions: unknown,
   labelMapping: Record<string, string | null>
@@ -113,10 +109,7 @@ export const mapPredictionsToAnnotations = (
   return { annotations, skipped }
 }
 
-/** Runs one sample through an annotator: reads its image bytes, POSTs them to /predict,
- *  and resolves the response through labelMapping - built live for the current run, never
- *  persisted (see hooks/useAnnotatorRuntime.ts). Throws on any network/parse failure so the
- *  caller can attribute the failure to this sample. */
+/** Runs one sample through an annotator: reads its image bytes, POSTs to /predict, resolves through labelMapping. Throws on any network/parse failure so the caller can attribute it to this sample. */
 export const runAnnotatorOnSample = async (
   annotator: IAnnotator,
   labelMapping: Record<string, string | null>,

--- a/src/renderer/src/components/AsyncButton.tsx
+++ b/src/renderer/src/components/AsyncButton.tsx
@@ -3,13 +3,11 @@ import { useCallback, useRef, useState, type FC } from 'react'
 
 export type AsyncButtonProps = Omit<ButtonProps, 'loading'> & {
   onClick: () => Promise<unknown>
-  /** Mirrors the internal pending state up, for callers that also need to disable sibling
-   *  controls (e.g. a Cancel button or other inputs) while the async work is in flight. */
+  /** Mirrors the internal pending state up, for callers that also need to disable sibling controls while the async work is in flight. */
   onPendingChange?: (isPending: boolean) => void
 }
 
-/** Wraps Mantine's Button to guard against double-submit: ignores clicks while a previous
- *  onClick's promise is still pending, and shows Mantine's built-in loading state meanwhile. */
+/** Wraps Mantine's Button to guard against double-submit - ignores clicks while a previous onClick's promise is still pending. */
 export const AsyncButton: FC<AsyncButtonProps> = ({
   onClick,
   onPendingChange,

--- a/src/renderer/src/components/AsyncButton.tsx
+++ b/src/renderer/src/components/AsyncButton.tsx
@@ -15,11 +15,7 @@ export const AsyncButton: FC<AsyncButtonProps> = ({
   ...buttonProps
 }) => {
   const [isPending, setIsPending] = useState(false)
-  // The re-entrancy gate itself must be a ref, not the isPending state: several clicks
-  // dispatched within the same synchronous tick (e.g. a fast native double-click) get
-  // batched by React into a single re-render, so a second click's handler can still read
-  // the pre-update `isPending` value from state. A ref is read/written synchronously and
-  // isn't subject to that batching, so it reliably blocks same-tick re-entrant clicks.
+  // Must be a ref, not isPending state - React batches same-tick clicks (e.g. a fast double-click) into one re-render, so state would still read stale on the second click.
   const isPendingRef = useRef(false)
 
   const handleClick = useCallback(() => {
@@ -27,12 +23,7 @@ export const AsyncButton: FC<AsyncButtonProps> = ({
     isPendingRef.current = true
     setIsPending(true)
     onPendingChange?.(true)
-    // Swallow rejections on this specific derived chain only - other consumers of the same
-    // promise (e.g. a caller's own try/catch, or react-hot-toast's toast.promise) still see
-    // the rejection on their own branch; this just keeps our own bookkeeping from producing
-    // a spurious unhandled-rejection warning when nothing else happens to be watching it.
-    // Wrapped in Promise.resolve() since onClick isn't guaranteed to return a real Promise
-    // (e.g. a test double that forgets to mock a resolved value).
+    // Swallows rejections on this derived chain only - other consumers of the same promise still see it. Promise.resolve() guards a test double that forgets to return one.
     Promise.resolve(onClick())
       .catch(() => {})
       .finally(() => {

--- a/src/renderer/src/components/BasicListPage.tsx
+++ b/src/renderer/src/components/BasicListPage.tsx
@@ -35,12 +35,7 @@ const Container = styled.div`
   box-sizing: border-box;
 `
 
-// A plain native overflow container instead of Mantine's <ScrollArea>: pages here can be
-// hidden (not unmounted) by the stack router's <Activity> boundary. Neither ScrollArea's
-// JS-managed scrollbar nor the browser reliably keeps scrollTop through that: a flex child
-// with min-height:0 whose ancestor toggles display:none loses its scroll offset once shown
-// again, even though the DOM node itself survives. So scroll position is saved/restored
-// manually below instead of trusted to survive the hide/show cycle on its own.
+// A plain native overflow container, not Mantine's <ScrollArea> - neither it nor the browser reliably keeps scrollTop when this page's <Activity> hides it, so scroll position is saved/restored manually below.
 const ScrollContainer = styled.div`
   display: flex;
   flex: 1;
@@ -53,15 +48,9 @@ const ScrollContainer = styled.div`
 
 export type BasicListPageProps = {
   top: ReactNode
-  /** Lets a caller share this page's scroll element with something outside it - a
-   *  virtualizer (see VirtualizedItemList) needs the actual scrolling DOM node to measure
-   *  against, which this component otherwise keeps entirely to itself. Optional: a page
-   *  that isn't virtualizing its content doesn't need to provide one. */
+  /** Lets a caller share this page's scroll element with something outside it - a virtualizer (see VirtualizedItemList) needs the actual scrolling DOM node. */
   scrollContainerRef?: RefObject<HTMLDivElement | null>
-  /** Relaxes the default 60%/1000px column cap to 90%/1400px - for a page whose content
-   *  genuinely needs more horizontal room than a plain list of rows (e.g.
-   *  CopyAnnotationsPage's side-by-side thumbnail/select mapping rows), rather than one
-   *  that's just a list and should stay narrow like Projects/Tasks/Samples. */
+  /** Relaxes the default 60%/1000px column cap to 90%/1400px, for a page that genuinely needs more room than a plain list (e.g. CopyAnnotationsPage). */
   wide?: boolean
 }
 
@@ -76,11 +65,7 @@ export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({
   const scrollTopRef = useRef(0)
   const widthStyle = wide ? { width: '90%', maxWidth: 1400 } : undefined
 
-  // Restores scrollTop on setup (mount, and the resetup that happens when this page's
-  // <Activity> boundary goes from hidden back to visible - see the ScrollContainer comment).
-  // The value itself is captured continuously via onScroll below rather than in this effect's
-  // cleanup: cleanup runs after the hide transition's DOM mutation (display:none) already
-  // applied, so by then scrollTop already reads back as the collapsed 0, not the real value.
+  // Restores scrollTop on mount/hidden->visible; captured via onScroll below since cleanup runs too late (scrollTop already reads 0 by then).
   useLayoutEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollTopRef.current
@@ -97,9 +82,7 @@ export const BasicListPage: FC<PropsWithChildren<BasicListPageProps>> = ({
           data-testid="basic-list-scroll-container"
           onScroll={(e) => {
             const el = e.currentTarget
-            // Hiding this page collapses it to 0x0 and fires a spurious scroll event with
-            // scrollTop 0 as a side effect - ignore that rather than clobbering the real
-            // last-known position with it.
+            // Hiding this page collapses it to 0x0 and fires a spurious scroll(0) - ignore it.
             if (el.clientHeight === 0) return
             scrollTopRef.current = el.scrollTop
           }}

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -55,22 +55,16 @@ export type BasicListPageItemProps = {
   onManageAnnotators?: () => void
   onAutoLabel?: () => void
   onEditTags?: () => void
-  /** Exports just this item - only offered outside select mode, where batch export
-   *  (acting on the whole selection instead) takes over. */
+  /** Exports just this item - only offered outside select mode, where batch export takes over. */
   onExport?: () => void
-  /** Copies this item's samples' annotations into another task - only offered outside
-   *  select mode, same as onExport (both are inherently single-source actions). */
+  /** Copies this item's samples' annotations into another task - only offered outside select mode, same as onExport. */
   onCopyAnnotations?: () => void
   onDelete?: () => void
-  /** Whether the list is currently in select mode - while true, clicking the row
-   *  anywhere (not just the checkbox) toggles selection instead of firing onClick, and
-   *  the checkbox itself becomes visible. */
+  /** While true, clicking the row anywhere toggles selection instead of firing onClick, and the checkbox becomes visible. */
   selectMode?: boolean
   selected?: boolean
   onSelectedChange?: (selected: boolean) => void
-  /** Enters select mode with just this item selected - the context menu's entry point
-   *  into selection outside select mode, where the All/Above/Below variants below
-   *  wouldn't yet make sense (there's no anchor item, and nothing else is selected). */
+  /** Enters select mode with just this item selected - the context menu's entry point into selection when nothing else is selected yet. */
   onSelect?: () => void
   /** Selects every currently visible (filtered) item. */
   onSelectAll?: () => void

--- a/src/renderer/src/components/BasicListPageItem.tsx
+++ b/src/renderer/src/components/BasicListPageItem.tsx
@@ -149,10 +149,7 @@ export const BasicListPageItem: FC<BasicListPageItemProps> = ({
         ]
       : [])
   ]
-  // Outside select mode, the All/Above/Below variants have no anchor to make sense of yet
-  // (nothing else is selected) - a single generic "Select" entry (via onSelect) is the
-  // only selection action offered until the list is already in select mode, at which
-  // point the fuller batch-selection variants take over.
+  // Outside select mode, All/Above/Below have no anchor to make sense of yet - just a generic "Select" entry until the list is already in select mode.
   const selectionItems = selectMode
     ? [
         ...(onSelectAll ? [{ key: 'select-all', title: 'Select All', onClick: onSelectAll }] : []),

--- a/src/renderer/src/components/BasicListPageTopBar.tsx
+++ b/src/renderer/src/components/BasicListPageTopBar.tsx
@@ -1,9 +1,6 @@
 import { styled } from '@linaria/react'
 
-// Shared by every list page's toolbar (Projects/Tasks/Samples): a left-hand action-button
-// group and a right-hand filter/search group. flex-wrap lets the right group drop to its
-// own line instead of being squeezed off-screen once the left group grows past one row
-// (e.g. select mode's batch action buttons) - TopArea's fixed width doesn't grow with them.
+// Shared by every list page's toolbar - flex-wrap lets the right group drop to its own line instead of getting squeezed off-screen once the left group (e.g. select mode's buttons) grows past one row.
 export const BasicListPageTopBar = styled.div`
   display: flex;
   width: 100%;

--- a/src/renderer/src/components/RenameModal.tsx
+++ b/src/renderer/src/components/RenameModal.tsx
@@ -11,9 +11,7 @@ export type RenameModalProps = {
   onConfirm: (name: string) => Promise<unknown>
 }
 
-/** Controlled by mounting with a `key` tied to the item being renamed (e.g. `key={item?.id}`)
- *  so its internal input state resets whenever the target changes, instead of carrying over
- *  the previous item's in-progress edit. */
+/** Controlled by mounting with `key={item?.id}` so input state resets on target change, instead of carrying over the previous edit. */
 export const RenameModal: FC<RenameModalProps> = ({
   opened,
   entityName,

--- a/src/renderer/src/components/VirtualizedItemList.tsx
+++ b/src/renderer/src/components/VirtualizedItemList.tsx
@@ -6,22 +6,13 @@ export type VirtualizedItemListProps<T> = {
   items: T[]
   getKey: (item: T, index: number) => string
   renderItem: (item: T, index: number) => ReactNode
-  /** The actual scrolling DOM element these rows live inside - see
-   *  BasicListPage's scrollContainerRef. */
+  /** The actual scrolling DOM element these rows live inside - see BasicListPage's scrollContainerRef. */
   scrollContainerRef: RefObject<HTMLDivElement | null>
-  /** A first-paint guess before a row has ever been measured - rows are re-measured
-   *  after mount, so this only affects the very first layout/scrollbar-size estimate,
-   *  not correctness. */
+  /** A first-paint guess before a row has ever been measured - only affects the very first layout estimate, not correctness. */
   estimateSize?: number
 }
 
-/** Renders only the rows currently scrolled into view (plus a look-ahead buffer)
- *  instead of the full list - the DOM cost of a `BasicListPageItem` row (icon, tags,
- *  progress bar, context menu) doesn't scale with dataset size this way. Row heights
- *  aren't uniform (badges/progress bars add lines) - react-virtuoso (rather than
- *  @tanstack/react-virtual, which this used previously) is built specifically to
- *  measure/reflow variable-height rows without the visible jump a coarser estimate
- *  can cause when fast scrolling outruns measurement. */
+/** Renders only rows scrolled into view (plus a look-ahead buffer) so DOM cost doesn't scale with dataset size. react-virtuoso handles the non-uniform row heights (badges/progress bars) without the jump a coarser estimate would cause. */
 export function VirtualizedItemList<T>({
   items,
   getKey,
@@ -29,22 +20,12 @@ export function VirtualizedItemList<T>({
   scrollContainerRef,
   estimateSize = 90
 }: VirtualizedItemListProps<T>) {
-  // scrollContainerRef.current is still null during this render (refs attach at
-  // commit, same as any other ref) - resolve it into state so Virtuoso never has a
-  // render where it falls back to creating its own internal scroller before swapping
-  // to the real one (BasicListPage's ScrollContainer, which also owns manual
-  // scrollTop save/restore across this page's Activity hide/show).
+  // Resolved into state so Virtuoso never renders with its own fallback internal scroller before swapping to the real one.
   const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null)
   useLayoutEffect(() => {
     setScrollParent(scrollContainerRef.current)
   }, [scrollContainerRef])
-  // If scrollContainerRef's owner is an ancestor that mounts in this same commit
-  // (rather than one already mounted from an earlier commit, e.g. behind a loading
-  // gate), its ref isn't attached yet when the layout effect above runs - refs attach
-  // bottom-up, so a descendant's layout effect can fire before an ancestor's own ref
-  // does. A plain effect runs strictly after every layout effect in the commit has
-  // finished (including that ancestor's), so it's guaranteed to see the real value
-  // once the layout-effect attempt above came back empty.
+  // Catches the case where scrollContainerRef's ref hasn't attached yet when the layout effect above runs (refs attach bottom-up) - a plain effect runs after every layout effect in the commit.
   useEffect(() => {
     if (scrollParent === null) setScrollParent(scrollContainerRef.current)
   }, [scrollContainerRef, scrollParent])
@@ -57,8 +38,7 @@ export function VirtualizedItemList<T>({
       data={items}
       computeItemKey={(index, item) => getKey(item, index)}
       defaultItemHeight={estimateSize}
-      // Look-ahead buffer, in pixels: measures/renders rows before they're ever
-      // visible, so fast scrolling is less likely to outrun measurement.
+      // Look-ahead buffer in pixels, so fast scrolling is less likely to outrun measurement.
       increaseViewportBy={{ top: 400, bottom: 400 }}
       itemContent={(index, item) => <Box pb="md">{renderItem(item, index)}</Box>}
     />

--- a/src/renderer/src/components/annotators/AnnotatorsModal.tsx
+++ b/src/renderer/src/components/annotators/AnnotatorsModal.tsx
@@ -36,9 +36,7 @@ type Step =
   | { step: 'run'; annotator: IAnnotator; samples: OptimisticSample[] }
   | { step: 'edit'; annotator: IAnnotator; name: string; url: string; headerRows: HeaderRow[] }
 
-/** Best-effort mapping by matching an annotator's label names against a project's own -
- *  never persisted, only used to seed the in-memory mapping the first time an annotator
- *  runs against a given project (see useAnnotatorRuntime.ts). */
+/** Best-effort mapping by matching label names - never persisted, only seeds the in-memory mapping the first time an annotator runs against a project. */
 const guessMapping = (
   labels: AnnotatorLabel[],
   project: IProject
@@ -67,8 +65,7 @@ type AnnotatorFormFieldsProps = {
   onChange: (value: AnnotatorFieldsValue) => void
 }
 
-/** Name/URL/headers fields - shared between the "Add Annotator" form and the settings/cog
- *  "edit" screen, which differ only in what they do with the result (create vs. update). */
+/** Name/URL/headers fields - shared between the "Add Annotator" form and the settings/cog "edit" screen, which differ only in what they do with the result. */
 const AnnotatorFormFields: FC<AnnotatorFormFieldsProps> = ({ value, onChange }) => (
   <>
     <TextInput
@@ -152,9 +149,7 @@ type AnnotatorMappingFieldsProps = {
   onChangeMapping: (labelId: string, value: string) => void
 }
 
-/** The per-label "map to a project label, or Ignore" editor - shared between the pre-run
- *  review screen and the settings/cog "edit" screen, both of which just read/write the
- *  same in-memory (annotatorId, projectId) mapping via different entry points. */
+/** The per-label "map to a project label, or Ignore" editor - shared between the pre-run review screen and the settings/cog "edit" screen. */
 const AnnotatorMappingFields: FC<AnnotatorMappingFieldsProps> = ({
   project,
   labels,
@@ -199,21 +194,13 @@ type AnnotatorRunStepProps = {
   project: IProject
   samples: OptimisticSample[]
   annotator: IAnnotator
-  /** Owned by the parent (not this component) so it survives this component's own
-   *  mount/unmount as the modal steps back and forth, and so a run that should start
-   *  immediately (a mapping was already known) can be kicked off from the click handler
-   *  that made that call, rather than this component re-deriving the same decision in a
-   *  mount effect - see AnnotatorsModal's own startRun. */
+  /** Owned by the parent so it survives this component's own mount/unmount, letting a run that should start immediately be kicked off from the same click handler - see AnnotatorsModal's startRun. */
   run: ReturnType<typeof useRunAnnotator>['run']
   progress: RunAnnotatorProgress
   isRunning: boolean
-  /** Whether a run has been kicked off at all - distinct from isRunning (flips back once
-   *  finished) and from progress.total (legitimately 0 when every sample was already
-   *  labeled), so this is the only reliable "show progress vs. show the mapping editor"
-   *  signal. See useRunAnnotator's own hasRun for why it isn't derived from progress. */
+  /** Whether a run has been kicked off at all - the only reliable "show progress vs. show the mapping editor" signal (isRunning flips back, progress.total can be legitimately 0). */
   hasRun: boolean
-  /** Also used by the post-run "Done" button - returns to the annotator list rather than
-   *  closing the whole modal, so the user can run another annotator without reopening it. */
+  /** Also used by the post-run "Done" button - returns to the annotator list rather than closing the whole modal. */
   onBack: () => void
 }
 
@@ -231,9 +218,7 @@ const AnnotatorRunStep: FC<AnnotatorRunStepProps> = ({
   const setMapping = useAnnotatorRuntime((s) => s.setMapping)
   const mapping = entry?.mappingByProjectId[project.id] ?? {}
 
-  // Fires exactly on a running -> finished transition, never on mount - wasRunning starts
-  // false regardless of whether a run was already under way when this component mounted,
-  // so an in-progress run finishing is the only thing that can flip it from true to false.
+  // Fires exactly on a running -> finished transition, never on mount.
   const wasRunning = useRef(false)
   useEffect(() => {
     if (wasRunning.current && !isRunning) {
@@ -301,10 +286,7 @@ const AnnotatorRunStep: FC<AnnotatorRunStepProps> = ({
 export type AnnotatorsModalProps = {
   opened: boolean
   project: IProject
-  /** Only passed when there's something to run against - when absent, the modal is
-   *  management-only (no per-row Run action), e.g. ProjectsPage's context-menu entry.
-   *  Usually a single task (a samples-page run), but a batch run kicked off from the
-   *  Tasks page can pass several at once. */
+  /** Only passed when there's something to run against - absent means management-only (e.g. ProjectsPage's context-menu entry). Usually one task, but a Tasks-page batch run can pass several. */
   tasks?: ITask[]
   samples?: OptimisticSample[]
   onClose: () => void
@@ -321,16 +303,13 @@ export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
   const activate = useAnnotatorRuntime((s) => s.activate)
   const setMapping = useAnnotatorRuntime((s) => s.setMapping)
   const forget = useAnnotatorRuntime((s) => s.forget)
-  // Owned here rather than by AnnotatorRunStep so a run whose mapping is already known can
-  // be kicked off directly from the click that decided that (see startRun below), instead
-  // of threading an "autoStart" flag through the Step union for a mount effect to interpret.
+  // Owned here, not AnnotatorRunStep, so a run whose mapping is already known can start directly from the click that decided that - see startRun below.
   const taskIds = useMemo(() => tasks?.map((t) => t.id) ?? [], [tasks])
   const { run, reset: resetRun, progress, isRunning, hasRun } = useRunAnnotator(taskIds)
   const [step, setStep] = useState<Step>({ step: 'list' })
   const [wasOpened, setWasOpened] = useState(opened)
   const [pendingDelete, setPendingDelete] = useState<IAnnotator | null>(null)
-  // Only meaningful while step.step === 'edit' - read unconditionally (selector itself
-  // branches) since hooks can't be called conditionally.
+  // Only meaningful while step.step === 'edit' - read unconditionally since hooks can't be conditional.
   const editRuntimeEntry = useAnnotatorRuntime((s) =>
     step.step === 'edit' ? s.entries[step.annotator.id] : undefined
   )
@@ -371,9 +350,7 @@ export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
     }
   }
 
-  /** Connects (if this annotator hasn't been activated yet this session) and seeds a
-   *  best-effort mapping for the current project (if one isn't already known) - shared by
-   *  the Run and settings/cog flows, which differ only in what they do once activated. */
+  /** Connects (if not yet activated this session) and seeds a best-effort mapping - shared by the Run and settings/cog flows, which differ only in what they do once activated. */
   const ensureActivated = async (annotator: IAnnotator): Promise<AnnotatorLabel[] | undefined> => {
     let labels = useAnnotatorRuntime.getState().entries[annotator.id]?.labels
     if (labels === undefined) {
@@ -399,8 +376,7 @@ export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
   const startRun = async (annotator: IAnnotator) => {
     if (tasks === undefined || tasks.length === 0 || samples === undefined) return
 
-    // Captured before ensureActivated seeds a fresh guess - only a mapping that was
-    // already known (not one just guessed by this very call) should skip the review step.
+    // Captured before ensureActivated seeds a fresh guess - only an already-known mapping skips the review step.
     const hadMapping =
       useAnnotatorRuntime.getState().entries[annotator.id]?.mappingByProjectId[project.id] !==
       undefined
@@ -408,17 +384,12 @@ export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
     const labels = await ensureActivated(annotator)
     if (labels === undefined) return
 
-    // Clears out whatever an earlier run in this same modal session left behind - run/
-    // progress/isRunning live in this component now, not remounted fresh per visit to the
-    // 'run' step, so a stale finished (or in-progress) state would otherwise leak into the
-    // next one, however it starts.
+    // Clears whatever an earlier run in this same modal session left behind - run/progress/isRunning aren't remounted fresh per visit to the 'run' step.
     resetRun()
     setStep({ step: 'run', annotator, samples })
 
     if (hadMapping) {
-      // Not awaited on purpose: this only needs to kick the run off, the same way the
-      // manual "Run" button does - blocking here would keep the list row's own Run button
-      // spinning for the whole run instead of just the connect step above.
+      // Not awaited on purpose - blocking here would keep the list row's own Run button spinning for the whole run.
       const mapping =
         useAnnotatorRuntime.getState().entries[annotator.id]?.mappingByProjectId[project.id] ?? {}
       void run(annotator, mapping, samples)
@@ -450,9 +421,7 @@ export const AnnotatorsModal: FC<AnnotatorsModalProps> = ({
     }
 
     const headers = headerRowsToRecord(step.headerRows)
-    // A changed URL means a possibly different service - the cached labels/mapping for
-    // the old one are no longer trustworthy, so drop them and let the next Run/edit
-    // reconnect fresh.
+    // A changed URL means a possibly different service - drop cached labels/mapping and reconnect fresh.
     if (url !== step.annotator.url) {
       forget(step.annotator.id)
     }

--- a/src/renderer/src/components/labeler/selectTool.ts
+++ b/src/renderer/src/components/labeler/selectTool.ts
@@ -33,8 +33,7 @@ export const selectTool: LabelerTool = {
 
     let controlPointId = hit.controlPointId
     if (hit.lineControlPointId !== null) {
-      // A Box only ever has 2 real points - its "lines" are edges, draggable to resize
-      // rather than a place to insert a new point (unlike a Polygon's lines).
+      // A Box only ever has 2 real points - its "lines" are edges, draggable to resize, not a place to insert a new point.
       if (state.selectedAnnotation.resolve().type === AnnotationType.Box) {
         controlPointId = hit.lineControlPointId
       } else {

--- a/src/renderer/src/components/labeler/types.ts
+++ b/src/renderer/src/components/labeler/types.ts
@@ -4,11 +4,9 @@ import type { StoreApi, UseBoundStore } from 'zustand'
 export type Point = { x: number; y: number }
 
 export enum PointerResult {
-  /** The tool fully handled the gesture; suppress the default behavior (panning for
-   * a left-click, the contextmenu popup for a right-click). */
+  /** The tool fully handled the gesture; suppress the default behavior (pan/contextmenu). */
   Consumed = 'consumed',
-  /** Let the default behavior also run (e.g. deselecting still allows a drag on
-   * empty canvas to pan). */
+  /** Let the default behavior also run (e.g. deselecting still allows a pan drag). */
   Default = 'default'
 }
 

--- a/src/renderer/src/components/sampleIO/ImportSamplesModal.tsx
+++ b/src/renderer/src/components/sampleIO/ImportSamplesModal.tsx
@@ -26,12 +26,9 @@ export type ImportSamplesModalProps = {
   opened: boolean
   project: IProject
   onClose: () => void
-  /** scratchDir is where the imported samples' image files live - onImported decides
-   *  when it's safe to delete it (immediately once persisted, or later if the caller only
-   *  stages samples for review before actually persisting them). */
+  /** scratchDir is where the imported samples' images live - onImported decides when it's safe to delete it. */
   onImported: (samples: INewSample[], scratchDir: string) => Promise<void>
-  /** Defaults to the standalone action-modal layer - pass ZIndex.nestedActionModal when
-   *  this is opened from within another already-open action modal (e.g. Create Task). */
+  /** Pass ZIndex.nestedActionModal when opened from within another already-open action modal (e.g. Create Task). */
   zIndex?: number
 }
 

--- a/src/renderer/src/components/sampleIO/LabelMapper.tsx
+++ b/src/renderer/src/components/sampleIO/LabelMapper.tsx
@@ -41,9 +41,7 @@ export const LabelMapper = <K extends string | number>({
             ]}
             value={mapping.get(item.id) ?? EXCLUDE_VALUE}
             onChange={(value) => onChange(item.id, value === EXCLUDE_VALUE ? null : value)}
-            // These importers/exporters all live inside a modal - without an explicit
-            // zIndex above the modal's own, this dropdown renders behind the modal body
-            // and can't be clicked.
+            // These importers/exporters live inside a modal - without an explicit zIndex above it, this dropdown renders behind the modal body and can't be clicked.
             comboboxProps={{ zIndex: ZIndex.actionModalContent }}
             disabled={disabled}
             allowDeselect={false}

--- a/src/renderer/src/components/sampleIO/LabelMapper.tsx
+++ b/src/renderer/src/components/sampleIO/LabelMapper.tsx
@@ -5,24 +5,19 @@ import { ZIndex } from '@renderer/zIndex'
 const EXCLUDE_VALUE = '__exclude__'
 
 export type LabelMapperProps<K extends string | number> = {
-  /** Rows to map - a source class/label for importers, or the project's own labels for
-   *  exporters (where `items` and `options` are the same list). */
+  /** Rows to map - a source class/label for importers, or the project's own labels for exporters (same list as `options` there). */
   items: { id: K; name: string }[]
   /** Selectable mapping targets - always the project's labels. */
   options: ILabel[]
-  /** `null` means the item is explicitly excluded; an item absent from the map means no
-   *  choice has been made yet (only meaningful where there's no auto-fill default). */
+  /** `null` means explicitly excluded; absent means no choice has been made yet. */
   mapping: Map<K, string | null>
   onChange: (id: K, target: string | null) => void
-  /** Label for the "don't include this" option - importers use the default "Ignore",
-   *  exporters pass "Don't Export". */
+  /** Label for the "don't include this" option - importers default to "Ignore", exporters pass "Don't Export". */
   excludeLabel?: string
   disabled?: boolean
 }
 
-/** One `Text` + `Select` row per item, letting each be mapped to one of `options` or
- *  excluded entirely. Shared by every importer (source class -> project label) and
- *  exporter (project label -> itself, another label to merge into, or excluded). */
+/** One `Text` + `Select` row per item, mapping it to one of `options` or excluding it - shared by every importer and exporter. */
 export const LabelMapper = <K extends string | number>({
   items,
   options,

--- a/src/renderer/src/components/sampleIO/exporters/annotationShape.ts
+++ b/src/renderer/src/components/sampleIO/exporters/annotationShape.ts
@@ -40,11 +40,7 @@ const rectangleCorners = (box: BoundingBox): { x: number; y: number }[] => [
   { x: box.minX, y: box.minY + box.height }
 ]
 
-/** The polygon to export for an annotation under the given shape mode. In Segment mode a
- *  Polygon keeps its real outline and a Box becomes its own 4 corners (a box has no shape
- *  beyond its rectangle). In Box mode every annotation - Polygon included - is flattened
- *  to its bounding rectangle's corners, discarding a Polygon's actual outline. Either way
- *  every annotation produces a usable shape, unlike formats that can only carry one kind. */
+/** In Segment mode a Polygon keeps its real outline (a Box becomes its own 4 corners); in Box mode every annotation flattens to its bounding rectangle. Either way every annotation produces a usable shape. */
 export const exportShapePoints = (
   annotation: Pick<IAnnotation, 'type' | 'points'>,
   shape: ExportShape

--- a/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/coco/CocoExporterComponent.tsx
@@ -26,9 +26,7 @@ const COCO_SHAPE_OPTIONS: SegmentedControlItem[] = [
   { value: CocoShapeMode.Native, label: 'As Is' }
 ]
 
-// 'preparing' covers fetching samples and building the manifest, plus the native save
-// dialog (no progress events arrive during either) - without it the progress bar would
-// otherwise sit at 0% with nothing explaining why until the first image is archived.
+// 'preparing' covers fetching samples/building the manifest/the save dialog - no progress events arrive during any of that, so without it the bar would sit at 0% unexplained.
 type ExportPhase = 'preparing' | 'exporting'
 
 export const CocoExporterComponent = ({

--- a/src/renderer/src/components/sampleIO/exporters/coco/buildCoco.ts
+++ b/src/renderer/src/components/sampleIO/exporters/coco/buildCoco.ts
@@ -1,10 +1,7 @@
 import { AnnotationType, IAnnotation, ILabel } from '@shared/types'
 import { boundingBoxOf, exportShapePoints, ExportShape, polygonArea } from '../annotationShape'
 
-/** Unlike YOLO's fixed-column label lines, a COCO annotation entry can carry a bbox and
- *  an independent (optional) segmentation, so it supports a third choice beyond forcing
- *  every annotation to one shape: Native, which leaves each annotation's segmentation as
- *  whatever it actually has - none for a Box, its real outline for a Polygon. */
+/** COCO can carry an independent optional segmentation alongside a bbox, so unlike YOLO there's a third mode: Native, leaving each annotation's segmentation as whatever it actually has. */
 export enum CocoShapeMode {
   Box = 'box',
   Segment = 'segment',
@@ -34,8 +31,7 @@ export type CocoCategory = {
   supercategory: string
 }
 
-/** COCO category ids are conventionally 1-indexed (0 is reserved in some tools for a
- *  background/superclass placeholder). */
+/** COCO category ids are conventionally 1-indexed (0 is reserved in some tools for a background/superclass placeholder). */
 export const buildCocoCategories = (labels: ILabel[]): CocoCategory[] =>
   labels.map((label, index) => ({ id: index + 1, name: label.name, supercategory: 'none' }))
 
@@ -48,13 +44,7 @@ const cocoSegmentationFor = (
   return [exportShapePoints(annotation, ExportShape.Segment).flatMap((p) => [p.x, p.y])]
 }
 
-/** Converts one sample's annotations to COCO annotation entries. `bbox` is always the
- *  annotation's own bounding box. `segmentation` depends on the mode: Box discards any
- *  shape entirely (pure detection data, even for a Polygon); Segment gives every
- *  annotation a polygon (a Box's own 4 corners, synthesized, if it has no real one);
- *  Native leaves a Box with no segmentation (it never had one) and a Polygon with its
- *  real outline. `area` uses the real polygon's area only when that's what's actually
- *  being exported. */
+/** `bbox` is always the bounding box. `segmentation` depends on mode: Box discards shape entirely, Segment synthesizes one for every annotation, Native leaves it as-is. `area` uses the real polygon area only when one is actually exported. */
 export const buildCocoAnnotations = (
   annotations: IAnnotation[],
   imageId: number,

--- a/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/cvLabelJson/CvLabelJsonExporterComponent.tsx
@@ -11,9 +11,7 @@ import { LabelMapper } from '../../LabelMapper'
 import { buildIncludedLabelsAndIndex } from '../labelRouting'
 import { buildCvLabelManifest, cvLabelImagePath, type CvLabelManifestSample } from './buildCvLabel'
 
-// 'preparing' covers fetching samples and building the manifest, plus the native save
-// dialog (no progress events arrive during either) - without it the progress bar would
-// otherwise sit at 0% with nothing explaining why until the first image is archived.
+// 'preparing' covers fetching samples/building the manifest/the save dialog - no progress events arrive during any of that, so without it the bar would sit at 0% unexplained.
 type ExportPhase = 'preparing' | 'exporting'
 
 export const CvLabelJsonExporterComponent = ({

--- a/src/renderer/src/components/sampleIO/exporters/cvLabelJson/buildCvLabel.ts
+++ b/src/renderer/src/components/sampleIO/exporters/cvLabelJson/buildCvLabel.ts
@@ -4,9 +4,7 @@ export interface CvLabelManifestSample extends Omit<ISample, 'imageUri' | 'compl
   imageFile: string
 }
 
-/** A flat sample list plus a label list (id + name only, enough for an importer to match
- *  by id then name) - deliberately independent of task structure, so re-importing works
- *  into any project regardless of which tasks the samples originally came from. */
+/** A flat sample list plus a label list (id + name only) - independent of task structure, so re-importing works into any project regardless of original tasks. */
 export const buildCvLabelManifest = (labels: ILabel[], samples: CvLabelManifestSample[]): string =>
   JSON.stringify(
     {

--- a/src/renderer/src/components/sampleIO/exporters/exportBaseName.ts
+++ b/src/renderer/src/components/sampleIO/exporters/exportBaseName.ts
@@ -1,8 +1,5 @@
 import type { IProject, ITask } from '@shared/types'
 
-/** The file/folder base name to suggest for an export - a single task's own name when
- *  exporting just that one task (the common case from a per-task "Export" action), since
- *  the project name would be redundant/less specific there. Falls back to the project's
- *  name once more than one task is involved, where no single task name would make sense. */
+/** The base name to suggest for an export - a single task's own name for a per-task export, falling back to the project's name once multiple tasks are involved. */
 export const exportBaseName = (project: IProject, tasks: ITask[]): string =>
   tasks.length === 1 ? tasks[0].name : project.name

--- a/src/renderer/src/components/sampleIO/exporters/labelRouting.ts
+++ b/src/renderer/src/components/sampleIO/exporters/labelRouting.ts
@@ -1,12 +1,6 @@
 import { ILabel } from '@shared/types'
 
-/** Turns a LabelMapper mapping (every project label -> itself, another label to merge
- *  into, or `null` to exclude) into what an exporter needs: the distinct set of labels
- *  that actually end up in the export, in a stable order, plus a routing table from
- *  every *source* label id to that target's index. A label mapped to `null` is simply
- *  absent from `labelIdToIndex`, so it's dropped by the same skip-if-missing logic the
- *  Coco/Yolo builders already use for an unmapped id. Two labels mapped to the same
- *  target route to the same index (merge). */
+/** Turns a LabelMapper mapping into what an exporter needs: the distinct labels that end up in the export, in stable order, plus a source-label-id -> target-index routing table. A `null` target is simply absent from labelIdToIndex, dropped by the same skip-if-missing logic the Coco/Yolo builders use. Two labels mapped to the same target route to the same index (merge). */
 export const buildIncludedLabelsAndIndex = (
   labels: ILabel[],
   mapping: Map<string, string | null>

--- a/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/YoloExporterComponent.tsx
@@ -18,9 +18,7 @@ const YOLO_SHAPE_OPTIONS: SegmentedControlItem[] = [
   { value: ExportShape.Segment, label: 'Segments' }
 ]
 
-// 'preparing' covers fetching samples and building the manifest, plus the native save
-// dialog (no progress events arrive during either) - without it the progress bar would
-// otherwise sit at 0% with nothing explaining why until the first image is archived.
+// 'preparing' covers fetching samples/building the manifest/the save dialog - no progress events arrive during any of that, so without it the bar would sit at 0% unexplained.
 type ExportPhase = 'preparing' | 'exporting'
 
 export const YoloExporterComponent = ({

--- a/src/renderer/src/components/sampleIO/exporters/yolo/buildYolo.ts
+++ b/src/renderer/src/components/sampleIO/exporters/yolo/buildYolo.ts
@@ -4,23 +4,17 @@ import { boundingBoxOf, exportShapePoints, ExportShape } from '../annotationShap
 
 export { ExportShape }
 
-/** Ultralytics-style data.yaml: split folders plus a 0-indexed classId -> name map,
- *  ordered the same way findYoloClasses would read it back on re-import. */
+/** Ultralytics-style data.yaml: split folders plus a 0-indexed classId -> name map, ordered the same way findYoloClasses reads it back on re-import. */
 export const buildYoloDataYaml = (labels: ILabel[]): string =>
   stringify({
     train: 'images/train',
     val: 'images/valid',
     test: 'images/test',
-    // A Map (rather than a plain object) keeps classId as a YAML int key instead of a
-    // quoted string, since Ultralytics indexes `names` by integer.
+    // A Map keeps classId as a YAML int key instead of a quoted string - Ultralytics indexes `names` by integer.
     names: new Map(labels.map((label, id) => [id, label.name]))
   })
 
-/** One label line per annotation, normalized to [0,1]. In Box mode every annotation
- *  (Polygon included) becomes a `class cx cy w h` bounding box; in Segment mode it
- *  becomes a `class x1 y1 x2 y2 ... xn yn` polygon - a Box's own 4 corners, or a
- *  Polygon's real outline. Either way nothing is skipped, unlike the plain detection
- *  format's usual box-only restriction. */
+/** One label line per annotation, normalized to [0,1]. Box mode always writes `class cx cy w h`; Segment mode writes `class x1 y1 ... xn yn` (a Box's own 4 corners, or a Polygon's real outline). */
 export const yoloLabelFileContent = (
   annotations: IAnnotation[],
   labelIdToClassId: Map<string, number>,

--- a/src/renderer/src/components/sampleIO/importers/coco/CocoImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/coco/CocoImporterComponent.tsx
@@ -86,10 +86,7 @@ export const CocoImporterComponent: FC<SampleImporterComponentProps> = ({
       e.target.value = ''
       return
     }
-    // input.files is the same mutable FileList object on every read, not a fresh
-    // snapshot - materialize it into a plain array before resetting the input's value
-    // below (needed so re-picking the same folder still fires onChange), since that reset
-    // clears this same FileList in place.
+    // input.files is a live mutable FileList - materialize it now, before the value reset below (needed so re-picking the same folder still fires onChange) clears it in place.
     const files = Array.from(fileList)
     e.target.value = ''
     loadSource(() => virtualFilesFromFileList(files))

--- a/src/renderer/src/components/sampleIO/importers/coco/parseCoco.ts
+++ b/src/renderer/src/components/sampleIO/importers/coco/parseCoco.ts
@@ -45,10 +45,7 @@ const dirOf = (path: string) => {
 
 const basenameOf = (path: string) => path.slice(path.lastIndexOf('/') + 1)
 
-/** Parses every `*.json` file that looks like a COCO annotations file (has `images`,
- *  `annotations` and `categories` arrays - covers both this app's own `_annotations.coco.json`
- *  export and hand-rolled COCO datasets under other names). Skips any `.json` file that
- *  isn't valid JSON or doesn't match the shape, rather than failing the whole import. */
+/** Parses every `*.json` file with `images`/`annotations`/`categories` arrays - covers this app's own export and hand-rolled COCO datasets alike. Invalid/mismatched files are skipped, not fatal. */
 const parseCocoJsonFiles = async (
   files: VirtualFile[]
 ): Promise<{ dir: string; dataset: RawCocoDataset }[]> => {
@@ -74,8 +71,7 @@ export type CocoClass = {
   name: string
 }
 
-/** Every category referenced across all found COCO annotation files, deduplicated by id
- *  (first occurrence wins) and kept in encounter order. */
+/** Every category referenced across all found COCO files, deduplicated by id (first wins), in encounter order. */
 export const findCocoClasses = async (files: VirtualFile[]): Promise<CocoClass[]> => {
   const classes = new Map<number, string>()
   for (const { dataset } of await parseCocoJsonFiles(files)) {
@@ -92,10 +88,7 @@ export type CocoImagePair = {
   split: TrainingSplit
 }
 
-/** Pairs each image referenced by a COCO annotations file with its own annotations.
- *  `file_name` is resolved relative to the directory the annotations file lives in (the
- *  Roboflow/COCO convention of images sitting alongside `_annotations.coco.json`). The
- *  split is inferred from that directory's path, same convention as the YOLO importer. */
+/** Pairs each image with its annotations - `file_name` resolves relative to the annotations file's own directory (Roboflow/COCO convention). Split is inferred from the path, same as the YOLO importer. */
 export const findCocoImagePairs = async (files: VirtualFile[]): Promise<CocoImagePair[]> => {
   const byPath = new Map(files.map((f) => [f.path, f] as const))
   const pairs: CocoImagePair[] = []
@@ -133,10 +126,7 @@ const isBboxRectangle = (
   return expected.every((v, i) => Math.abs(v - segmentation[i]) < 1e-6)
 }
 
-/** Converts one COCO annotation to the labeler's point representation. A polygon
- *  `segmentation` that isn't just the bbox's own rectangle (i.e. it carries real shape
- *  information, unlike the rectangular segmentation this app's COCO exporter writes for
- *  Box annotations) becomes a Polygon; everything else becomes a Box from `bbox`. */
+/** A `segmentation` that isn't just the bbox's own rectangle (real shape data, unlike what this app's own exporter writes for boxes) becomes a Polygon; everything else becomes a Box from `bbox`. */
 export const cocoAnnotationToPoints = (
   annotation: RawCocoAnnotation
 ): { type: AnnotationType; points: IPoint[] } => {
@@ -184,8 +174,7 @@ const buildSampleFromCocoPair = async (
   }
 }
 
-/** Converts the whole dataset to samples, one image at a time - see yoloDatasetToSamples
- *  for why this isn't parallelized. */
+/** Converts the whole dataset to samples, one image at a time (see yoloDatasetToSamples). */
 export const cocoDatasetToSamples = async (
   pairs: CocoImagePair[],
   categoryIdToLabelId: Map<number, string | null>,

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
@@ -87,15 +87,7 @@ export const CvLabelImporterComponent: FC<CvLabelImporterComponentProps> = ({
     [project]
   )
 
-  // Mirrors what the Dropzone's own onDrop would do with this same file - runs once per
-  // distinct initialFile (a new drop passes a new File instance, so this naturally re-fires
-  // for each one) rather than on every render, which handleFileSelected alone would cause
-  // if depended on directly given it's recreated whenever `project` changes. Deferred a
-  // microtask out rather than called directly: handleFileSelected's first statement is a
-  // synchronous setState (the same immediate "parsing" flip the Dropzone's own onDrop
-  // relies on), which react-hooks flags as a cascading-render risk when it runs straight
-  // in an effect body - the lazy initial state above already shows "parsing" on the very
-  // first paint, so this deferral costs nothing visible.
+  // Mirrors Dropzone's own onDrop for this file - re-fires per distinct initialFile instance. Deferred a microtask since handleFileSelected's synchronous setState would flag as a cascading-render risk called directly in the effect body.
   useEffect(() => {
     if (initialFile) {
       void Promise.resolve().then(() => handleFileSelected([initialFile]))
@@ -138,9 +130,7 @@ export const CvLabelImporterComponent: FC<CvLabelImporterComponentProps> = ({
           </Group>
         ) : (
           <Dropzone
-            // .cvlabel has no registered OS mime type, so a dropped file typically
-            // reports an empty File.type - matching it as a zip by extension (the
-            // Accept map's array side) is what actually lets it through, not the mime key.
+            // .cvlabel has no OS mime type, so File.type is typically empty - matching by extension is what actually lets it through, not the mime key.
             accept={{ [MIME_TYPES.zip]: ['.cvlabel', '.zip'] }}
             multiple={false}
             onDrop={(files) => handleFileSelected(files)}

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/CvLabelImporterComponent.tsx
@@ -22,10 +22,7 @@ type WizardState =
   | { step: 'importing'; progress: number }
 
 type CvLabelImporterComponentProps = SampleImporterComponentProps & {
-  /** Skips the drop/browse step and feeds this file straight into parsing, as if it had
-   *  just been dropped - lets a caller that already has the file in hand (e.g. the Tasks
-   *  page's own full-screen drop target, see CreateTaskButton.tsx) land the user directly
-   *  on the label-mapping step instead of making them drop it again inside this wizard. */
+  /** Skips the drop/browse step, feeding this file straight into parsing - for a caller (e.g. CreateTaskButton's own drop target) that already has the file in hand. */
   initialFile?: FileWithPath
 }
 

--- a/src/renderer/src/components/sampleIO/importers/cvlabel/parseCvLabel.ts
+++ b/src/renderer/src/components/sampleIO/importers/cvlabel/parseCvLabel.ts
@@ -40,11 +40,7 @@ const dirOf = (path: string) => {
   return idx === -1 ? '' : path.slice(0, idx + 1)
 }
 
-/** Reads this app's own .cvlabel export - a manifest.json (a label list plus a flat
- *  sample list, no task grouping) alongside the referenced images. `dir` is the folder
- *  manifest.json itself lives in, since `imageFile` paths are relative to it (matters if
- *  a zip tool wrapped the export in an extra top-level folder). Returns null if no valid
- *  manifest is found, so the caller can show a clear "not a .cvlabel file" error. */
+/** Reads this app's own .cvlabel export - a manifest.json plus referenced images. `dir` is manifest.json's own folder, since `imageFile` paths are relative to it. Null if no valid manifest is found. */
 export const findCvLabelManifest = async (
   files: VirtualFile[]
 ): Promise<{ manifest: CvLabelManifest; dir: string } | null> => {
@@ -67,9 +63,7 @@ export type CvLabelPair = {
   image: VirtualFile | null
 }
 
-/** Pairs each manifest sample with its referenced image file. A sample whose image is
- *  missing from the archive is kept with a null image and skipped when building samples,
- *  rather than failing the whole import. */
+/** Pairs each manifest sample with its referenced image file - a missing image is kept as null and skipped later, rather than failing the whole import. */
 export const findCvLabelPairs = (
   manifest: CvLabelManifest,
   dir: string,
@@ -82,12 +76,7 @@ export const findCvLabelPairs = (
   }))
 }
 
-/** Converts the whole archive to samples, one image at a time (not in parallel - see
- *  yoloDatasetToSamples for why). Every id (sample, annotation, point) is regenerated
- *  fresh rather than reusing the exported ones, so re-importing the same file twice - or
- *  into the project it came from - never collides with existing records. Each
- *  annotation's `labelId` is remapped via `labelIdToProjectLabelId`; annotations whose
- *  source label has no mapping are dropped. */
+/** Converts the whole archive to samples, one image at a time (see yoloDatasetToSamples). Every id is regenerated fresh so re-importing never collides with existing records; annotations with no label mapping are dropped. */
 export const cvLabelDatasetToSamples = async (
   pairs: CvLabelPair[],
   labelIdToProjectLabelId: Map<string, string | null>,

--- a/src/renderer/src/components/sampleIO/importers/filesToSamples.ts
+++ b/src/renderer/src/components/sampleIO/importers/filesToSamples.ts
@@ -8,9 +8,7 @@ const extensionOf = (filename: string) => {
   return idx === -1 ? 'bin' : filename.slice(idx + 1).toLowerCase()
 }
 
-/** Writes each file to scratchDir one at a time (not in parallel - datasets can run into
- *  the thousands of images, and holding them all as blobs/base64 at once risks spiking
- *  memory). Returns samples referencing the scratch paths, not image bytes. */
+/** Writes each file to scratchDir one at a time, not in parallel - holding thousands of images as blobs at once risks spiking memory. Returns samples referencing scratch paths, not bytes. */
 export const filesToSamples = async (
   files: File[],
   scratchDir: string,

--- a/src/renderer/src/components/sampleIO/importers/matchLabel.ts
+++ b/src/renderer/src/components/sampleIO/importers/matchLabel.ts
@@ -2,14 +2,10 @@ import { ILabel } from '@shared/types'
 
 const normalizeLabelName = (name: string): string => name.trim().toLowerCase()
 
-/** Matches by a case/whitespace-insensitive name comparison - used to default an
- *  imported class/category to a project label of the same name, since importers have
- *  no other reliable signal (YOLO classes and COCO categories don't share id space with
- *  this app's own label ids). */
+/** Case/whitespace-insensitive name match - the only reliable signal for defaulting an imported class to a project label, since YOLO/COCO ids don't share id space with this app's. */
 export const findLabelIdByName = (labels: ILabel[], name: string): string | undefined =>
   labels.find((label) => normalizeLabelName(label.name) === normalizeLabelName(name))?.id
 
-/** Matches by exact label id - only meaningful when re-importing this app's own export
- *  format, where the source label ids are this app's own label ids. */
+/** Exact label id match - only meaningful when re-importing this app's own export format. */
 export const findLabelIdById = (labels: ILabel[], id: string): string | undefined =>
   labels.find((label) => label.id === id)?.id

--- a/src/renderer/src/components/sampleIO/importers/splitFromPath.ts
+++ b/src/renderer/src/components/sampleIO/importers/splitFromPath.ts
@@ -3,9 +3,7 @@ import { TrainingSplit } from '@shared/types'
 const VALID_PATH_PATTERN = /(^|\/)(val|valid|validation)(\/|$)/i
 const TEST_PATH_PATTERN = /(^|\/)test(ing)?(\/|$)/i
 
-/** Infers a sample's train/valid/test split from its dataset path, mirroring the
- *  conventional YOLO/COCO folder layout (images/valid/..., images/test/..., etc.).
- *  Defaults to Train when neither pattern matches. */
+/** Infers train/valid/test split from the dataset path (conventional YOLO/COCO folder layout) - defaults to Train when neither pattern matches. */
 export const splitFromPath = (path: string): TrainingSplit => {
   if (VALID_PATH_PATTERN.test(path)) return TrainingSplit.Valid
   if (TEST_PATH_PATTERN.test(path)) return TrainingSplit.Test

--- a/src/renderer/src/components/sampleIO/importers/virtualFileSystem.ts
+++ b/src/renderer/src/components/sampleIO/importers/virtualFileSystem.ts
@@ -1,12 +1,7 @@
 import JSZip from 'jszip'
 import { writeBlobToScratchFile } from './writeToScratch'
 
-/** A file from either a zip archive or a picked folder, addressed by a forward-slash
- *  relative path so the rest of the importers don't need to know which source it
- *  came from. `diskPath` is set for disk-backed sources (a zip extracted to a scratch
- *  directory) - importers reuse it directly as a sample's imagePath instead of writing
- *  another scratch copy, and can look up its dimensions without ever reading its bytes
- *  into the renderer. */
+/** A file from a zip or picked folder, addressed by a relative path so importers don't need to know the source. `diskPath` is set for disk-backed sources, reusable directly as a sample's imagePath. */
 export type VirtualFile = {
   path: string
   diskPath?: string
@@ -14,9 +9,7 @@ export type VirtualFile = {
   blob: () => Promise<Blob>
 }
 
-/** Reads the whole input zip into memory - only used for small manifest/label reads via
- *  findYoloClasses etc. Large zip-based imports should extract to disk instead; see
- *  virtualFilesFromExtractedZip. */
+/** Reads the whole zip into memory - only for small manifest/label reads. Large imports should use virtualFilesFromExtractedZip instead. */
 export const virtualFilesFromZip = async (zipFile: File): Promise<VirtualFile[]> => {
   const zip = await JSZip.loadAsync(zipFile)
   const files: VirtualFile[] = []
@@ -33,21 +26,7 @@ export const virtualFilesFromZip = async (zipFile: File): Promise<VirtualFile[]>
   return files
 }
 
-/** Extracts a dropped zip disk-to-disk into scratchDir (via the main-process streaming
- *  extractor) instead of inflating the whole archive into renderer memory. Every entry's
- *  `diskPath` points at its real extracted location, so importers can reuse it as a
- *  sample's imagePath with no further copying.
- *
- *  Resolves the picked file's own real path via webUtils.getPathForFile rather than
- *  copying it into scratchDir first - a naive copy (read the File's bytes, ship them
- *  across IPC, write them back out) would hold the entire file in memory twice over for
- *  something that's already sitting on disk, which for a multi-gigabyte dataset export
- *  defeats the point of extracting it in a streaming fashion at all. That resolution only
- *  works for a File Electron itself handed the renderer (a native file-picker selection or
- *  a plain OS drag) - a Dropzone drag that goes through directory-aware processing (needed
- *  elsewhere for folder drops) re-materializes the File via the FileSystemEntry API first,
- *  which Electron can't map back to a real path. Falls back to the naive copy only in that
- *  case, so drag-and-drop still works for a zip too, just without the streaming shortcut. */
+/** Extracts a dropped zip disk-to-disk into scratchDir instead of inflating it into renderer memory - falls back to a naive byte-copy only when the picked File has no resolvable real path (a Dropzone folder-drop re-materializes it via FileSystemEntry first, which Electron can't map back to a path). */
 export const virtualFilesFromExtractedZip = async (
   zipFile: File,
   scratchDir: string
@@ -57,9 +36,7 @@ export const virtualFilesFromExtractedZip = async (
 
   await window.zip.extractTo(zipPath, scratchDir)
   if (!resolvedPath) {
-    // The staged copy lives inside scratchDir itself (nowhere else to put it without a
-    // second temporary-directory round trip) - remove it before listing so it isn't
-    // mistaken for one of the zip's own extracted entries.
+    // The staged copy lives inside scratchDir itself - remove it before listing so it isn't mistaken for an extracted entry.
     await window.system.deleteFile(zipPath)
   }
 
@@ -71,23 +48,15 @@ export const virtualFilesFromExtractedZip = async (
       path: relativePath,
       diskPath,
       text: () => window.system.readTextFile(diskPath),
-      // Callers should use diskPath directly (as an imagePath, or via
-      // window.system.getImageDimensions) instead of reading bytes back into the
-      // renderer - blob() is only meaningful for in-memory sources.
+      // Callers should use diskPath directly instead - blob() is only for in-memory sources.
       blob: () => Promise.reject(new Error('blob() is not supported for disk-backed files'))
     }
   })
 }
 
-/** Accepts a plain File[] as well as a live FileList - callers reading from an
- *  <input type="file"> should pass Array.from(input.files) captured synchronously in
- *  the change handler, before any await. input.files is the same mutable FileList object
- *  on every read (not a fresh snapshot), and gets cleared in place by a later
- *  `input.value = ''` reset - holding onto the FileList itself across an async gap silently
- *  empties it out from under you. */
+/** Accepts a plain File[] as well as a live FileList - capture via Array.from(input.files) synchronously in the change handler, since the live FileList empties out from under an async gap after `input.value = ''`. */
 export const virtualFilesFromFileList = (fileList: FileList | File[]): VirtualFile[] => {
-  // webkitdirectory-selected files carry their folder-relative path here, e.g.
-  // "MyDataset/images/train/img1.jpg".
+  // webkitdirectory-selected files carry a folder-relative path, e.g. "MyDataset/images/train/img1.jpg".
   return Array.from(fileList).map((file) => ({
     path: (file.webkitRelativePath || file.name).replace(/\\/g, '/'),
     text: () => file.text(),

--- a/src/renderer/src/components/sampleIO/importers/writeToScratch.ts
+++ b/src/renderer/src/components/sampleIO/importers/writeToScratch.ts
@@ -6,9 +6,7 @@ export const extensionOf = (path: string) => {
   return idx === -1 ? 'bin' : path.slice(idx + 1).toLowerCase()
 }
 
-/** Writes one blob to a fresh file under scratchDir, returning its path. Images ingested
- *  this way never get held as base64/blob arrays for the whole import batch - only one at
- *  a time crosses into a scratch file, which the store then consumes directly by path. */
+/** Writes one blob to a fresh file under scratchDir - only one image at a time crosses into a scratch file, never held as base64/blob for the whole batch. */
 export const writeBlobToScratchFile = async (
   scratchDir: string,
   blob: Blob,
@@ -19,9 +17,7 @@ export const writeBlobToScratchFile = async (
   return filePath
 }
 
-/** A disk-backed VirtualFile (extracted from a zip) is reused as-is - no extra copy. A
- *  blob-backed one (from a picked folder) has no on-disk file yet, so it's written to
- *  scratchDir. */
+/** A disk-backed VirtualFile is reused as-is; a blob-backed one is written to scratchDir. */
 export const resolveImagePath = async (image: VirtualFile, scratchDir: string): Promise<string> => {
   if (image.diskPath) return image.diskPath
   const blob = await image.blob()

--- a/src/renderer/src/components/sampleIO/importers/yolo/YoloImporterComponent.tsx
+++ b/src/renderer/src/components/sampleIO/importers/yolo/YoloImporterComponent.tsx
@@ -102,10 +102,7 @@ export const YoloImporterComponent: FC<SampleImporterComponentProps> = ({
       e.target.value = ''
       return
     }
-    // input.files is the same mutable FileList object on every read, not a fresh
-    // snapshot - materialize it into a plain array now, synchronously, before loadSource's
-    // first await runs. Otherwise the value reset below (needed so re-picking the same
-    // folder still fires onChange) clears this same FileList in place before it's read.
+    // input.files is a live mutable FileList - materialize it now, before the value reset below (needed so re-picking the same folder still fires onChange) clears it in place.
     const files = Array.from(fileList)
     loadSource(() => virtualFilesFromFileList(files))
     e.target.value = ''

--- a/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
+++ b/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
@@ -25,9 +25,7 @@ export type YoloClass = {
   name: string
 }
 
-/** Reads class names from data.yaml/dataset.yaml (Ultralytics format, `names` as either a
- *  list or an `{id: name}` map) or classes.txt (one name per line, in order). Returns null
- *  if neither is present, so the caller can fall back to naming classes by their raw id. */
+/** Reads class names from data.yaml/dataset.yaml (Ultralytics `names`) or classes.txt - null if neither is present, so the caller can fall back to naming by raw id. */
 export const findYoloClasses = async (files: VirtualFile[]): Promise<YoloClass[] | null> => {
   const dataYaml = files.find((f) => /(^|\/)(data|dataset)\.ya?ml$/i.test(f.path))
   if (dataYaml) {
@@ -64,9 +62,7 @@ export type YoloBox = {
   h: number
 }
 
-/** Parses a YOLO label .txt file's bounding-box lines (`class cx cy w h`). Ignores blank
- *  lines and any trailing columns (e.g. from segmentation/OBB variants) - only the first
- *  five fields are used. Malformed lines are skipped rather than failing the whole import. */
+/** Parses a YOLO label .txt file's box lines (`class cx cy w h`) - only the first 5 fields are used, malformed lines are skipped rather than failing the import. */
 export const parseYoloLabelFile = (content: string): YoloBox[] => {
   return content
     .split(/\r?\n/)
@@ -116,10 +112,7 @@ export type YoloPolygon = {
   points: { x: number; y: number }[]
 }
 
-/** Parses a YOLO-seg label .txt file's polygon lines (`class x1 y1 x2 y2 ... xn yn`).
- *  Requires at least 3 vertices - anything shorter isn't a real polygon and would be
- *  indistinguishable from a detection line anyway. Malformed or too-short lines are
- *  skipped rather than failing the whole import. */
+/** Parses a YOLO-seg label .txt file's polygon lines (`class x1 y1 ... xn yn`) - requires at least 3 vertices, malformed/short lines are skipped rather than failing the import. */
 export const parseYoloSegmentationLabelFile = (content: string): YoloPolygon[] => {
   return content
     .split(/\r?\n/)
@@ -161,12 +154,7 @@ export type YoloImagePair = {
 
 const IMAGES_DIR_PATTERN = /(^|\/)images\//
 
-/** Pairs each image with its YOLO label file, checked in the same directory first (flat
- *  layouts) and then via the Ultralytics `images/` -> `labels/` sibling-directory
- *  convention. Images without a matching label are kept (imported with no annotations)
- *  rather than dropped. Images under a val/valid/validation folder default to the Valid
- *  split, a test folder to Test, and everything else to Train - there's no UI for this
- *  since it just mirrors the dataset's own folder structure. */
+/** Pairs each image with its YOLO label file - same directory first, then the Ultralytics `images/` -> `labels/` convention. An unmatched image is kept with no annotations, not dropped. Split is inferred from the folder name (val/test/train), no UI for it. */
 export const findYoloImagePairs = (files: VirtualFile[]): YoloImagePair[] => {
   const byPath = new Map(files.map((f) => [f.path, f] as const))
 
@@ -184,8 +172,7 @@ export const findYoloImagePairs = (files: VirtualFile[]): YoloImagePair[] => {
     })
 }
 
-/** Every distinct class id actually referenced by the dataset's label files, used to build
- *  a fallback class list ("Class 0", "Class 1", ...) when there's no data.yaml/classes.txt. */
+/** Every distinct class id referenced in the dataset's labels - builds a fallback ("Class 0", "Class 1", ...) class list when there's no data.yaml/classes.txt. */
 export const findReferencedClassIds = async (pairs: YoloImagePair[]): Promise<number[]> => {
   const ids = new Set<number>()
   for (const pair of pairs) {
@@ -197,12 +184,7 @@ export const findReferencedClassIds = async (pairs: YoloImagePair[]): Promise<nu
   return Array.from(ids).sort((a, b) => a - b)
 }
 
-/** Gets the image's pixel dimensions (needed to normalize box/polygon coordinates) and a
- *  scratch-file imagePath. A disk-backed pair (extracted from a zip) already has a real
- *  file - its dimensions are read directly via sharp (main-process, no bytes cross into
- *  the renderer) and its diskPath is reused as-is, no extra copy. A blob-backed pair (a
- *  picked folder) has no on-disk file yet, so it's decoded once via createImageBitmap for
- *  its dimensions and then written to scratchDir. */
+/** Gets the image's pixel dimensions and a scratch-file imagePath. A disk-backed pair reuses its diskPath as-is (dimensions read main-process side, no bytes cross into the renderer); a blob-backed pair is decoded once via createImageBitmap and written to scratchDir. */
 const resolveImagePathAndDimensions = async (
   image: VirtualFile,
   scratchDir: string
@@ -266,11 +248,7 @@ const buildSampleFromYoloPair = async (
   }
 }
 
-/** Converts the whole dataset to samples, one image at a time (not in parallel - datasets
- *  can run into the thousands of images, and decoding many at once risks spiking memory).
- *  `format` picks how every label line in the dataset is interpreted - YOLO's own label
- *  files don't self-describe this, and a dataset is conventionally all-detection or
- *  all-segmentation, so it's one choice for the whole import rather than inferred per line. */
+/** Converts the whole dataset to samples one image at a time, not in parallel - datasets can run into the thousands and decoding many at once risks spiking memory. `format` is one choice for the whole import since YOLO label files don't self-describe it. */
 export const yoloDatasetToSamples = async (
   pairs: YoloImagePair[],
   classIdToLabelId: Map<number, string | null>,

--- a/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
+++ b/src/renderer/src/components/sampleIO/importers/yolo/parseYolo.ts
@@ -82,8 +82,7 @@ export const parseYoloLabelFile = (content: string): YoloBox[] => {
     )
 }
 
-/** Converts a normalized YOLO box into the labeler's 2-point (top-left, bottom-right)
- *  absolute-pixel box representation. */
+/** Converts a normalized YOLO box into the labeler's 2-point (top-left, bottom-right) absolute-pixel box. */
 export const yoloBoxToPoints = (
   box: YoloBox,
   imageWidth: number,

--- a/src/renderer/src/components/sampleIO/types.ts
+++ b/src/renderer/src/components/sampleIO/types.ts
@@ -3,9 +3,7 @@ import type { INewSample, IProject, ISample, ITask } from '@shared/types'
 
 export interface SampleImporterComponentProps {
   project: IProject
-  /** scratchDir is the directory the importer wrote every sample's imagePath into -
-   *  the caller owns deleting it once it's done with the samples (immediately if they're
-   *  persisted right away, or later if they're only staged for review first). */
+  /** scratchDir is where the importer wrote every sample's imagePath - the caller owns deleting it once done with the samples. */
   onComplete: (samples: INewSample[], scratchDir: string) => void
   onCancel: () => void
 }
@@ -15,11 +13,7 @@ export interface SampleImporter {
   name: string
   description: string
   icon: ReactNode
-  /**
-   * Owns its own step/wizard state internally (e.g. a COCO importer might go
-   * pick file -> map categories to labels -> preview -> confirm). Must call
-   * onComplete exactly once, when it has produced samples to import.
-   */
+  /** Owns its own step/wizard state internally. Must call onComplete exactly once, when it has produced samples to import. */
   Component: FC<SampleImporterComponentProps>
 }
 

--- a/src/renderer/src/data/IpcDataStore.ts
+++ b/src/renderer/src/data/IpcDataStore.ts
@@ -17,8 +17,7 @@ import {
   ITaskUpdate
 } from '@shared/types'
 
-/** A generic proxy to whatever IDataStore main currently has active - it doesn't know or
- *  care which backend that is, main's StoreOrchestrator handles that entirely. */
+/** A generic proxy to whatever IDataStore main currently has active - doesn't know or care which backend, StoreOrchestrator handles that entirely. */
 export class IpcDataStore implements IDataStore {
   connect(): Promise<void> {
     return window.store.connect()

--- a/src/renderer/src/hooks/useAnnotatorRuntime.ts
+++ b/src/renderer/src/hooks/useAnnotatorRuntime.ts
@@ -20,10 +20,7 @@ type AnnotatorRuntimeActions = {
   forget: (annotatorId: string) => void
 }
 
-/** Deliberately plain in-memory state, not backed by any store/database - an annotator's
- *  label vocabulary and its mapping against a project's labels are only ever known once
- *  the app connects to it (see components/annotators/AnnotatorsModal.tsx), and both are
- *  discarded on reload rather than persisted anywhere. */
+/** Deliberately plain in-memory state, not backed by any store - an annotator's label vocabulary/mapping is only known once connected, and discarded on reload. */
 export const useAnnotatorRuntime = create<AnnotatorRuntimeState & AnnotatorRuntimeActions>(
   (set) => ({
     entries: {},

--- a/src/renderer/src/hooks/useAnnotators.ts
+++ b/src/renderer/src/hooks/useAnnotators.ts
@@ -2,10 +2,7 @@ import { useCallback } from 'react'
 import { makeUUID } from '@shared/utils'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 const ANNOTATORS_QUERY_KEY = ['annotators'] as const
-/** Annotators are store-agnostic and project-agnostic app-level data (see
- *  main/appStore.ts) - fetched straight off window.appStore rather than through
- *  useAppStore's pluggable IDataStore, the same way window.system/window.exportApi are
- *  called directly elsewhere without going through a zustand slice. */
+/** Annotators are store-agnostic app-level data (see main/appStore.ts) - fetched straight off window.appStore, not through useAppStore's pluggable IDataStore. */
 export const useAnnotators = () => {
   const queryClient = useQueryClient()
 

--- a/src/renderer/src/hooks/useCopyAnnotations.ts
+++ b/src/renderer/src/hooks/useCopyAnnotations.ts
@@ -36,13 +36,7 @@ const INITIAL_PROGRESS: CopyAnnotationsProgress = {
   failures: []
 }
 
-/** Copies each pair's source-sample annotations onto its destination sample, skipping a
- *  pair whose destination already has annotations (never overwrite manual work), whose
- *  source/destination dimensions differ (points are absolute pixel coordinates, so a
- *  verbatim copy is only correct when the images are the same size), or whose destination
- *  was already claimed by an earlier pair in this same run (first pair mapped to a given
- *  destination wins - prevents double-copying into it). Runs sequentially and keeps going
- *  past a per-pair failure, same as useRunAnnotator. */
+/** Copies source annotations onto each pair's destination, skipping one that's already labeled, has mismatched dimensions (points are absolute pixels), or was already claimed by an earlier pair this run. Sequential, keeps going past a per-pair failure. */
 export const useCopyAnnotations = (destinationTaskId: string) => {
   const store = useAppStore((s) => s.store)
   const queryClient = useQueryClient()

--- a/src/renderer/src/hooks/useProjects.ts
+++ b/src/renderer/src/hooks/useProjects.ts
@@ -63,9 +63,7 @@ export const useProjects = () => {
         current.map((project) => {
           if (project.id !== update.id) return project
           const existingIds = new Set(project.labels.map((l) => l.id))
-          // A label id the project doesn't have yet is a new one being added (see
-          // IProjectUpdate), not a rename - append it rather than dropping it on the
-          // floor until the post-mutation refetch catches up.
+          // A label id the project doesn't have yet is new, not a rename - append it rather than dropping it until the refetch catches up.
           const newLabels = (update.labels ?? []).filter((l) => !existingIds.has(l.id))
           return {
             ...project,

--- a/src/renderer/src/hooks/useRunAnnotator.ts
+++ b/src/renderer/src/hooks/useRunAnnotator.ts
@@ -36,10 +36,7 @@ export const useRunAnnotator = (taskIds: string[]) => {
   const queryClient = useQueryClient()
   const [progress, setProgress] = useState<RunAnnotatorProgress>(INITIAL_PROGRESS)
   const [isRunning, setIsRunning] = useState(false)
-  // Distinct from isRunning (which flips back to false once the run finishes) and from
-  // progress.total (which is legitimately 0 when every sample was already labeled) - the
-  // only reliable way to tell "a run happened" from "nothing has run yet" is a flag that
-  // run() itself sets and only reset() clears.
+  // Distinct from isRunning (flips back once finished) and progress.total (legitimately 0 when already labeled) - only run()/reset() touch this.
   const [hasRun, setHasRun] = useState(false)
 
   const run = useCallback(
@@ -86,9 +83,7 @@ export const useRunAnnotator = (taskIds: string[]) => {
         }
       }
 
-      // Awaited before clearing isRunning (which enables "Done") - the caller can stay on
-      // this same modal and immediately Run again, so the sample list backing that next
-      // run must already reflect the annotations just created, not a stale pre-run snapshot.
+      // Awaited before clearing isRunning - an immediate re-Run must see the annotations just created, not a stale snapshot.
       await Promise.all(
         taskIds.map((taskId) =>
           queryClient.invalidateQueries({ queryKey: ['samples', taskId, store] })

--- a/src/renderer/src/hooks/useRunAnnotator.ts
+++ b/src/renderer/src/hooks/useRunAnnotator.ts
@@ -30,12 +30,7 @@ const INITIAL_PROGRESS: RunAnnotatorProgress = {
   failures: []
 }
 
-/** Runs an annotator over a set of samples, skipping any sample that already has at
- *  least one annotation - auto-labeling only ever targets unlabeled samples. Runs
- *  sequentially and keeps going past a per-sample failure so one bad image doesn't stop
- *  the rest of the batch. `taskIds` covers every task the passed-in samples were drawn
- *  from (usually one, but a batch run from the Tasks page can span several), so each of
- *  their sample caches gets invalidated once the run finishes. */
+/** Runs an annotator over samples, skipping any already-annotated one. Sequential, keeps going past a per-sample failure. `taskIds` covers every task the samples were drawn from, so each cache gets invalidated when the run finishes. */
 export const useRunAnnotator = (taskIds: string[]) => {
   const store = useAppStore((s) => s.store)
   const queryClient = useQueryClient()

--- a/src/renderer/src/hooks/useTags.ts
+++ b/src/renderer/src/hooks/useTags.ts
@@ -4,9 +4,7 @@ import { useCallback } from 'react'
 import { useAppStore } from './useAppStore'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-/** A project's tag vocabulary - managed from one place (ManageTagsModal). Typing only
- *  ever happens here (create/rename); everywhere else a tag is attached to a task, it's
- *  picked from `items` by id. */
+/** A project's tag vocabulary - managed from one place (ManageTagsModal); elsewhere a tag is always picked from `items` by id. */
 export const useTags = (project: IProject) => {
   const store = useAppStore((s) => s.store)
   const queryClient = useQueryClient()

--- a/src/renderer/src/hooks/useTags.ts
+++ b/src/renderer/src/hooks/useTags.ts
@@ -21,8 +21,7 @@ export const useTags = (project: IProject) => {
     [queryClient, tagsQueryKey]
   )
 
-  // A rename/delete changes what's embedded in each task's own `tags` field too - not
-  // needed for create, which can't affect any task's existing tags.
+  // A rename/delete changes what's embedded in each task's `tags` field too - not needed for create.
   const invalidateTasksToo = useCallback(
     () => queryClient.invalidateQueries({ queryKey: tasksQueryKey }),
     [queryClient, tasksQueryKey]

--- a/src/renderer/src/hooks/useTasks.ts
+++ b/src/renderer/src/hooks/useTasks.ts
@@ -123,11 +123,7 @@ export const useTasks = (project: IProject) => {
     [removeMutateAsync]
   )
 
-  // Tags are picked by id (see hooks/useTags.ts for the project's vocabulary) and
-  // attached/detached across a whole batch of task ids in one call (see
-  // IDataStore.addTagsToTasks) - simple invalidate-on-success here rather than granular
-  // optimistic patching, since tagging isn't perf-sensitive and the resulting per-task
-  // tag lists are easiest to just re-fetch.
+  // Simple invalidate-on-success rather than granular optimistic patching - tagging isn't perf-sensitive, easiest to just re-fetch.
   const { mutateAsync: addTagsMutateAsync } = useMutation({
     mutationFn: ({ taskIds, tagIds }: { taskIds: string[]; tagIds: string[] }) =>
       store.addTagsToTasks(taskIds, tagIds),

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,5 +1,4 @@
-// Import styles of packages that you've installed.
-// All packages except `@mantine/hooks` require styles imports
+// All packages except @mantine/hooks require a styles import.
 import '@mantine/core/styles.css'
 import '@mantine/dropzone/styles.css'
 import 'mantine-contextmenu/styles.css'

--- a/src/renderer/src/router/RouterOutlet.tsx
+++ b/src/renderer/src/router/RouterOutlet.tsx
@@ -6,9 +6,7 @@ import { LabelPage } from '@renderer/routes/label/LabelPage'
 import { makeRouterOutlet } from './makeRouter'
 import { appRouter, type AppRoutes } from './appRouter'
 
-// Only App.tsx should import this module: it pulls in every page component to build the
-// stack, and those pages' hooks import navigate/back from appRouter.tsx - importing this
-// file from anywhere reachable by a page would recreate that cycle.
+// Only App.tsx should import this - it pulls in every page component, and pages' hooks import navigate/back from appRouter.tsx, so importing this from a page would recreate that cycle.
 export const RouterOutlet = makeRouterOutlet<AppRoutes>(appRouter, {
   projects: ProjectsPage,
   tasks: TasksPage,

--- a/src/renderer/src/router/appRouter.tsx
+++ b/src/renderer/src/router/appRouter.tsx
@@ -10,9 +10,7 @@ export type AppRoutes = {
   'copy-annotations': { project: IProject; sourceTask: ITask }
 }
 
-// No page components imported here on purpose - pages' hooks import navigate/back from
-// this module, so pulling in the page components here (which the RouterOutlet needs) would
-// create a cycle. See router/RouterOutlet.tsx for that half.
+// No page components imported here on purpose - pages' hooks import navigate/back from this module, so pulling in page components too would create a cycle. See RouterOutlet.tsx.
 export const appRouter = makeRouter<AppRoutes>('projects')
 export const {
   navigate,

--- a/src/renderer/src/router/makeRouter.tsx
+++ b/src/renderer/src/router/makeRouter.tsx
@@ -38,9 +38,7 @@ export type RouterScreens<Routes extends RouteParamsMap> = {
   [K in keyof Routes]: FC<Routes[K] extends undefined ? Record<string, never> : Routes[K]>
 }
 
-/** Identifies which stack entry a screen (and anything it renders) belongs to, so the
- *  lifecycle hooks below can look up their own entry's visibility. Provided by
- *  `makeRouterOutlet` around each `<Activity>`'s children. */
+/** Identifies which stack entry a screen belongs to, so the lifecycle hooks below can look up its visibility. Provided by `makeRouterOutlet` around each `<Activity>`'s children. */
 type RouteContextValue = { key: string }
 
 export type RouterHandle<Routes extends RouteParamsMap> = {
@@ -49,27 +47,14 @@ export type RouterHandle<Routes extends RouteParamsMap> = {
   useRouterStore: RouterStore<Routes>
   /** True iff this screen's stack entry is currently the top (visible) one. */
   useIsRouteVisible: () => boolean
-  /** Runs `callback` when this screen becomes visible: on first mount, and again every
-   *  time its `<Activity>` subtree goes from hidden back to visible (Activity remounts
-   *  effects on that transition, so a plain mount effect already doubles as this). */
+  /** Runs callback on mount, and again whenever its `<Activity>` subtree goes hidden -> visible (Activity remounts effects on that transition). */
   useOnRouteEnter: (callback: () => void) => void
-  /** Runs `callback` when this screen stops being visible: hidden by a `navigate()` past
-   *  it, or fully removed by `back()` (Activity tears down effects in both cases, so a
-   *  plain effect cleanup already doubles as this). */
+  /** Runs callback when this screen stops being visible - hidden by navigate() past it, or removed by back() (Activity tears down effects either way). */
   useOnRouteLeave: (callback: () => void) => void
   RouteContext: React.Context<RouteContextValue | null>
 }
 
-/**
- * Builds a stack-based navigator's data/actions: screens are pushed on top of each other
- * and stay mounted (see `makeRouterOutlet`) so state like scroll position survives going
- * back, instead of the unmount/remount that a route-swapping router does.
- *
- * Deliberately takes no screen components - only the route/param shape - so modules that
- * just need to call `navigate`/`back` (e.g. a page's data hook) don't have to import every
- * other page's component to get them, which would create a circular dependency between
- * this module and the pages themselves. Pair with `makeRouterOutlet` to render the stack.
- */
+/** Builds a stack navigator's data/actions - screens stay mounted (see makeRouterOutlet) so state like scroll position survives going back. Takes no screen components, only the route/param shape, so callers of navigate()/back() don't create a circular dependency importing every page. */
 export const makeRouter = <Routes extends RouteParamsMap>(
   ...initial: AnyNavigateArgs<Routes>
 ): RouterHandle<Routes> => {
@@ -137,13 +122,7 @@ export const makeRouter = <Routes extends RouteParamsMap>(
   }
 }
 
-/**
- * Builds the `<RouterOutlet>` component that actually renders a router's stack, given its
- * screen components. Kept separate from `makeRouter` so the store/navigate/back can live in
- * a module with no page imports (see `makeRouter`'s doc comment) while this piece - which
- * necessarily imports every page component - stays isolated to wherever the app root
- * assembles them (e.g. `App.tsx`), rather than being reachable from the pages themselves.
- */
+/** Builds the `<RouterOutlet>` that renders a router's stack given its screen components - kept separate from makeRouter so only the app root (which imports every page) needs this piece. */
 export const makeRouterOutlet = <Routes extends RouteParamsMap>(
   router: RouterHandle<Routes>,
   screens: RouterScreens<Routes>

--- a/src/renderer/src/routes/label/AnnotationsDrawer.tsx
+++ b/src/renderer/src/routes/label/AnnotationsDrawer.tsx
@@ -51,12 +51,10 @@ export type AnnotationsDrawerProps = {
 const AnnotationTypeIcon = ({ type }: { type: AnnotationType }) =>
   type === AnnotationType.Box ? <BsBoundingBoxCircles size={14} /> : <PiPolygonLight size={14} />
 
-/** Groups annotations that don't resolve to a project label (e.g. the label was since
- *  deleted) - kept visible under their own group rather than dropped. */
+/** Groups annotations whose label was since deleted - kept visible under their own group rather than dropped. */
 const UNKNOWN_LABEL_GROUP = '__unknown__'
 
-/** Buckets annotations by label id, preserving each group's first-occurrence order in
- *  the underlying annotation list. */
+/** Buckets annotations by label id, preserving each group's first-occurrence order. */
 const groupByLabel = (annotations: IAnnotation[]): Map<string, IAnnotation[]> => {
   const groups = new Map<string, IAnnotation[]>()
   for (const annotation of annotations) {

--- a/src/renderer/src/routes/label/AnnotationsDrawer.tsx
+++ b/src/renderer/src/routes/label/AnnotationsDrawer.tsx
@@ -21,9 +21,7 @@ import tinycolor from 'tinycolor2'
 import { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 
-// Same hover-affordance convention as BasicListPageItem's Row: a plain background swap
-// on hover, layered with a stronger one for the selected row so hovering an
-// already-selected row still visibly reacts instead of looking inert.
+// Same hover convention as BasicListPageItem's Row - a stronger swap layered on the selected row so it still visibly reacts to hover.
 const AnnotationRow = styled(Group)`
   cursor: pointer;
   border-radius: var(--mantine-radius-sm);
@@ -79,17 +77,14 @@ export const AnnotationsDrawer: FC<AnnotationsDrawerProps> = ({ store, opened, o
   const labelsMap = store((s) => s.labelsMap)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
 
-  // Closing the drawer doesn't naturally fire a mouseleave on whatever was hovered when
-  // it closed - clear the canvas dim/spotlight explicitly so it doesn't linger.
+  // Closing the drawer doesn't fire a mouseleave on whatever was hovered - clear the dim explicitly so it doesn't linger.
   useEffect(() => {
     if (!opened) {
       store.getState().setAnnotationsDrawerHovered(false)
     }
   }, [opened, store])
 
-  // Same idea for leaving the Labeler page entirely while the drawer happened to be open -
-  // that also doesn't fire a mouseleave, and Activity would otherwise preserve the dim
-  // state until the user's mouse re-triggers it on return.
+  // Same idea for leaving the Labeler page entirely while the drawer was open.
   useOnRouteLeave(() => store.getState().setAnnotationsDrawerHovered(false))
 
   const toggleGroup = (key: string) =>

--- a/src/renderer/src/routes/label/LabelPage.tsx
+++ b/src/renderer/src/routes/label/LabelPage.tsx
@@ -110,9 +110,7 @@ const LabelerModeControl = ({ value, onChange, size = 'md' }: LabelerModeControl
   />
 )
 
-// Labels grow unbounded (a project can have dozens), so this row needs to size to its
-// natural content width and scroll rather than stretch every item to fill the bar -
-// the fixed cap keeps the bottom bar's other controls from getting pushed off-screen.
+// Labels grow unbounded (a project can have dozens), so this row scrolls at its natural width instead of stretching and pushing the bottom bar's other controls off-screen.
 const LABEL_LIST_MAX_WIDTH = 'min(420px, 40vw)'
 
 const TextSegmentedControl = ({
@@ -244,10 +242,7 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
       const { commit, rollback } = sample.update({
         completedAt: newValue
       })
-      // sample.update() mutates the OptimisticObject through its own private
-      // subscription system, which the labeler zustand store never hears about.
-      // Force a notify so selectors reading sample.resolve() (currentSampleId,
-      // sampleCompletedAt) actually re-render.
+      // sample.update() mutates via its own private subscription, which the labeler store never hears about - force a notify so its selectors re-render.
       store.setState((s) => ({ ...s }))
       return useAppStore
         .getState()
@@ -273,12 +268,9 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
     store.getState().setSample(samples[index])
   }, [index, samples, store])
 
-  // Force a full repaint on return: the canvas's own resize-detection normally covers
-  // becoming visible again, but that depends on measuring a bounding rect that Activity
-  // may not have finished restoring yet - an explicit markAllDirty() here is reliable.
+  // Forces a repaint on return - Activity's bounding rect may not be finished restoring when the canvas's own resize-detection would otherwise run.
   useOnRouteEnter(() => store.getState().markAllDirty())
-  // Don't let a bitmap load started for this page keep running (and settling into a
-  // hidden store) after the user has already left it.
+  // Don't let a bitmap load started for this page keep running after the user has left it.
   useOnRouteLeave(() => store.getState().cancelPendingSampleLoad())
 
   const goToSample = useCallback(
@@ -336,13 +328,11 @@ export const LabelPage = ({ project, samples, initial }: LabelPageProps) => {
     ]
   )
 
-  // useHotkeys ignores INPUT/TEXTAREA/SELECT targets by default, so this doesn't fire
-  // while e.g. the sample index NumberInput below is focused.
+  // useHotkeys ignores INPUT/TEXTAREA/SELECT targets, so this doesn't fire while e.g. the sample index NumberInput is focused.
   useHotkeys(hotkeys)
 
   useEffect(() => {
-    // event.button 3/4 are the mouse's back/forward side buttons - preventDefault on
-    // mousedown, which is where Electron/Chromium's own back/forward would otherwise fire.
+    // event.button 3/4 are the mouse's back/forward buttons - preventDefault on mousedown blocks Electron/Chromium's own back/forward.
     const onMouseDown = (event: MouseEvent) => {
       if (isDeleteConfirmOpen) return
       if (event.button === 3) {

--- a/src/renderer/src/routes/projects/EditProjectModal.tsx
+++ b/src/renderer/src/routes/projects/EditProjectModal.tsx
@@ -27,12 +27,9 @@ export const EditProjectModal: FC<EditProjectModalProps> = ({
   onConfirm
 }) => {
   const [name, setName] = useState(project?.name ?? '')
-  // Only ids the project already had when this modal opened are "existing" - anything
-  // added afterward stays removable for the rest of this session.
+  // Only ids the project had when this modal opened count as "existing" - anything added afterward stays removable.
   const [existingLabelIds] = useState(() => new Set((project?.labels ?? []).map((l) => l.id)))
-  // useArray mutates its initial array in place (push/splice/etc. act directly on the
-  // reference it's given) - a shallow copy here keeps that from reaching back into
-  // project.labels itself, which react-query still owns.
+  // useArray mutates its initial array in place - a shallow copy keeps that from reaching back into project.labels, which react-query still owns.
   const labels = useArray<ILabel>((project?.labels ?? []).map((l) => ({ ...l })))
 
   const canSave = name.trim().length > 0 && labels.every((l) => l.name.trim().length > 0)

--- a/src/renderer/src/routes/projects/EditProjectModal.tsx
+++ b/src/renderer/src/routes/projects/EditProjectModal.tsx
@@ -19,11 +19,7 @@ export type EditProjectModalProps = {
   ) => Promise<unknown>
 }
 
-/** Renames the project, edits existing labels (including their colors), and lets new
- *  labels be added - existing labels still can't be removed here, since one already
- *  used by an annotation can't be deleted. A label added (and not yet saved) in this
- *  same session can be removed again freely, since nothing references it yet. Controlled
- *  by mounting with `key={project?.id}` so state resets when the target project changes. */
+/** Renames the project and edits/adds labels - can't remove an existing one (used by an annotation), but a not-yet-saved new one can be removed freely. Mount with `key={project?.id}` to reset state per project. */
 export const EditProjectModal: FC<EditProjectModalProps> = ({
   opened,
   project,

--- a/src/renderer/src/routes/projects/ProjectsPage.tsx
+++ b/src/renderer/src/routes/projects/ProjectsPage.tsx
@@ -51,8 +51,7 @@ export const ProjectsPage = () => {
   const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(new Set())
   const [isBatchDeletePending, setIsBatchDeletePending] = useState(false)
 
-  // Selected projects stay visible even if a search narrows the list below them, so
-  // batch actions never silently lose track of a selection the user can no longer see.
+  // Selected projects stay visible even if a search narrows the list below them.
   const filteredItems = useMemo(
     () =>
       items.filter(
@@ -69,8 +68,7 @@ export const ProjectsPage = () => {
     setSelectedProjectIds(new Set())
   }
 
-  // Multiselect shouldn't still be armed when the user comes back to this page later -
-  // Activity preserves this state across a hide/show, so it has to be cleared explicitly.
+  // Activity preserves this state across a hide/show, so it needs clearing explicitly.
   useOnRouteLeave(exitSelectMode)
 
   const toggleSelected = (projectId: string, selected: boolean) => {
@@ -85,16 +83,13 @@ export const ProjectsPage = () => {
     })
   }
 
-  // Enters select mode with just this one project selected - the context menu's "Select"
-  // entry point outside select mode (see selectAll/selectAbove/selectBelow below for the
-  // batch variants offered once already in select mode).
+  // The context menu's "Select" entry point outside select mode.
   const selectOnly = (projectId: string) => {
     setIsSelectMode(true)
     setSelectedProjectIds(new Set([projectId]))
   }
 
-  // Selection helpers operate on filteredItems (the currently visible/filtered list),
-  // not the full unfiltered project list, and all three enter select mode if not already.
+  // Operate on filteredItems, not the full unfiltered list, and all enter select mode if not already.
   const selectAll = () => {
     setIsSelectMode(true)
     setSelectedProjectIds(new Set(filteredItems.map((p) => p.id)))
@@ -220,8 +215,7 @@ export const ProjectsPage = () => {
             items={filteredItems}
             getKey={(p) => p.id}
             scrollContainerRef={scrollContainerRef}
-            // Closer to a row with a label badge line than the component's generic
-            // default (90) - most projects have at least one label.
+            // Closer to a row with a label badge line than the generic default (90) - most projects have at least one label.
             estimateSize={80}
             renderItem={(p, index) => (
               <BasicListPageItem

--- a/src/renderer/src/routes/samples/SamplesPage.tsx
+++ b/src/renderer/src/routes/samples/SamplesPage.tsx
@@ -84,11 +84,7 @@ const STATUS_COMBO_BOX_OPTIONS: SegmentedControlItem[] = [
   }
 ]
 
-// Per-label annotation counts for one sample, e.g. "Stop Sign: 2" - ordered to match the
-// project's own label list rather than first-seen order, and coloured the same way
-// ProjectsPage's LabelTags colours a project's label badges (filled with the label's own
-// color, text contrast picked via tinycolor). A label with zero annotations on this
-// sample is omitted entirely rather than shown as "Label: 0".
+// Per-label annotation counts for one sample, e.g. "Stop Sign: 2" - ordered to match the project's label list, colored like ProjectsPage's LabelTags. A zero-count label is omitted, not shown as "Label: 0".
 const AnnotationLabelCounts = ({
   annotations,
   labels
@@ -277,15 +273,11 @@ export const SamplesPage = ({ project, task }: SamplesPageProps) => {
   const [pendingDelete, setPendingDelete] = useState<OptimisticSample | null>(null)
   const [pendingRename, setPendingRename] = useState<OptimisticSample | null>(null)
   const [isImportOpen, setIsImportOpen] = useState(false)
-  // A descriptor, not a frozen sample list - the modal can stay open across multiple runs
-  // (see AnnotatorsModal's "Done" button), so the samples it acts on must be re-derived
-  // from the live `items` on every render rather than snapshotted once at click time, or a
-  // second Run would see samples the first run just labeled as still unlabeled.
+  // A descriptor, not a frozen sample list - re-derived from live `items` every render, since the modal can stay open across multiple runs (AnnotatorsModal's "Done").
   const [autoLabelSelection, setAutoLabelSelection] = useState<'all' | string | null>(null)
   const canAutoLabel = annotators.length > 0
 
-  // Don't leave the auto-label modal armed to reopen against a stale target next time
-  // this page becomes visible - Activity preserves this state across a hide/show.
+  // Activity preserves this state across a hide/show, so it needs clearing explicitly.
   useOnRouteLeave(() => setAutoLabelSelection(null))
 
   const filteredItems = useMemo(

--- a/src/renderer/src/routes/tasks/BatchEditTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/BatchEditTagsModal.tsx
@@ -10,17 +10,13 @@ export type BatchEditTagsModalProps = {
   opened: boolean
   project: IProject
   taskCount: number
-  /** Tags currently on at least one selected task - the only ones removal makes sense
-   *  for, since there's no single "current" tag list across a batch of possibly
-   *  differently-tagged tasks to diff against (unlike EditTaskTagsModal). */
+  /** Tags on at least one selected task - the only ones removal makes sense for, since there's no single "current" list across a differently-tagged batch. */
   removableTags: ITag[]
   onCancel: () => void
   onConfirm: (addedIds: string[], removedIds: string[]) => Promise<unknown>
 }
 
-/** Adds/removes tags across a batch of tasks - "Add" is a creatable combobox (TagPicker,
- *  same as the single-task modal) and "Remove" is a row of clickable chips (only tags
- *  already on some selected task, so there's nothing to type there). */
+/** Adds/removes tags across a batch of tasks - "Add" is a creatable combobox (TagPicker), "Remove" is a row of chips for tags already on some selected task. */
 export const BatchEditTagsModal: FC<BatchEditTagsModalProps> = ({
   opened,
   project,

--- a/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
+++ b/src/renderer/src/routes/tasks/CopyAnnotationsPage.tsx
@@ -49,17 +49,7 @@ type SampleMappingRowsProps = {
   onChange: (sourceSampleId: string, destinationSampleId: string | null) => void
 }
 
-/** Two lines per source sample: its own thumbnail + full name on top, then a Select to
- *  pick which destination sample it maps to (or Skip) plus a live thumbnail preview of
- *  whichever destination is currently picked - a closed Select can only show text, and
- *  visually confirming "this is the same page" is the whole point when the destination
- *  task's names/text are in a different language. The name gets its own line rather than
- *  sharing one with the Select (source and destination names here are typically long and
- *  differ only by a suffix) so it never has to compete with the Select for width and get
- *  truncated illegibly. Colocated here rather than folded into the shared LabelMapper,
- *  which 6 importer/exporter callers depend on for a plain text-only "map to a project
- *  label" row - bolting a thumbnail concept onto it would leak this one caller's needs
- *  into all of them. */
+/** Two lines per source sample: thumbnail + name, then a Select (or Skip) plus a live thumbnail of the picked destination - visual confirmation matters here since names can differ by language. Kept out of the shared LabelMapper so its thumbnail concept doesn't leak into that component's 6 other text-only callers. */
 const SampleMappingRows: FC<SampleMappingRowsProps> = ({
   sourceSamples,
   destinationSamples,

--- a/src/renderer/src/routes/tasks/CreateTaskButton.tsx
+++ b/src/renderer/src/routes/tasks/CreateTaskButton.tsx
@@ -29,12 +29,7 @@ const CVLABEL_EXTENSION = /\.cvlabel$/i
 /** The dropped file's name minus the .cvlabel extension - seeds the Create Task modal's name field, same role as folderNameFromDroppedFiles for the image-drop path. */
 const taskNameFromCvLabelFile = (file: FileWithPath) => file.name.replace(CVLABEL_EXTENSION, '')
 
-// Mantine's Dropzone only builds valid file-picker options (and skips a console warning)
-// from the record form of `accept` - a flat array gets turned into one made of the array
-// itself as keys, which breaks for an extension-only entry like .cvlabel that isn't a mime
-// type on its own. Every image mime type maps to no extra extensions (the mime key alone
-// is enough), .cvlabel is keyed under the generic zip mime since it has no real one of its
-// own - same association CvLabelImporterComponent's own Dropzone already uses.
+// Dropzone needs the record form of `accept` - .cvlabel has no real mime type, so it's keyed under the generic zip mime, same as CvLabelImporterComponent's own Dropzone.
 const DROP_ACCEPT: Record<string, string[]> = {
   ...Object.fromEntries(IMAGE_MIME_TYPE.map((mimeType) => [mimeType, []])),
   [MIME_TYPES.zip]: ['.cvlabel']
@@ -178,31 +173,21 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
   const [taskName, setTaskName] = useState('')
   const [samples, setSamples] = useState<INewSample[]>([])
 
-  // When a drop spans more than one top-level folder, pendingSplit holds both the raw
-  // files (for the "one task" decline path) and the per-folder grouping (for "separate
-  // tasks"), while the confirm modal asks which the user wants.
+  // Holds both the raw files (for the "one task" decline path) and the per-folder grouping (for "separate tasks") when a drop spans multiple folders.
   const [pendingSplit, setPendingSplit] = useState<{
     allFiles: FileWithPath[]
     groups: ImportQueueItem[]
   } | null>(null)
 
-  // A dropped .cvlabel file takes a different path than images: it needs a label-mapping
-  // step (its annotations reference label ids that may not match this project's), so it
-  // opens the same importer wizard used from "Add Samples" instead of going straight into
-  // startQueue. Once mapped, its onComplete lands in the exact same Create Task modal the
-  // image-drop path uses, pre-filled from the file's own name.
+  // A dropped .cvlabel needs a label-mapping step, so it opens the same importer wizard "Add Samples" uses instead of going straight into startQueue.
   const [cvLabelDropFile, setCvLabelDropFile] = useState<FileWithPath | null>(null)
 
-  // Once a choice is made, importQueue drives the Create Task modal through one item at
-  // a time - Skip or Create both advance to the next. The close button means something
-  // stronger: abandon the rest of the queue entirely, so it's confirmed separately.
+  // Drives the Create Task modal through one queued item at a time - Skip/Create both advance; the close button abandons the whole queue instead.
   const [importQueue, setImportQueue] = useState<ImportQueueItem[]>([])
   const [importQueueIndex, setImportQueueIndex] = useState(0)
   const [isStopConfirmOpen, setIsStopConfirmOpen] = useState(false)
 
-  // Every scratch dir created while staging samples for this Create Task session (from
-  // direct drops or from "Add Samples" sub-imports) - swept once the session ends,
-  // whether that's a submitted task, a skipped item, or the modal being closed outright.
+  // Every scratch dir created this Create Task session - swept once the session ends, however it ends.
   const [, setPendingScratchDirs] = useState<string[]>([])
 
   const discardPendingScratchDirs = useCallback(() => {
@@ -258,8 +243,7 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
     [loadQueueItem]
   )
 
-  // Shared by both Skip and Create - either one is "done with this step," so both move
-  // on to the next queued folder, or close once there isn't one.
+  // Shared by Skip and Create - both move to the next queued folder, or close once there isn't one.
   const advanceQueue = () => {
     const nextIndex = importQueueIndex + 1
     if (nextIndex < importQueue.length) {
@@ -269,19 +253,14 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
       setIsModalOpen(false)
       setImportQueue([])
       setImportQueueIndex(0)
-      // Mantine's Modal keeps its content mounted and interactive during its close
-      // transition, so the Create button (still bound to the just-submitted item) stays
-      // clickable for a moment after this. Clearing samples/taskName here disables it
-      // immediately (empty name), rather than leaving a window to resubmit the same
-      // already-created samples and hit a UNIQUE constraint on their ids.
+      // Clears immediately (empty name disables Create) rather than leaving a window, during Mantine's close transition, to resubmit and hit a UNIQUE constraint.
       setSamples([])
       setTaskName('')
       discardPendingScratchDirs()
     }
   }
 
-  // The close button, once confirmed: unlike Skip, this abandons every remaining queued
-  // folder (not just the current one) rather than continuing to the next.
+  // Unlike Skip, this abandons every remaining queued folder, not just the current one.
   const stopQueue = () => {
     setIsStopConfirmOpen(false)
     setIsModalOpen(false)
@@ -446,7 +425,6 @@ export const CreateTaskButton: FC<CreateTaskButtonProps> = ({ project, create })
         <Stack gap={'lg'}>
           <TextInput
             label="Name"
-            // w={500}
             placeholder="Task Name"
             value={taskName}
             onChange={(e) => setTaskName(e.target.value)}

--- a/src/renderer/src/routes/tasks/CreateTaskButton.tsx
+++ b/src/renderer/src/routes/tasks/CreateTaskButton.tsx
@@ -26,9 +26,7 @@ import { ZIndex } from '@renderer/zIndex'
 
 const CVLABEL_EXTENSION = /\.cvlabel$/i
 
-/** The dropped file's own name, minus the .cvlabel extension - mirrors
- *  folderNameFromDroppedFiles' role for the image-drop path (both just seed the Create
- *  Task modal's name field; the user can still rename before creating). */
+/** The dropped file's name minus the .cvlabel extension - seeds the Create Task modal's name field, same role as folderNameFromDroppedFiles for the image-drop path. */
 const taskNameFromCvLabelFile = (file: FileWithPath) => file.name.replace(CVLABEL_EXTENSION, '')
 
 // Mantine's Dropzone only builds valid file-picker options (and skips a console warning)
@@ -114,9 +112,7 @@ const SelectedSampleRow = memo(function SelectedSampleRow({
   )
 })
 
-/** Memoized so typing in the task name field (which lives in the same parent state as
- *  `samples`) doesn't re-render every imported sample's row, which was visibly laggy for
- *  a large import even before rows only held a scratch path rather than a full image. */
+/** Memoized so typing in the task name field doesn't re-render every imported sample's row - was visibly laggy for a large import otherwise. */
 const SampleList = memo(function SampleList({
   samples,
   onAddSamples,

--- a/src/renderer/src/routes/tasks/EditTaskTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/EditTaskTagsModal.tsx
@@ -14,12 +14,7 @@ export type EditTaskTagsModalProps = {
   onConfirm: (addedIds: string[], removedIds: string[]) => Promise<unknown>
 }
 
-/** Edits one task's tags via a single creatable combobox (TagPicker), pre-filled with the
- *  task's current tags as pills - add more by picking (or creating) from the dropdown,
- *  remove by clicking a pill's own remove button. Diffed against the original set on
- *  Save. Controlled by mounting with a `key` tied to the task (e.g. `key={task?.id}`),
- *  same convention as RenameModal, so reopening for a different task doesn't carry over
- *  the previous selection. */
+/** Edits one task's tags via TagPicker, pre-filled as pills, diffed against the original set on Save. Controlled by mounting with a `key={task?.id}`, same convention as RenameModal. */
 export const EditTaskTagsModal: FC<EditTaskTagsModalProps> = ({
   opened,
   project,

--- a/src/renderer/src/routes/tasks/ManageTagsModal.tsx
+++ b/src/renderer/src/routes/tasks/ManageTagsModal.tsx
@@ -14,9 +14,7 @@ export type ManageTagsModalProps = {
   onClose: () => void
 }
 
-/** The one place a project's tag vocabulary is created/renamed/deleted - typing only
- *  happens here (the "New tag" field); everywhere a tag gets attached to a task, it's
- *  picked from this list by id (see EditTaskTagsModal, BatchEditTagsModal). */
+/** The one place a project's tag vocabulary is created/renamed/deleted - elsewhere a tag is always picked from this list by id (see EditTaskTagsModal, BatchEditTagsModal). */
 export const ManageTagsModal: FC<ManageTagsModalProps> = ({ opened, project, onClose }) => {
   const { items, isLoading, create, rename, remove } = useTags(project)
   const [newName, setNewName] = useState('')

--- a/src/renderer/src/routes/tasks/TagPicker.tsx
+++ b/src/renderer/src/routes/tasks/TagPicker.tsx
@@ -25,9 +25,7 @@ export const TagPicker: FC<TagPickerProps> = ({
   onCreate
 }) => {
   const [search, setSearch] = useState('')
-  // Bridges the gap between a tag being created and useTags' invalidate-triggered
-  // refetch landing - without this, the just-created pill would briefly show no label
-  // (allTags won't contain it yet).
+  // Bridges the gap before useTags' invalidate-triggered refetch lands - otherwise the just-created pill would briefly show no label.
   const [pendingNewTags, setPendingNewTags] = useState<ITag[]>([])
 
   const knownTags = [

--- a/src/renderer/src/routes/tasks/TagPicker.tsx
+++ b/src/renderer/src/routes/tasks/TagPicker.tsx
@@ -15,10 +15,7 @@ export type TagPickerProps = {
   onCreate: (name: string) => Promise<ITag>
 }
 
-/** A single combobox that's both "pick an existing tag" (click, no typing needed) and
- *  "create a new one" (typing only reveals a "+ Create …" option when nothing matches -
- *  clicking that is what actually creates it, never automatic on Enter). Selected tags
- *  render as removable pills in the input itself, standard MultiSelect behavior. */
+/** One combobox that both picks an existing tag and creates a new one (typing reveals "+ Create …", but only clicking it creates - never automatic on Enter). */
 export const TagPicker: FC<TagPickerProps> = ({
   label,
   placeholder,

--- a/src/renderer/src/routes/tasks/TasksPage.tsx
+++ b/src/renderer/src/routes/tasks/TasksPage.tsx
@@ -99,9 +99,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
   const [pendingEditTags, setPendingEditTags] = useState<ITask | null>(null)
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set())
-  // Covers both batch export (the toolbar button, acting on the current selection) and
-  // per-task export (the context menu's single-item entry, offered outside select mode) -
-  // one modal, whichever list of tasks last triggered it.
+  // One modal covers both batch export (toolbar button) and per-task export (context menu) - whichever list of tasks last triggered it.
   const [exportTarget, setExportTarget] = useState<ITask[] | null>(null)
   const [isBatchDeletePending, setIsBatchDeletePending] = useState(false)
   const [isBatchTagsOpen, setIsBatchTagsOpen] = useState(false)
@@ -116,9 +114,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
     [allTags]
   )
 
-  // Selected tasks stay visible even if a search or tag filter narrows the list below
-  // them, so batch actions never silently lose track of a selection the user can no
-  // longer see.
+  // Selected tasks stay visible even if a search/tag filter narrows the list below them.
   const filteredItems = useMemo(
     () =>
       items.filter((t) => {
@@ -149,8 +145,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
     setSelectedTaskIds(new Set())
   }
 
-  // Multiselect shouldn't still be armed when the user comes back to this page later -
-  // Activity preserves this state across a hide/show, so it has to be cleared explicitly.
+  // Activity preserves this state across a hide/show, so it needs clearing explicitly.
   useOnRouteLeave(exitSelectMode)
 
   const toggleSelected = (taskId: string, selected: boolean) => {
@@ -165,16 +160,13 @@ export const TasksPage = ({ project }: TasksPageProps) => {
     })
   }
 
-  // Enters select mode with just this one task selected - the context menu's "Select"
-  // entry point outside select mode (see selectAll/selectAbove/selectBelow below for the
-  // batch variants offered once already in select mode).
+  // The context menu's "Select" entry point outside select mode.
   const selectOnly = (taskId: string) => {
     setIsSelectMode(true)
     setSelectedTaskIds(new Set([taskId]))
   }
 
-  // Selection helpers operate on filteredItems (the currently visible/filtered list),
-  // not the full unfiltered task list, and all three enter select mode if not already in it.
+  // Operate on filteredItems, not the full unfiltered list, and all enter select mode if not already in it.
   const selectAll = () => {
     setIsSelectMode(true)
     setSelectedTaskIds(new Set(filteredItems.map((t) => t.id)))
@@ -190,9 +182,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
     setSelectedTaskIds(new Set(filteredItems.slice(index).map((t) => t.id)))
   }
 
-  // Fetches each task's samples fresh (this page never loads sample data otherwise) and
-  // opens the AnnotatorsModal run flow against all of them at once - lets a batch of tasks
-  // get auto-labeled without opening each one's Samples page individually.
+  // Fetches each task's samples fresh (never otherwise loaded here) and runs AnnotatorsModal against all of them at once.
   const runAutoLabelOn = async (tasksToRun: ITask[]) => {
     const samplesByTask = await Promise.all(tasksToRun.map((t) => store.getSamplesForTask(t.id)))
     setAutoLabelTarget({
@@ -405,9 +395,7 @@ export const TasksPage = ({ project }: TasksPageProps) => {
             items={filteredItems}
             getKey={(t) => t.id}
             scrollContainerRef={scrollContainerRef}
-            // Closer to a row with both a tag line and the progress line than the
-            // component's generic default (90) - every task row shows progress, and
-            // most show tags too.
+            // Closer to a row with both a tag line and progress line than the generic default (90).
             estimateSize={104}
             renderItem={(t, index) => (
               <BasicListPageItem

--- a/src/renderer/src/util/toOptimisticSample.ts
+++ b/src/renderer/src/util/toOptimisticSample.ts
@@ -2,9 +2,7 @@ import { IAnnotation, ISample } from '@shared/types'
 import { OptimisticObject } from './optimistic_object'
 import { OptimisticSample } from '@renderer/types'
 
-/** Wraps a raw ISample (and its annotations) in the OptimisticObject layer the rest of the
- *  app expects a sample to already be in - shared by anything that fetches samples outside
- *  useSamples' own query (e.g. a batch action that pulls samples for several tasks at once). */
+/** Wraps a raw ISample in the OptimisticObject layer the rest of the app expects - for anything fetching samples outside useSamples' own query. */
 export const toOptimisticSample = (sample: ISample): OptimisticSample => {
   const annotationsObj = sample.annotations.reduce<{
     [key: string]: OptimisticObject<IAnnotation>

--- a/src/renderer/src/utils.ts
+++ b/src/renderer/src/utils.ts
@@ -19,9 +19,7 @@ export const normalizeFilename = (filename: string) => {
   return filename.slice(0, idx)
 }
 
-// A flat (non-folder) file's relativePath falls back to "./name.ext" (file-selector's
-// own convention for "no real path") - strip that leading "./" first so it doesn't get
-// mistaken for a real (if oddly named) folder segment.
+// A flat file's relativePath falls back to "./name.ext" (file-selector's "no real path" convention) - strip that leading "./" so it isn't mistaken for a folder segment.
 const topFolderSegment = (path?: string): string | null => {
   const segments = path?.replace(/^\.\//, '').split('/').filter(Boolean) ?? []
   return segments.length >= 2 ? segments[0] : null

--- a/src/renderer/src/utils.ts
+++ b/src/renderer/src/utils.ts
@@ -27,10 +27,7 @@ const topFolderSegment = (path?: string): string | null => {
   return segments.length >= 2 ? segments[0] : null
 }
 
-/** The dropped folder's name, if every file's relativePath (set by the browser's
- *  drag-and-drop directory traversal, e.g. react-dropzone's FileWithPath) shares a
- *  common first path segment - i.e. the user dropped one folder rather than loose
- *  files. Returns null for a flat file drop, or a drop spanning multiple folders. */
+/** The dropped folder's name if every file's relativePath shares a common first segment - null for a flat drop or one spanning multiple folders. */
 export const folderNameFromDroppedFiles = (files: { relativePath?: string }[]): string | null => {
   const folderName = topFolderSegment(files[0]?.relativePath)
   if (!folderName) return null
@@ -39,10 +36,7 @@ export const folderNameFromDroppedFiles = (files: { relativePath?: string }[]): 
   return allMatch ? folderName : null
 }
 
-/** Groups dropped files by their top-level folder - for offering a separate task per
- *  folder when more than one was dropped at once. A file with no folder segment (a loose
- *  file dropped alongside folders) belongs to no group and is omitted, since only real
- *  folders make sense as task drafts. */
+/** Groups dropped files by their top-level folder, for offering a separate task per folder. A file with no folder segment is omitted. */
 export const groupFilesByTopFolder = <T extends { relativePath?: string }>(
   files: T[]
 ): Map<string, T[]> => {

--- a/src/renderer/src/zIndex.ts
+++ b/src/renderer/src/zIndex.ts
@@ -1,24 +1,14 @@
-/** Centralized z-index layers so modals/overlays stack in a predictable order instead of
- *  relying on Mantine's default z-index, which breaks ties by DOM/mount order rather than
- *  "which one was opened on top of the other" - e.g. two modals at the same default
- *  z-index stack by mount order, not by which one opened later. Always use one of these
- *  instead of a bare number; derive new layers from `ActionModal` rather than guessing a
- *  fresh magic number. */
+// Centralized z-index layers so modals/overlays stack predictably instead of by DOM/mount order (Mantine's default). Always use one of these; derive new layers from ACTION_MODAL.
 
 const ACTION_MODAL = 1000
 
 export const ZIndex = {
-  /** A modal driving a primary flow on its own: Create/Edit Project, Rename,
-   *  Import/Export Samples when opened directly from a page. */
+  /** A modal driving a primary flow on its own: Create/Edit Project, Rename, Import/Export Samples opened directly from a page. */
   actionModal: ACTION_MODAL,
-  /** A modal opened from within another action modal (e.g. Import Samples opened from
-   *  inside Create Task's modal) - must clear the modal it was opened from. */
+  /** A modal opened from within another action modal - must clear the modal it was opened from. */
   nestedActionModal: ACTION_MODAL + 100,
-  /** Popovers/dropdowns (Select comboboxes, etc.) rendered inside an action modal - must
-   *  clear every action-modal layer above, regardless of nesting depth. */
+  /** Popovers/dropdowns rendered inside an action modal - must clear every action-modal layer above, regardless of nesting depth. */
   actionModalContent: ACTION_MODAL + 200,
-  /** Yes/no decision dialogs (Confirm Delete, Stop creating tasks, Multiple folders
-   *  detected) - always above every action-modal layer, since one can appear while any
-   *  of them is still open. */
+  /** Yes/no decision dialogs - always above every action-modal layer, since one can appear while any of them is still open. */
   confirmationModal: ACTION_MODAL + 1000
 } as const

--- a/src/shared/concurrency.ts
+++ b/src/shared/concurrency.ts
@@ -1,6 +1,4 @@
-/** Runs fn over items with at most `limit` in flight at once, preserving result order.
- *  Used to bound memory/file-handle usage for batches that can run into the thousands,
- *  instead of Promise.all-ing the whole batch at once. */
+/** Runs fn over items with at most `limit` in flight, preserving result order - bounds memory/file-handle usage instead of Promise.all-ing a batch that can run into the thousands. */
 export const mapWithConcurrency = async <T, R>(
   items: T[],
   limit: number,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,25 +1,10 @@
-/** Privileged protocol scheme main registers to serve arbitrary local scratch files (e.g.
- *  a not-yet-imported sample's thumbnail) straight to the renderer, the same way the
- *  images:// protocol serves persisted ones - see main/scratchProtocol.ts.
- *
- *  A raw file path can't be embedded in the URL itself (`scratch:///C%3A%5Cfoo` etc.) -
- *  for a custom "standard" scheme, Chromium's URL parser treats everything between `//`
- *  and the next `/` as the host/authority, subject to host-validity rules that reject or
- *  mangle drive letters, colons and backslashes, same as images:// already avoids by using
- *  an opaque id instead of a raw path. So this is request/response (main mints an id for a
- *  path and hands back `scratch://<id>`), not a pure client-side string builder. */
+/** Privileged protocol serving arbitrary local scratch files to the renderer - request/response (mint an id, hand back `scratch://<id>`) since a raw file path can't safely go in the URL itself. See main/scratchProtocol.ts. */
 export const SCRATCH_PROTOCOL_URL = 'scratch'
 
-/** Privileged protocol scheme main registers to serve persisted sample images. A URL is
- *  `image://<storeId>/<imageId>.<ext>` - `storeId` is the host/authority segment (same
- *  custom-scheme parsing behavior SCRATCH_PROTOCOL_URL relies on), so the single
- *  `protocol.handle` registered in main/store.ts can dispatch to whichever registered
- *  IDataStore produced the image, regardless of which store is currently active. */
+/** Privileged protocol serving persisted sample images: `image://<storeId>/<imageId>.<ext>` - storeId lets main/store.ts dispatch to whichever IDataStore produced the image. */
 export const IMAGE_PROTOCOL_URL = 'image'
 
-/** The id the always-registered local/worker-backed store is known by to the orchestrator
- *  and stamps onto every image:// URL it mints - see main/localStore.ts,
- *  main/storeOrchestrator.ts. */
+/** The id the always-registered local/worker-backed store is known by - see main/localStore.ts, main/storeOrchestrator.ts. */
 export const LOCAL_STORE_ID = 'local'
 
 export type BoundaryResult<T> =
@@ -54,10 +39,7 @@ export interface IProject {
   labels: ILabel[]
 }
 
-/** Renames the project, edits existing labels, and can add new labels (an id not
- *  already on the project is inserted rather than treated as a rename) - existing
- *  labels still can't be removed here, since one already used by an annotation would
- *  violate a foreign key. */
+/** Renames the project and edits/adds labels - can't remove one here, since one already used by an annotation would violate a foreign key. */
 export interface IProjectUpdate {
   id: IProject['id']
   name?: string
@@ -77,9 +59,7 @@ export interface ITagUpdate {
 export interface ITask {
   id: string
   name: string
-  /** Optional since not every code path that returns an ITask computes these (e.g.
-   *  updateTasks, which only renames - its result is never read for progress display,
-   *  only getTasksForProject/createTask populate them). Absent, not 0, when unknown. */
+  /** Absent, not 0, when unknown - only getTasksForProject/createTask populate these. */
   sampleCount?: number
   completedSampleCount?: number
   tags?: ITag[]
@@ -99,10 +79,7 @@ export enum TrainingSplit {
 export interface INewSample {
   id: string
   name: string
-  /** Absolute path to a scratch file on local disk, written by whichever importer built
-   *  this sample. The active IDataStore implementation decides how to ingest it -
-   *  localStore moves it into its own image store; a future remote store would stream-
-   *  upload from the same local path. Always a reference, never held bytes. */
+  /** Absolute path to a scratch file on disk, written by whichever importer built this sample - always a reference, never held bytes. */
   imagePath: string
   split: TrainingSplit
   annotations: IAnnotation[]
@@ -120,10 +97,7 @@ export interface ISampleUpdate extends Partial<OmitV2<ISample, 'annotations' | '
   id: ISample['id']
 }
 
-/** Store-agnostic and project-agnostic connection info for an external annotator server -
- *  see main/appStore.ts. Neither its label vocabulary nor any mapping against a project's
- *  labels is ever persisted - both are fetched/built live and held only in renderer memory
- *  (see hooks/useAnnotatorRuntime.ts, api/ExternalAnnotator.ts). */
+/** Store-agnostic and project-agnostic connection info for an external annotator server - see main/appStore.ts. Its label mapping is never persisted, only rebuilt live in renderer memory. */
 export interface INewAnnotator {
   id: string
   name: string
@@ -177,17 +151,13 @@ export interface IDataStore {
   updateTasks(updates: ITaskUpdate[]): Promise<ITask[]>
   deleteTasks(taskIds: string[]): Promise<boolean[]>
 
-  /** A project-global vocabulary managed from one place (ManageTagsModal) - typing only
-   *  happens here, when a tag is actually being created/renamed. Everywhere a tag gets
-   *  attached to a task, it's picked from this list by id, never typed. */
+  /** A project-global vocabulary managed from one place (ManageTagsModal) - a tag is always picked by id elsewhere, never typed. */
   getTagsForProject(projectId: string): Promise<ITag[]>
   createTag(projectId: string, id: string, name: string): Promise<ITag>
   updateTags(updates: ITagUpdate[]): Promise<ITag[]>
   deleteTags(tagIds: string[]): Promise<boolean[]>
 
-  /** Attaches/detaches existing tags (by id) to/from every task in taskIds - never a
-   *  per-task "replace the whole set" operation, so batch add/remove across differently-
-   *  tagged tasks doesn't require knowing each task's current tags up front. */
+  /** Attaches/detaches existing tags (by id) to/from every task in taskIds - never a per-task "replace the whole set" operation. */
   addTagsToTasks(taskIds: string[], tagIds: string[]): Promise<void>
   removeTagsFromTasks(taskIds: string[], tagIds: string[]): Promise<void>
 
@@ -205,9 +175,7 @@ export interface IDataStore {
   replacePoints(annotationId: string, points: IPointReplacement[]): Promise<IPoint[]>
 }
 
-/** The always-on, store-agnostic counterpart to IDataStore - annotators live here instead
- *  of in whichever IDataStore is currently active (see main/appStore.ts), so main routes
- *  App_* IPC straight to a single fixed AppStore rather than through StoreOrchestrator. */
+/** The always-on, store-agnostic counterpart to IDataStore - annotators live here, not in whichever IDataStore is active, so App_* IPC skips StoreOrchestrator entirely. */
 export interface IAppDataStore {
   getAnnotators(): Promise<IAnnotator[]>
   createAnnotator(
@@ -222,9 +190,7 @@ export interface IAppDataStore {
 
 export type StoreDescriptor = { id: string; name: string }
 
-/** Lets the renderer list/switch which registered IDataStore main is currently routing
- *  Store_* IPC calls to - separate from IDataStore itself since these are orchestration
- *  operations, not data operations. See main/storeOrchestrator.ts. */
+/** Lets the renderer list/switch which registered IDataStore main is routing Store_* IPC to - orchestration, not data operations. See main/storeOrchestrator.ts. */
 export interface IStoreManager {
   listStores(): Promise<StoreDescriptor[]>
   useStore(id: string): Promise<void>
@@ -234,8 +200,7 @@ export interface ISystem {
   createTemporaryDirectory(): Promise<string>
   deleteFile(filePath: string): Promise<void>
   deleteDirectory(filePath: string): Promise<void>
-  /** Shows a native save dialog defaulted to suggestedName; writes data to the chosen
-   *  path. Returns false if the user cancelled the dialog. */
+  /** Shows a native save dialog defaulted to suggestedName; returns false if cancelled. */
   saveFile(suggestedName: string, data: ArrayBuffer): Promise<boolean>
   /** Writes data to an explicit local path - no dialog, unlike saveFile. */
   writeFile(filePath: string, data: ArrayBuffer): Promise<void>
@@ -243,26 +208,18 @@ export interface ISystem {
   /** Relative, forward-slash paths of every file under dirPath (recursive). */
   listFilesRecursive(dirPath: string): Promise<string[]>
   getFileSize(filePath: string): Promise<number>
-  /** Reads just enough of the file to determine its dimensions - never loads the full
-   *  image into memory, unlike decoding it renderer-side via createImageBitmap. */
+  /** Reads just enough of the file to determine dimensions - never loads the full image into memory. */
   getImageDimensions(filePath: string): Promise<{ width: number; height: number }>
-  /** Mints a scratch://<id> URI that resolves back to filePath - see SCRATCH_PROTOCOL_URL
-   *  for why this can't just be built client-side from the path. */
+  /** Mints a scratch://<id> URI resolving back to filePath - see SCRATCH_PROTOCOL_URL. */
   getScratchPreviewUri(filePath: string): Promise<string>
 }
 
 export interface IZip {
-  // getKeys(filePath: string): Promise<string[]>
   extractTo(filePath: string, destination: string): Promise<void>
 }
 
 export interface IFileUtils {
-  /** The real absolute path of a File picked via <input type="file"> - Electron's
-   *  webUtils.getPathForFile, the documented replacement for the removed File.path
-   *  property. Synchronous and never touches the file's bytes, unlike reading it via
-   *  arrayBuffer()/stream() - use this instead of copying a picked file's contents
-   *  through IPC just to hand main process code a path to it. Returns '' for a File that
-   *  has no real on-disk path (e.g. one constructed in memory rather than picked). */
+  /** The real absolute path of a picked File - Electron's webUtils.getPathForFile. Returns '' for a File with no real on-disk path. */
   getPathForFile(file: File): string
 }
 
@@ -272,13 +229,9 @@ export type ArchiveManifest = { textEntries: ArchiveTextEntry[]; imageEntries: A
 export type ExportProgressEvent = { completed: number; total: number }
 
 export interface IExportApi {
-  /** Shows a native save dialog defaulted to suggestedName, then streams manifest's
-   *  entries straight into a zip archive at the chosen path - image entries are read
-   *  from the store and never fully buffered in the renderer. Returns false if the user
-   *  cancelled the dialog. */
+  /** Streams manifest's entries into a zip at a user-chosen path - image entries never fully buffer in the renderer. False if cancelled. */
   runExport(suggestedName: string, manifest: ArchiveManifest): Promise<boolean>
-  /** Subscribes to progress updates for the currently in-flight export. Returns an
-   *  unsubscribe function. */
+  /** Subscribes to progress for the in-flight export; returns an unsubscribe function. */
   onProgress(callback: (event: ExportProgressEvent) => void): () => void
 }
 
@@ -344,8 +297,7 @@ export enum IPCKeys {
 
   // Export
   Export_Run = 'export-run',
-  /** Main -> renderer push channel (not part of IPCEvents' request/response shape) -
-   *  carries ExportProgressEvent payloads while an export triggered by Export_Run runs. */
+  /** Main -> renderer push channel carrying ExportProgressEvent while Export_Run is in flight. */
   Export_Progress = 'export-progress'
 }
 

--- a/src/shared/uint8array.d.ts
+++ b/src/shared/uint8array.d.ts
@@ -1,7 +1,4 @@
-// TypeScript's bundled lib.d.ts doesn't have types for the Uint8Array base64/hex methods
-// yet, even though Electron's renderer (Chromium 133+) has shipped them for a while - see
-// arrayBufferToBase64 in utils.ts. Optional, not everywhere this code type-checks against
-// actually has it at runtime (e.g. this project's own dev/test Node) - callers feature-detect.
+// lib.d.ts doesn't have types for Uint8Array's base64/hex methods yet, though Electron's renderer has shipped them - see arrayBufferToBase64. Optional since dev/test Node may lack them at runtime.
 export {}
 
 declare global {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -16,16 +16,10 @@ export const checkBoundaryResult = <T>(result: Promise<BoundaryResult<T>>) =>
 
 export const mod = (x: number, m: number) => ((x % m) + m) % m
 
-// Chunk size for the fallback path below - comfortably under engines' call-stack-depth
-// limit for a spread argument list, so a multi-megabyte image still encodes without
-// blowing the stack the way `btoa(String.fromCharCode(...bytes))` would in one shot.
+// Comfortably under engines' call-stack-depth limit for a spread argument list.
 const CHUNK_SIZE = 0x8000
 
-/** Encodes raw bytes as base64, preferring the native `Uint8Array.prototype.toBase64`
- *  (Electron's renderer has it, but this app's test/dev Node doesn't always) - the
- *  fallback builds the binary string one chunk at a time before a single `btoa()` call,
- *  for the same reason: `btoa(String.fromCharCode(...bytes))` in one shot blows the call
- *  stack on a multi-megabyte image. */
+/** Prefers the native `Uint8Array.prototype.toBase64` (Electron has it, test/dev Node doesn't always) - the fallback chunks to avoid blowing the call stack on a multi-megabyte image. */
 export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
   const bytes = new Uint8Array(buffer)
   if (typeof bytes.toBase64 === 'function') return bytes.toBase64()


### PR DESCRIPTION
## Summary
Full-codebase pass trimming multi-line JSDoc/comment blocks down to one line each - no loss of the actual WHY, just cut the elaboration. Started with the worst offenders (`shared/types.ts`, the YOLO/COCO/cvlabel importers, `makeRouter.tsx`, `AnnotatorsModal.tsx`) and worked through every file that had one, across main/renderer/shared.

Also caught a few more stray commented-out code fragments and one genuinely empty JSDoc stub along the way (removed, not trimmed).

Purely a cleanup pass - no behavior changes. Verified after every batch of files (checkpointed in the commit history) rather than only at the end.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors, same 2 pre-existing warnings)
- [x] `pnpm test` (467 passing)
- [x] Confirmed no multi-line `/** */` blocks remain outside test files