### PR TITLE
Reject accidental box annotations

### DIFF
--- a/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
@@ -93,6 +93,12 @@ describe('useLabeler undo/redo', () => {
       async (_sampleId, annotations) => annotations
     )
     vi.mocked(dataStore.deleteAnnotations).mockResolvedValue([true])
+    act(() =>
+      store.setState({
+        bitmap: { width: 100, height: 100 } as ImageBitmap,
+        imageRect: { x: 0, y: 0, width: 100, height: 100 }
+      })
+    )
 
     await act(async () => {
       store.getState().setMode(LabelerMode.CreateBox)
@@ -274,6 +280,65 @@ describe('useLabeler undo/redo', () => {
     expect(dataStore.createAnnotations).not.toHaveBeenCalled()
     expect(dataStore.replacePoints).not.toHaveBeenCalled()
     expect(dataStore.updateAnnotations).not.toHaveBeenCalled()
+  })
+})
+
+describe('useLabeler box creation validation', () => {
+  const setupWithImage = () => {
+    const store = setup([])
+    act(() =>
+      store.setState({
+        bitmap: { width: 100, height: 100 } as ImageBitmap,
+        imageRect: { x: 0, y: 0, width: 100, height: 100 }
+      })
+    )
+    const dataStore = useAppStore.getState().store
+    vi.mocked(dataStore.createAnnotations).mockImplementation(
+      async (_sampleId, annotations) => annotations
+    )
+    return store
+  }
+
+  it('creates a box that starts inside the image and is large enough', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      store.setState({ mousePos: [10, 10] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(60, 60)
+      store.getState().onConfirmPoint(60, 60)
+      await flush()
+    })
+
+    expect(Object.keys(store.getState().sample!.resolve().annotations.resolve())).toHaveLength(1)
+  })
+
+  it('discards a box whose corners were both clicked outside the image', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      store.setState({ mousePos: [-10, -10] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(-20, -20)
+      store.getState().onConfirmPoint(-20, -20)
+      await flush()
+    })
+
+    expect(Object.keys(store.getState().sample!.resolve().annotations.resolve())).toHaveLength(0)
+  })
+
+  it('discards a box too small on screen to be an intentional drag', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      store.setState({ mousePos: [50, 50] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(51, 51)
+      store.getState().onConfirmPoint(51, 51)
+      await flush()
+    })
+
+    expect(Object.keys(store.getState().sample!.resolve().annotations.resolve())).toHaveLength(0)
   })
 })
 

--- a/src/renderer/src/hooks/useLabeler.ts
+++ b/src/renderer/src/hooks/useLabeler.ts
@@ -17,6 +17,9 @@ const ZOOM_STEP_DELTA = 0.15
 const MIN_ZOOM = 0.05
 const MAX_ZOOM = 32
 
+/** Below this on-screen size (any zoom), a just-drawn box is treated as an accidental click, not a real annotation. */
+const MIN_BOX_SCREEN_SIZE_PX = 4
+
 /** Sentinels for a Box's 2 derived corner handles (see moveAnnotationPoint) - safe as fixed literals since only one Box is ever selected at a time. */
 export const BOX_CORNER_HANDLE_TOP_RIGHT = '__box-corner-top-right__'
 export const BOX_CORNER_HANDLE_BOTTOM_LEFT = '__box-corner-bottom-left__'
@@ -282,6 +285,8 @@ export const useLabeler = (labels: ILabel[]) => {
       create<LabelerStore>((set, get) => {
         const colorGenerator = new ColorGenerator()
         let activeSampleAbort: AbortController | null = null
+        /** Raw (pre-clamp) canvas position of the in-progress box's first corner - see isValidBoxCreation. */
+        let annotationCreationRawStart: Vector2 | null = null
         const imageHitId = colorGenerator.make()
         const labelsMap = createLabelsMap(labels)
         const hitIdToAnnotationId = new OneToOneMap<string, string>()
@@ -390,11 +395,18 @@ export const useLabeler = (labels: ILabel[]) => {
           return [newX, newY]
         }
 
+        const pointInRect = (pos: Vector2, rect: Rect): boolean =>
+          pos[0] >= rect.x &&
+          pos[0] <= rect.x + rect.width &&
+          pos[1] >= rect.y &&
+          pos[1] <= rect.y + rect.height
+
         const createPendingAnnotation = (
           type: AnnotationType,
           labelId: string,
           mousePos: Vector2
         ) => {
+          annotationCreationRawStart = [...mousePos]
           const [x, y] = canvasToBitmapSpace(...mousePos)
           return {
             id: makeUUID(),
@@ -408,6 +420,26 @@ export const useLabeler = (labels: ILabel[]) => {
               }
             ]
           } satisfies INewAnnotation
+        }
+
+        /** Rejects a Box whose corners were both clicked outside the image, or whose on-screen size is too small to be intentional. */
+        const isValidBoxCreation = (
+          rawEnd: Vector2,
+          imageRect: Rect,
+          scale: number,
+          annotation: INewAnnotation
+        ): boolean => {
+          const startInside =
+            annotationCreationRawStart !== null &&
+            pointInRect(annotationCreationRawStart, imageRect)
+          const endInside = pointInRect(rawEnd, imageRect)
+          if (!startInside && !endInside) return false
+
+          const box = boundingBoxOf(annotation.points)
+          return (
+            box.width * scale >= MIN_BOX_SCREEN_SIZE_PX &&
+            box.height * scale >= MIN_BOX_SCREEN_SIZE_PX
+          )
         }
 
         const fitBitmapToCanvas = () => {
@@ -935,6 +967,9 @@ export const useLabeler = (labels: ILabel[]) => {
               }
 
               annotation = normalizeAnnotationPoints(annotation)
+              const shouldDiscard =
+                annotation.type === AnnotationType.Box &&
+                !isValidBoxCreation(state.mousePos, state.imageRect, state.scale, annotation)
 
               set({
                 annotationBeingCreated: createPendingAnnotation(
@@ -944,6 +979,8 @@ export const useLabeler = (labels: ILabel[]) => {
                 ),
                 annotationDirty: true
               })
+
+              if (shouldDiscard) return
 
               applyCreateAnnotation(annotation)
               pushHistory({ kind: 'create', annotation })


### PR DESCRIPTION
## Summary
- Discard a Box at commit time if both corners were clicked outside the image area (checked against the raw pre-clamp canvas position — the clamped bitmap-space points alone can't tell, since `canvasToBitmapSpace` already clamps into bounds).
- Discard a Box whose on-screen size is under 4px in either dimension, measured in canvas pixels (`size * scale`) so the threshold stays meaningful at any zoom level.
- Covers both ways a box is completed: drag-release and right-click-to-confirm.

## Testing
- Added 3 unit tests in `useLabeler.test.tsx` (valid box, both-corners-outside, too-small).
- Updated an existing undo/redo test to inject a real bitmap/imageRect so its box isn't degenerate.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)