### PR TITLE
Fix box-creation validation: rect-intersection, not corner-in-rect

### DIFF
--- a/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
@@ -382,6 +382,26 @@ describe('useLabeler box creation validation', () => {
       [100, 100]
     ])
   })
+
+  it('creates a box whose start and end are both outside the image but whose extent covers it', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      store.setState({ mousePos: [-50, -50] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(-50, -50)
+      store.getState().onMouseMove(150, 150)
+      store.getState().onConfirmPoint(150, 150)
+      await flush()
+    })
+
+    const created = Object.values(store.getState().sample!.resolve().annotations.resolve())
+    expect(created).toHaveLength(1)
+    expect(created[0].resolve().points.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [100, 100]
+    ])
+  })
 })
 
 describe('useLabeler duplicateAnnotation', () => {

--- a/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useLabeler.test.tsx
@@ -340,6 +340,48 @@ describe('useLabeler box creation validation', () => {
 
     expect(Object.keys(store.getState().sample!.resolve().annotations.resolve())).toHaveLength(0)
   })
+
+  it('captures the start corner at the actual click, not wherever the mouse was when the tool was armed', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      // The tool is armed while hovering far outside the image (e.g. over a toolbar button).
+      store.setState({ mousePos: [-500, -500] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onMouseMove(10, 10)
+      store.getState().onConfirmPoint(10, 10)
+      store.getState().onMouseMove(60, 60)
+      store.getState().onConfirmPoint(60, 60)
+      await flush()
+    })
+
+    const created = Object.values(store.getState().sample!.resolve().annotations.resolve())
+    expect(created).toHaveLength(1)
+    expect(created[0].resolve().points.map((p) => [p.x, p.y])).toEqual([
+      [10, 10],
+      [60, 60]
+    ])
+  })
+
+  it('creates a box that starts inside the image and is dragged past the edge, clamping to the boundary', async () => {
+    const store = setupWithImage()
+
+    await act(async () => {
+      store.setState({ mousePos: [10, 10] })
+      store.getState().setMode(LabelerMode.CreateBox)
+      store.getState().onConfirmPoint(10, 10)
+      store.getState().onMouseMove(500, 500)
+      store.getState().onConfirmPoint(500, 500)
+      await flush()
+    })
+
+    const created = Object.values(store.getState().sample!.resolve().annotations.resolve())
+    expect(created).toHaveLength(1)
+    expect(created[0].resolve().points.map((p) => [p.x, p.y])).toEqual([
+      [10, 10],
+      [100, 100]
+    ])
+  })
 })
 
 describe('useLabeler duplicateAnnotation', () => {

--- a/src/renderer/src/hooks/labeler/geometry.ts
+++ b/src/renderer/src/hooks/labeler/geometry.ts
@@ -39,13 +39,10 @@ export const axisMaskedMoveDelta = (
   return [axis === 'y' ? 0 : moveCurrent[0], axis === 'x' ? 0 : moveCurrent[1]]
 }
 
-export const pointInRect = (pos: Vector2, rect: Rect): boolean =>
-  pos[0] >= rect.x &&
-  pos[0] <= rect.x + rect.width &&
-  pos[1] >= rect.y &&
-  pos[1] <= rect.y + rect.height
+const rectsIntersect = (a: Rect, b: Rect): boolean =>
+  a.x <= b.x + b.width && a.x + a.width >= b.x && a.y <= b.y + b.height && a.y + a.height >= b.y
 
-/** Rejects a Box whose corners were both clicked outside the image, or whose on-screen size is too small to be intentional. */
+/** Rejects a Box whose raw (pre-clamp) extent doesn't touch the image at all, or whose on-screen size is too small to be intentional - a box can legitimately start inside and end outside (dragged to the edge, clamped) or vice versa, so this checks the drawn rectangle against the image, not either single corner. */
 export const isValidBoxCreation = (
   rawStart: Vector2 | null,
   rawEnd: Vector2,
@@ -53,9 +50,15 @@ export const isValidBoxCreation = (
   scale: number,
   annotation: INewAnnotation
 ): boolean => {
-  const startInside = rawStart !== null && pointInRect(rawStart, imageRect)
-  const endInside = pointInRect(rawEnd, imageRect)
-  if (!startInside && !endInside) return false
+  if (rawStart === null) return false
+
+  const rawExtent: Rect = {
+    x: Math.min(rawStart[0], rawEnd[0]),
+    y: Math.min(rawStart[1], rawEnd[1]),
+    width: Math.abs(rawEnd[0] - rawStart[0]),
+    height: Math.abs(rawEnd[1] - rawStart[1])
+  }
+  if (!rectsIntersect(rawExtent, imageRect)) return false
 
   const box = boundingBoxOf(annotation.points)
   return box.width * scale >= MIN_BOX_SCREEN_SIZE_PX && box.height * scale >= MIN_BOX_SCREEN_SIZE_PX

--- a/src/renderer/src/hooks/useLabeler.ts
+++ b/src/renderer/src/hooks/useLabeler.ts
@@ -105,7 +105,6 @@ export const useLabeler = (labels: ILabel[]) => {
           labelId: string,
           mousePos: Vector2
         ) => {
-          annotationCreationRawStart = [...mousePos]
           const [x, y] = canvasToBitmapSpace(...mousePos)
           return {
             id: makeUUID(),
@@ -372,6 +371,10 @@ export const useLabeler = (labels: ILabel[]) => {
               ) {
                 state.onConfirmAnnotationCreation()
               } else {
+                if (state.annotationBeingCreated.type === AnnotationType.Box) {
+                  // The box's start corner, locked in at the actual click - see isValidBoxCreation.
+                  annotationCreationRawStart = [x, y]
+                }
                 state.annotationBeingCreated.points.push({
                   id: makeUUID(),
                   x: 0,


### PR DESCRIPTION
## Summary
Two bugs in `isValidBoxCreation` (introduced in #41), both reported directly:

- `annotationCreationRawStart` was captured in `createPendingAnnotation`, which runs at tool-arm time (`setMode`) or re-arm time — i.e. wherever the mouse happened to be *before* the user actually clicked, not the real first-click position. If that stale position was outside the image (e.g. the mouse was over a toolbar button when the hotkey was pressed), a box that legitimately started on the image would still read as starting outside it. Now captured in `onConfirmPoint` at the moment the start corner is actually locked in.
- The "outside the image" check tested whether either raw corner was individually inside `imageRect`. That wrongly rejects a box that starts inside and is dragged past the edge (or vice versa) — a completely normal way to draw a box that should clamp to the boundary, not get discarded. Replaced with a real rectangle-intersection test between the raw (pre-clamp) drawn extent and the image, so a box is only rejected when it doesn't touch the image at all, or is too small to be intentional.

## Testing
- 2 new regression tests covering each bug specifically, plus the existing 3 box-validation tests still pass.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (472/472) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)