### PR TITLE
Add .cvlabel format spec for external consumers

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,6 +21,11 @@ default, behind an `IDataStore` interface designed to be swapped for other backe
 Sample images are from the [COCO dataset](https://cocodataset.org), used here for
 demonstration only.
 
+## Data formats
+
+Import/export YOLO, COCO, and this app's own `.cvlabel` archive format — see
+[`formats/`](./formats) for the `.cvlabel` spec.
+
 ## Recommended IDE Setup
 
 - [VSCode](https://code.visualstudio.com/) + [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) + [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/formats/README.md
+++ b/formats/README.md
@@ -1,0 +1,7 @@
+# Formats
+
+Specs for this app's own data formats, for anyone consuming them outside the app.
+
+- [`cvlabel/`](./cvlabel/SPEC.md) — the `.cvlabel` archive format
+
+YOLO and COCO exports/imports follow their respective upstream specs and aren't duplicated here.

--- a/formats/cvlabel/SPEC.md
+++ b/formats/cvlabel/SPEC.md
@@ -1,0 +1,114 @@
+# CV-Label Archive Format (`.cvlabel`)
+
+Version: unversioned (see [§5](#5-versioning))
+
+## 1. Overview
+
+A `.cvlabel` file is this app's native interchange format: a zip archive containing one
+`manifest.json` plus the sample images it references. It's flat (no task structure), so it can be
+re-imported into any project via a label-mapping step.
+
+## 2. File layout
+
+```
+manifest.json
+images/<sampleId>.<ext>
+```
+
+`imageFile` paths inside the manifest are relative to the archive root (wherever `manifest.json`
+sits, which is always the root today).
+
+## 3. `manifest.json`
+
+Top-level object:
+
+| Field     | Type       | Description        |
+| --------- | ---------- | ------------------- |
+| `labels`  | `Label[]`  | Every exported label |
+| `samples` | `Sample[]` | Every exported sample |
+
+### Label
+
+| Field  | Type     |
+| ------ | -------- |
+| `id`   | `string` |
+| `name` | `string` |
+
+### Sample
+
+| Field         | Type              | Description |
+| ------------- | ----------------- | ----------- |
+| `id`          | `string`          | |
+| `name`        | `string`          | |
+| `split`       | `"train" \| "test" \| "valid"` | |
+| `createdAt`   | `string`          | ISO 8601 |
+| `imageFile`   | `string`          | Path relative to `manifest.json`, e.g. `images/abc123.jpg` |
+| `annotations` | `Annotation[]`    | |
+| `width`, `height` | `number` (optional) | Written on export; not read on import today |
+
+### Annotation
+
+| Field     | Type                  | Description |
+| --------- | --------------------- | ----------- |
+| `id`      | `string`              | |
+| `type`    | `"box" \| "polygon"`  | |
+| `labelId` | `string`              | References a `Label.id` in the same manifest |
+| `points`  | `Point[]`             | See below |
+
+- **`box`** — exactly 2 points: any two opposite corners of an axis-aligned rectangle (not
+  required to be top-left/bottom-right; consumers should take min/max of both).
+- **`polygon`** — 3+ points, the ordered outline vertices.
+
+### Point
+
+| Field | Type     | Description |
+| ----- | -------- | ----------- |
+| `id`  | `string` | |
+| `x`   | `number` | Absolute pixel coordinate in the source image (not normalized 0–1) |
+| `y`   | `number` | Absolute pixel coordinate in the source image (not normalized 0–1) |
+
+## 4. Label mapping on import
+
+A manifest's `labels` list is independent of any project's existing labels. Importing asks the
+user to map each manifest label id to a project label (or drop it); annotations whose label has
+no mapping are dropped. Every id (sample, annotation, point) is regenerated fresh on import, so
+manifest ids only need to be unique within the file, not globally.
+
+## 5. Versioning
+
+There is no `version` field today. A parser should ignore unknown fields rather than reject them —
+the reference importer only reads `id`, `name`, `split`, `createdAt`, `imageFile` and `annotations`
+off each `Sample`. Any breaking change to this format should add an explicit top-level `version`
+field before external tooling should rely on it.
+
+## 6. Example
+
+```json
+{
+  "labels": [{ "id": "lbl_1", "name": "person" }],
+  "samples": [
+    {
+      "id": "smp_1",
+      "name": "frame_0001",
+      "split": "train",
+      "createdAt": "2026-08-01T12:00:00.000Z",
+      "imageFile": "images/smp_1.jpg",
+      "width": 1920,
+      "height": 1080,
+      "annotations": [
+        {
+          "id": "ann_1",
+          "type": "box",
+          "labelId": "lbl_1",
+          "points": [
+            { "id": "pt_1", "x": 100, "y": 200 },
+            { "id": "pt_2", "x": 300, "y": 400 }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+See [`schema.json`](./schema.json) for a machine-checkable JSON Schema of `manifest.json`.

--- a/formats/cvlabel/schema.json
+++ b/formats/cvlabel/schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TareHimself/cv-label/formats/cvlabel/schema.json",
+  "title": "CV-Label manifest.json",
+  "description": "manifest.json found at the root of a .cvlabel archive. See SPEC.md.",
+  "type": "object",
+  "required": ["labels", "samples"],
+  "properties": {
+    "labels": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/label" }
+    },
+    "samples": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sample" }
+    }
+  },
+  "$defs": {
+    "label": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" }
+      }
+    },
+    "sample": {
+      "type": "object",
+      "required": ["id", "name", "split", "createdAt", "imageFile", "annotations"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "split": { "enum": ["train", "test", "valid"] },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "imageFile": { "type": "string" },
+        "width": { "type": "number" },
+        "height": { "type": "number" },
+        "annotations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/annotation" }
+        }
+      }
+    },
+    "annotation": {
+      "type": "object",
+      "required": ["id", "type", "labelId", "points"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "enum": ["box", "polygon"] },
+        "labelId": { "type": "string" },
+        "points": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/point" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "box" } } },
+          "then": { "properties": { "points": { "minItems": 2, "maxItems": 2 } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "polygon" } } },
+          "then": { "properties": { "points": { "minItems": 3 } } }
+        }
+      ]
+    },
+    "point": {
+      "type": "object",
+      "required": ["id", "x", "y"],
+      "properties": {
+        "id": { "type": "string" },
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `formats/cvlabel/SPEC.md` — human-readable spec of the `.cvlabel` archive format (file layout, `manifest.json` fields, box/polygon point semantics, label-mapping-on-import behavior, versioning note, worked example), verified against `buildCvLabel.ts`/`parseCvLabel.ts`.
- `formats/cvlabel/schema.json` — matching JSON Schema (2020-12) for machine validation.
- `formats/README.md` — short index; notes YOLO/COCO already follow upstream specs so aren't duplicated here.
- Linked from the root ReadMe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)